### PR TITLE
Add configurable comparator for AxBalance service order

### DIFF
--- a/src/ax/ai/balance.test.ts
+++ b/src/ax/ai/balance.test.ts
@@ -1,0 +1,134 @@
+import test from 'ava';
+
+import { AxBalancer, axInputOrderComparator } from './balance.js';
+import type {
+  AxAIPromptConfig,
+  AxAIService,
+  AxAIServiceActionOptions,
+  AxChatRequest,
+  AxChatResponse,
+  AxEmbedResponse
+} from './types.js';
+
+/**
+ * Mock service for testing
+ */
+class MockService implements AxAIService {
+  constructor(
+    private readonly chatFn: () => unknown = () => ({}),
+    private readonly cost: number = 100
+  ) {}
+
+  getName = () => 'mock';
+
+  getModelInfo = () => ({
+    name: 'mock',
+    provider: 'mock',
+    promptTokenCostPer1M: this.cost,
+    completionTokenCostPer1M: this.cost
+  });
+
+  getEmbedModelInfo = () => undefined;
+  getModelConfig = () => ({});
+  getFeatures = () => ({ functions: false, streaming: false });
+  getModelMap = () => undefined;
+
+  embed = async () => ({}) as AxEmbedResponse;
+  setOptions = () => {};
+
+  chat = async (
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    _req: Readonly<AxChatRequest>,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    _options?: Readonly<AxAIPromptConfig & AxAIServiceActionOptions>
+  ) => {
+    this.chatFn();
+    return Promise.resolve({} as AxChatResponse);
+  };
+}
+
+test('first service works', async (t) => {
+  let calledService: number | undefined;
+  const services: AxAIService[] = [
+    new MockService(() => {
+      calledService = 0;
+    }, 2.0),
+    new MockService(() => {
+      calledService = 1;
+    }, 1.0)
+  ];
+
+  const balancer = new AxBalancer(services);
+  await balancer.chat({
+    chatPrompt: [{ role: 'user', content: 'test' }],
+    model: 'mock'
+  });
+
+  t.is(calledService, 1);
+});
+
+test('first service fails', async (t) => {
+  let calledService: number | undefined;
+  const services: AxAIService[] = [
+    new MockService(() => {
+      calledService = 0;
+    }, 2.0),
+    new MockService(() => {
+      throw new Error('test');
+    }, 1.0)
+  ];
+
+  const balancer = new AxBalancer(services);
+  await balancer.chat({
+    chatPrompt: [{ role: 'user', content: 'test' }],
+    model: 'mock'
+  });
+
+  t.is(calledService, 0);
+});
+
+test('first service works comparator', async (t) => {
+  let calledService: number | undefined;
+  const services: AxAIService[] = [
+    new MockService(() => {
+      calledService = 0;
+    }, 2.0),
+    new MockService(() => {
+      calledService = 1;
+    }, 1.0)
+  ];
+
+  const balancer = new AxBalancer(services, {
+    comparator: axInputOrderComparator
+  });
+
+  await balancer.chat({
+    chatPrompt: [{ role: 'user', content: 'test' }],
+    model: 'mock'
+  });
+
+  t.is(calledService, 0);
+});
+
+test('first service fails comparator', async (t) => {
+  let calledService: number | undefined;
+  const services: AxAIService[] = [
+    new MockService(() => {
+      throw new Error('test');
+    }, 2.0),
+    new MockService(() => {
+      calledService = 1;
+    }, 1.0)
+  ];
+
+  const balancer = new AxBalancer(services, {
+    comparator: axInputOrderComparator
+  });
+
+  await balancer.chat({
+    chatPrompt: [{ role: 'user', content: 'test' }],
+    model: 'mock'
+  });
+
+  t.is(calledService, 1);
+});


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Adds a feature where the order in which AxBalancer cycles through services can be configured.

- **What is the current behavior?** (You can also link to an open issue here)
Currently AxBalancer always picks the cheapest service first.

- **What is the new behavior (if this is a feature change)?**
The new behavior is that AxBalancer defaults to a "costComparator" that behaves identically to before. But now we can pass in a custom comparator that changes the service order / priority.
