### PR TITLE
Fix: Bind agent functions to instances for correct 'this' context"

### DIFF
--- a/src/ax/prompts/agent.ts
+++ b/src/ax/prompts/agent.ts
@@ -127,7 +127,11 @@ export class AxAgent<IN extends AxGenIn, OUT extends AxGenOut>
   }
 
   public getFunction(): AxFunction {
-    return this.func;
+    const boundFunc = this.forward.bind(this);
+    return {
+      ...this.func,
+      func: boundFunc
+    };
   }
 
   public async forward(

--- a/src/examples/agent.ts
+++ b/src/examples/agent.ts
@@ -28,7 +28,7 @@ const summarizer = new AxAgent(ai, {
   name: 'Science Summarizer',
   description:
     'Summarizer can write short summaries of advanced science topics',
-  signature: `textToSummarize "text to summarize" -> shortSummary "summarize in 5 to 10 words"`
+  signature: `answer "bullet points to summarize" -> shortSummary "summarize in 10 to 20 words"`
 });
 
 const agent = new AxAgent(ai, {
@@ -38,7 +38,13 @@ const agent = new AxAgent(ai, {
   agents: [researcher, summarizer]
 });
 
-const question = `Why is gravity not a real force? Why is light pure energy? Why is physics scale invariant? Why is the centrifugal force talked about so much if it's not real?`;
+const question = `
+  Why is gravity not a real force? Why is light pure energy? 
+  Why is physics scale invariant? 
+  Why is the centrifugal force talked about so much if it's not real? 
+  For each question include a summary with the bullet points.
+  Include the summary and bullet points in the answer.
+  Return this only if you can answer all the questions.`;
 
 const res = await agent.forward({ question });
 console.log('>', res);


### PR DESCRIPTION
Currently, functions from agent instances are not properly bound to their respective agents. This causes this to be undefined when these functions are called, leading to unexpected behavior and potential errors.

### Solution

Modify the function mapping process to bind agent functions to their respective instances. This ensures that when these functions are called, they have access to the correct this context.

### Example
```
Scientist receives the multi-part question
Splits it into individual questions
Sends each question to the Physics Researcher
Receives detailed bullet-point answers
Sends each detailed answer to the Science Summarizer
Receives concise summaries
Combines all information into a comprehensive, well-structured answer
```