### PR TITLE
Relax Node.js version in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "tsx": "node --env-file=.env --import=tsx"
   },
   "engines": {
-    "node": ">=21"
+    "node": ">=20"
   },
   "dependencies": {
     "json5": "^2.2.3"


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Relax Node.js version in package.json

- **What is the current behavior?** (You can also link to an open issue here)

Ax requires Node.js >= 20 that conflicts with some dependencies

- **What is the new behavior (if this is a feature change)?**
Ax will require Node.js >= 20


