### PR TITLE
Ava test timeout and "prepare" script changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "doc:api": "typedoc src/ax --tsconfig src/ax/tsconfig.build.module.json",
     "doc:html": "npm run build-doc --workspace=@ax-llm/ax-docs",
     "version": "standard-version",
-    "prepare": "run-s test",
+    "prepare": "npm run build:parser --workspace=@ax-llm/ax",
     "release": "npm run release --workspaces --if-present && release-it --no-increment",
     "publish": "npm run publish --workspaces  --if-present -- --provenance --access public",
     "git-cz": "npx git-cz",

--- a/src/ax/package.json
+++ b/src/ax/package.json
@@ -27,7 +27,7 @@
     "test:unit": "ava --timeout=500s --verbose",
     "tsx": "node --env-file=.env --import=tsx",
     "release": "release-it",
-    "publish": "cd build && npm publish",
+    "publish": "npm run build && cd build && npm publish",
     "postbuild": "node ../../scripts/postbuild.js"
   },
   "dependencies": {


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Ava test timeout and "prepare" script changes

- **What is the current behavior?** (You can also link to an open issue here)

Ava tests fail

- **What is the new behavior (if this is a feature change)?**

Ava test timeout increased and "prepare" script changed
