### PR TITLE
Add terms to spellcheck dictionary

### DIFF
--- a/.cspell/project-words.txt
+++ b/.cspell/project-words.txt
@@ -8,6 +8,10 @@ asig
 Buena
 chrono
 chunker
+codellama
+Codellama
+codestral
+Codestral
 commandline
 companys
 countrys
@@ -34,6 +38,8 @@ Macbook
 minilm
 Mixtral
 nanos
+nemo
+Nemo
 neumann
 ollama
 onopentag


### PR DESCRIPTION
This PR adds AI-related terms (Codestral, Nemo, Codellama) to the spellcheck dictionary to resolve build failures due to spellcheck errors.