### PR TITLE
Handle MALFORMED_FUNCTION_CALL in google gemini api

### DIFF
--- a/src/ax/ai/google-gemini/api.ts
+++ b/src/ax/ai/google-gemini/api.ts
@@ -392,9 +392,11 @@ export class AxAIGoogleGemini extends AxBaseAI<
             throw new Error('Finish reason: SAFETY');
           case 'RECITATION':
             throw new Error('Finish reason: RECITATION');
+          case 'MALFORMED_FUNCTION_CALL':
+            throw new Error('Finish reason: MALFORMED_FUNCTION_CALL');
         }
 
-        if (!candidate.content.parts) {
+        if (!candidate.content || !candidate.content.parts) {
           return result;
         }
 


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Improves error reporting in the case of a malformed function call

- **What is the current behavior?** (You can also link to an open issue here)
```
error: Uncaught (in promise) TypeError: Cannot read properties of undefined (reading 'parts')
    at file:///Users/josh/Projects/bigb/api/node_modules/.deno/@ax-llm+ax@10.0.9/node_modules/@ax-llm/ax/ai/google-gemini/api.js:274:34
    at Array.map (<anonymous>)
    at AxAIGoogleGemini.generateChatResp (file:///Users/josh/Projects/bigb/api/node_modules/.deno/@ax-llm+ax@10.0.9/node_modules/@ax-llm/ax/ai/google-gemini/api.js:257:42)
    ...
```

- **What is the new behavior (if this is a feature change)?**
```sh
error: Uncaught (in promise) Error: Finish reason: MALFORMED_FUNCTION_CALL
    at file:///Users/josh/Projects/bigb/api/node_modules/.deno/@ax-llm+ax@10.0.9/node_modules/@ax-llm/ax/ai/google-gemini/api.js:271:27
    at Array.map (<anonymous>)
    at AxAIGoogleGemini.generateChatResp (file:///Users/josh/Projects/bigb/api/node_modules/.deno/@ax-llm+ax@10.0.9/node_modules/@ax-llm/ax/ai/google-gemini/api.js:257:42)
    ...
```
