### PR TITLE
fix: input fields type image rejected #33

### DIFF
--- a/src/dsp/sig.ts
+++ b/src/dsp/sig.ts
@@ -155,9 +155,6 @@ export class AxSignature {
   private updateHash = (): [string, string] => {
     this.getInputFields().forEach((field) => {
       validateField(field);
-      if (field.type?.name === 'image') {
-        throw new Error('Image type is not supported in output fields.');
-      }
     });
     this.getOutputFields().forEach((field) => {
       validateField(field);


### PR DESCRIPTION
**What kind of change does this PR introduce?**

This pull request introduces a bug fix about the input fields type image.

**What is the current behavior?**

The current behavior is that when using the `AxGenerate::forward` function with an input parameter of type image, an error is thrown with the message: "Image type is not supported in output fields." This issue is described in more detail in the linked issue [#33](https://github.com/ax-llm/ax/issues/33).

**What is the new behavior (if this is a feature change)?**

With the changes introduced in this pull request, the `AxGenerate::forward` function will now properly accept input parameters of type image and process them without throwing any errors.

**Other information**:

I have tested these changes locally, and they resolve the issue described in the linked issue. Please let me know if there are any further modifications needed or if you have any questions.

Thank you for reviewing this pull request.