### PR TITLE
Fix: don't fail validation on missing optional field

### DIFF
--- a/src/ax/dsp/asserts.ts
+++ b/src/ax/dsp/asserts.ts
@@ -131,7 +131,9 @@ export const assertRequiredFields = (
   values: Record<string, unknown>
 ) => {
   const fields = sig.getOutputFields()
-  const missingFields = fields.filter((f) => !(f.name in values))
+  const missingFields = fields.filter(
+    (f) => !f.isOptional && !(f.name in values)
+  )
   if (missingFields.length > 0) {
     throw new AxAssertionError({
       message: `Output must include: ${missingFields.map((f) => `\`${f.title}:\``).join(', ')}`,


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix

- **What is the current behavior?** (You can also link to an open issue here)
Output field validation fails if an optional field has no value

- **What is the new behavior (if this is a feature change)?**
Optional fields can have no value
