### PR TITLE
Fix: Typo in limit guard

### DIFF
--- a/src/ax/mem/memory.ts
+++ b/src/ax/mem/memory.ts
@@ -11,7 +11,7 @@ export class AxMemory implements AxAIMemory {
 
   constructor(limit = 50) {
     if (limit <= 0) {
-      throw Error("argument 'last' must be greater than 0");
+      throw Error("argument 'limit' must be greater than 0");
     }
     this.limit = limit;
   }


### PR DESCRIPTION
## Fixes Typo in limit guard

- This PR is a typo correction

- BEFORE: when limit <= 0, throws a `last` error

- NOW: when limit <= 0, throws a `limit` error


