### PR TITLE
Fix bug where boolean false is treated as empty

### DIFF
--- a/src/ax/dsp/prompt.ts
+++ b/src/ax/dsp/prompt.ts
@@ -416,6 +416,11 @@ const isEmptyValue = (
   field: Readonly<AxField>,
   value?: Readonly<AxFieldValue>
 ) => {
+  // Boolean type can't be empty
+  if (typeof value === 'boolean') {
+    return false;
+  }
+
   if (
     !value ||
     ((Array.isArray(value) || typeof value === 'string') && value.length === 0)


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix

- **What is the current behavior?** (You can also link to an open issue here)
Currently, if a required field is type boolean, and the boolean value is false, isEmptyValue returns true and the signature fails validation.

- **What is the new behavior (if this is a feature change)?**
Boolean false no longer fails the isEmptyValue check.

- **Other information**:
