### PR TITLE
corrected ollama embeddings api endpoint

### DIFF
--- a/src/ax/ai/ollama/api.ts
+++ b/src/ax/ai/ollama/api.ts
@@ -53,7 +53,7 @@ export class AxAIOllama extends AxAIOpenAI {
       apiKey,
       options,
       config: _config,
-      apiURL: new URL('/v1', url).href,
+      apiURL: new URL('/api', url).href,
       modelMap
     });
 


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix
- **What is the current behavior?** (You can also link to an open issue here)
The current implementation of the AxAIOllama class uses an incorrect API endpoint (/v1/embeddings) which results in a fetch failure when trying to generate embeddings.
- **What is the new behavior (if this is a feature change)?**
The new behavior changes the endpoint to /api/embeddings, ensuring that the correct API URL is used.
- **Other information**:
This fix has been verified locally by testing the embedding generation endpoint from within the Docker container, ensuring the correct functionality.
The issue was identified in the node_modules/@ax-llm/ax/ai/ollama/api.js file.
Documentation for the correct API endpoint can be found at https://github.com/ollama/ollama/blob/main/docs/api.md#generate-a-completion
Another Note: The default model name all-minilms was also hardcoded in the configuration. 