### PR TITLE
Fix bug where Gemini STOP token causes crash

### DIFF
--- a/src/ax/ai/google-gemini/api.ts
+++ b/src/ax/ai/google-gemini/api.ts
@@ -378,6 +378,10 @@ export class AxAIGoogleGemini extends AxBaseAI<
             throw new Error('Finish reason: RECITATION');
         }
 
+        if (!candidate.content.parts) {
+          return result;
+        }
+
         for (const part of candidate.content.parts) {
           if ('text' in part) {
             result.content = part.text;


### PR DESCRIPTION
Sometimes Gemini sends a STOP token here during normal processing. When this happens, `candidate.content.parts` is undefined, which causes the loop below to fail and crash generation with an exception:

```
Error summarizing message TypeError: candidate.content.parts is not iterable
    at file:///Users/josh/Projects/bigb/api/node_modules/.deno/@ax-llm+ax@10.0.1/node_modules/@ax-llm/ax/ai/google-gemini/api.js:266:50
    at Array.map (<anonymous>)
    at AxAIGoogleGemini.generateChatResp (file:///Users/josh/Projects/bigb/api/node_modules/.deno/@ax-llm+ax@10.0.1/node_modules/@ax-llm/ax/ai/google-gemini/api.js:249:42)
    at generateChatStreamResp (file:///Users/josh/Projects/bigb/api/node_modules/.deno/@ax-llm+ax@10.0.1/node_modules/@ax-llm/ax/ai/google-gemini/api.js:300:21)
    at TypeTransformer.transformFn (file:///Users/josh/Projects/bigb/api/node_modules/.deno/@ax-llm+ax@10.0.1/node_modules/@ax-llm/ax/ai/base.js:188:29)
    at TypeTransformer.transform (file:///Users/josh/Projects/bigb/api/node_modules/.deno/@ax-llm+ax@10.0.1/node_modules/@ax-llm/ax/util/transform.js:12:26)
    at Module.invokeCallbackFunction (ext:deno_webidl/00_webidl.js:982:16)
    at TransformStreamDefaultController.transformAlgorithm (ext:deno_web/06_streams.js:3789:14)
    at transformStreamDefaultControllerPerformTransform (ext:deno_web/06_streams.js:4058:59)
    at transformStreamDefaultSinkWriteAlgorithm (ext:deno_web/06_streams.js:4161:10)
```

The `candidate` object looks like this in these cases:

```
{ content: { role: "model" }, finishReason: "STOP", index: 0 }
```

- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

- **What is the current behavior?** (You can also link to an open issue here)

- **What is the new behavior (if this is a feature change)?**

- **Other information**:
