### PR TITLE
Add missing getMetrics call in AxBalancer and test mock

### DIFF
--- a/src/ax/ai/balance.test.ts
+++ b/src/ax/ai/balance.test.ts
@@ -5,6 +5,7 @@ import type {
   AxAIPromptConfig,
   AxAIService,
   AxAIServiceActionOptions,
+  AxAIServiceMetrics,
   AxChatRequest,
   AxChatResponse,
   AxEmbedResponse
@@ -32,6 +33,7 @@ class MockService implements AxAIService {
   getModelConfig = () => ({});
   getFeatures = () => ({ functions: false, streaming: false });
   getModelMap = () => undefined;
+  getMetrics = () => ({}) as AxAIServiceMetrics;
 
   embed = async () => ({}) as AxEmbedResponse;
   setOptions = () => {};

--- a/src/ax/ai/balance.ts
+++ b/src/ax/ai/balance.ts
@@ -5,6 +5,7 @@ import type {
   AxAIPromptConfig,
   AxAIService,
   AxAIServiceActionOptions,
+  AxAIServiceMetrics,
   AxAIServiceOptions,
   AxChatRequest,
   AxChatResponse,
@@ -103,6 +104,10 @@ export class AxBalancer implements AxAIService {
 
   getFeatures(model?: string) {
     return this.currentService.getFeatures(model);
+  }
+
+  getMetrics(): AxAIServiceMetrics {
+    return this.currentService.getMetrics();
   }
 
   async chat(


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix

- **What is the current behavior?** (You can also link to an open issue here)
Doc build fails because `getMetrics` call is missing in a couple places.

- **What is the new behavior (if this is a feature change)?**
Doc build succeeds
