### PR TITLE
Render and parse YAML lists for array fields

### DIFF
--- a/src/ax/dsp/extract.test.ts
+++ b/src/ax/dsp/extract.test.ts
@@ -198,3 +198,27 @@ test('error handling for malformed content', (t) => {
   // Should not extract any values
   t.deepEqual(values, {});
 });
+
+test('extractValues: handles array output JSON', (t) => {
+  const sig = new AxSignature('input -> output1:string[]');
+  const values: Record<string, unknown> = {};
+
+  const content = 'Output 1: ["test", "test2"]';
+
+  extractValues(sig, values, content);
+
+  t.deepEqual(values, { output1: ['test', 'test2'] });
+});
+
+test('extractValues: handles array output markdown', (t) => {
+  const sig = new AxSignature('input -> output1:string[]');
+  const values: Record<string, unknown> = {};
+
+  const content = `Output 1:
+  - test
+  - test2`;
+
+  extractValues(sig, values, content);
+
+  t.deepEqual(values, { output1: ['test', 'test2'] });
+});

--- a/src/ax/dsp/extract.ts
+++ b/src/ax/dsp/extract.ts
@@ -4,6 +4,7 @@ import JSON5 from 'json5';
 
 import { parseLLMFriendlyDate, parseLLMFriendlyDateTime } from './datetime.js';
 import type { AxField, AxSignature } from './sig.js';
+import { parseMarkdownList } from './util.js';
 import { AxValidationError } from './validate.js';
 
 export const extractValues = (
@@ -151,7 +152,12 @@ function validateAndParseFieldValue(
 
   if (field.type?.isArray) {
     try {
-      value = JSON5.parse(fieldValue);
+      try {
+        value = JSON5.parse(fieldValue);
+      } catch (e) {
+        // If JSON parsing fails, try markdown parsing
+        value = parseMarkdownList(fieldValue);
+      }
       if (!Array.isArray(value)) {
         throw new Error('Expected an array');
       }

--- a/src/ax/dsp/prompt.ts
+++ b/src/ax/dsp/prompt.ts
@@ -374,7 +374,7 @@ export class AxPromptTemplate {
 
     if (Array.isArray(value)) {
       text.push('\n');
-      text.push(value.map((v, i) => `[${i + 1}] ${v}`).join('\n'));
+      text.push(value.map((v) => `- ${v}`).join('\n'));
     } else {
       text.push(value as string);
     }

--- a/src/ax/dsp/util.test.ts
+++ b/src/ax/dsp/util.test.ts
@@ -1,0 +1,50 @@
+import test from 'ava';
+
+import { parseMarkdownList } from './util.js';
+
+// Tests for parseMarkdownList
+test('parseMarkdownList: parses a simple markdown list', (t) => {
+  const content = `Output 1:
+  - value1
+  - value2
+  - value3`;
+
+  const result = parseMarkdownList(content);
+
+  t.deepEqual(result, ['value1', 'value2', 'value3']);
+});
+
+test('parseMarkdownList: parses a simple markdown list 2', (t) => {
+  const content = `
+    * value1
+    * value2
+    * value3`;
+
+  const result = parseMarkdownList(content);
+  t.deepEqual(result, ['value1', 'value2', 'value3']);
+});
+
+test('parseMarkdownList: parses a numbered markdown list', (t) => {
+  const content = `Output 1:
+  1. value1
+  2. value2
+  3. value3`;
+
+  const result = parseMarkdownList(content);
+  t.deepEqual(result, ['value1', 'value2', 'value3']);
+});
+
+test('parseMarkdownList: fails on non-list content', (t) => {
+  const content = 'not a list';
+
+  t.throws(() => parseMarkdownList(content));
+});
+
+test('parseMarkdownList: fails on mixed content', (t) => {
+  const content = `
+  - value1
+  Header
+  - value3`;
+
+  t.throws(() => parseMarkdownList(content));
+});

--- a/src/ax/dsp/util.ts
+++ b/src/ax/dsp/util.ts
@@ -158,3 +158,53 @@ export function mergeProgramUsage(
 
   return Object.values(usageMap);
 }
+
+/**
+ * Parses a markdown list from a string. This is a very forgiving parser that
+ * will try to handle anything that looks vaguely like a markdown list.
+ */
+export const parseMarkdownList = (input: string): string[] => {
+  // Handle empty input
+  if (!input.trim()) {
+    return [];
+  }
+
+  const listBullets = new Set(['-', '*', '+']);
+  const numberedListRegex = /^\d+[\s]*[.)\]]\s*/;
+
+  const lines = input.split('\n');
+  const list = [];
+
+  for (const line of lines) {
+    const trimmedLine = line.trim();
+    // Skip empty lines
+    if (!trimmedLine) {
+      continue;
+    }
+
+    // Check for bullet points
+    if (trimmedLine[0] && listBullets.has(trimmedLine[0])) {
+      list.push(trimmedLine.slice(1).trim());
+    }
+    // Check for numbered lists (e.g., "1.", "2.", etc.)
+    else if (numberedListRegex.test(trimmedLine)) {
+      list.push(trimmedLine.replace(numberedListRegex, '').trim());
+    }
+    // If it's not a list item and we haven't collected any items yet, skip it
+    else if (list.length === 0) {
+      continue;
+    }
+    // If we've already started collecting list items, then this non-list line
+    //is an error
+    else {
+      throw new Error('Could not parse markdown list: mixed content detected');
+    }
+  }
+
+  // If we didn't find any list items, throw error
+  if (list.length === 0) {
+    throw new Error('Could not parse markdown list: no valid list items found');
+  }
+
+  return list;
+};


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix

- **What is the current behavior?** (You can also link to an open issue here)
Currently we render arrays as numbered lists, but parse LLM array output as JSON. This confuses the LLM in some cases.

- **What is the new behavior (if this is a feature change)?**
The new behavior is that we render arrays as YAML, and more flexibly parse LLM arrays as JSON or YAML/Markdown.
