### PR TITLE
Export hugging face data Loader and fix summarize example

### DIFF
--- a/src/dsp/index.ts
+++ b/src/dsp/index.ts
@@ -7,6 +7,7 @@ export * from './eval.js';
 export * from './loader.js';
 export * from './strutil.js';
 export * from './router.js';
+export * from './loader.js';
 
 export type { AxAssertion, AxStreamingAssertion } from './asserts.js';
 export type { AxPromptTemplate, AxFieldTemplateFn } from './prompt.js';

--- a/src/dsp/loader.ts
+++ b/src/dsp/loader.ts
@@ -50,12 +50,13 @@ export class AxHFDataLoader {
   public async loadData(
     dataset: string,
     split: 'train' | 'validation',
+    config: string = 'distractor',
     options?: Readonly<{ offset?: number; length?: number }>
   ): Promise<{ rows: AxDataRow[] }> {
     const offset = options?.offset ?? 0;
     const length = options?.length ?? 100;
 
-    const url = `${this.baseUrl}?dataset=${dataset}&config=distractor&split=${split}&offset=${offset}&length=${length}`;
+    const url = `${this.baseUrl}?dataset=${dataset}&config=${config}&split=${split}&offset=${offset}&length=${length}`;
     const filePath = this.getFilePath(url);
 
     if (existsSync(filePath)) {
@@ -75,15 +76,17 @@ export class AxHFDataLoader {
     split,
     count,
     fields,
-    renameMap
+    renameMap,
+    config
   }: Readonly<{
     dataset: string;
     split: 'train' | 'validation';
     count: number;
     fields: readonly string[];
     renameMap?: Record<string, string>;
+    config?: string;
   }>): Promise<T[]> {
-    const data = await this.loadData(dataset, split);
+    const data = await this.loadData(dataset, split, config);
     const dataRows = data.rows.slice(0, count);
 
     return dataRows
@@ -113,7 +116,7 @@ export class AxHFDataLoader {
           if (!resultFieldName) {
             throw new Error(`Invalid field name: ${field}`);
           }
-          result[resultFieldName] = value as AxFieldValue;
+          result[resultFieldName] = String(value) as AxFieldValue;
         });
 
         return result;

--- a/src/examples/summarize.ts
+++ b/src/examples/summarize.ts
@@ -1,7 +1,7 @@
 import { AxAI, AxAIOpenAIModel } from '../ai/index.js';
 import { AxChainOfThought } from '../prompts/cot.js';
 
-const text = `The technological singularity—or simply the singularity[1]—is a hypothetical future point in time at which technological growth becomes uncontrollable and irreversible, resulting in unforeseeable changes to human civilization.[2][3] According to the most popular version of the singularity hypothesis, I.J. Good's intelligence explosion model, an upgradable intelligent agent will eventually enter a "runaway reaction" of self-improvement cycles, each new and more intelligent generation appearing more and more rapidly, causing an "explosion" in intelligence and resulting in a powerful superintelligence that qualitatively far surpasses all human intelligence.[4]`;
+const noteText = `The technological singularity—or simply the singularity[1]—is a hypothetical future point in time at which technological growth becomes uncontrollable and irreversible, resulting in unforeseeable changes to human civilization.[2][3] According to the most popular version of the singularity hypothesis, I.J. Good's intelligence explosion model, an upgradable intelligent agent will eventually enter a "runaway reaction" of self-improvement cycles, each new and more intelligent generation appearing more and more rapidly, causing an "explosion" in intelligence and resulting in a powerful superintelligence that qualitatively far surpasses all human intelligence.[4]`;
 
 const ai = new AxAI({
   name: 'openai',
@@ -15,16 +15,18 @@ ai.setOptions({ debug: true });
 
 const gen = new AxChainOfThought(
   ai,
-  `text -> shortSummary "summarize in 5 to 10 words"`
+  `noteText -> shortSummary "summarize in 5 to 10 words"`
 );
 gen.setExamples([
   {
-    text: 'Mathematical platonism is a philosophical view that posits the existence of abstract mathematical objects that are independent of human thought and language. According to this view, mathematical entities such as numbers, shapes, and functions exist in a non-physical realm and can be discovered but not invented.',
+    noteText:
+      'Mathematical platonism is a philosophical view that posits the existence of abstract mathematical objects that are independent of human thought and language. According to this view, mathematical entities such as numbers, shapes, and functions exist in a non-physical realm and can be discovered but not invented.',
     shortSummary:
       'A philosophy that suggests mathematical objects exist independently of human thought in a non-physical realm.'
   },
   {
-    text: 'Quantum entanglement is a physical phenomenon occurring when pairs or groups of particles are generated, interact, or share spatial proximity in ways such that the quantum state of each particle cannot be described independently of the state of the others, even when the particles are separated by large distances. This leads to correlations between observable physical properties of the particles.',
+    noteText:
+      'Quantum entanglement is a physical phenomenon occurring when pairs or groups of particles are generated, interact, or share spatial proximity in ways such that the quantum state of each particle cannot be described independently of the state of the others, even when the particles are separated by large distances. This leads to correlations between observable physical properties of the particles.',
     shortSummary:
       'A phenomenon where particles remain interconnected and the state of one affects the state of another, regardless of distance.'
   }
@@ -35,6 +37,6 @@ gen.addAssert(({ reason }: Readonly<{ reason: string }>) => {
   return !reason.includes('goat');
 }, 'Reason should not contain "the"');
 
-const res = await gen.forward({ text }, { modelConfig: { stream: true } });
+const res = await gen.forward({ noteText }, { modelConfig: { stream: true } });
 
 console.log('>', res);


### PR DESCRIPTION
- This exports the data loader and allows the user to select the configuration for the dataset.
- This PR also fixes an issue with the summary example.

The optimization example is still failing, and there are still some issues with loading Hugging Face datasets where the answer isn't a string value. I think we need more optimization examples to show the true benefits of DSPy.