### PR TITLE
Add auth for Google Vertex API

### DIFF
--- a/.cspell/project-words.txt
+++ b/.cspell/project-words.txt
@@ -91,3 +91,4 @@ weaviate
 Weaviate
 xlarge
 xstate
+googleauth

--- a/package-lock.json
+++ b/package-lock.json
@@ -4111,7 +4111,6 @@
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.3.tgz",
       "integrity": "sha512-jRR5wdylq8CkOe6hei19GGZnxM6rBGwFl3Bg0YItGDimvjGtAvdZk4Pu6Cl4u4Igsws4a1fd1Vq3ezrhn4KmFw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 14"
@@ -5391,7 +5390,6 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
       "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -5424,6 +5422,15 @@
       "integrity": "sha512-Nik3Sc0ncrMK4UUdXQmAnRtzmNQTAAXmXIopizwZ1W1t8QmfJj+zL4OA2I7XPTPW5z5TDqv4hRo/JzouDJnX3A==",
       "dev": true,
       "license": "Apache-2.0"
+    },
+    "node_modules/bignumber.js": {
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.1.2.tgz",
+      "integrity": "sha512-2/mKyZH9K85bzOEfhXDBFZTGd1CTs+5IHpeFQo9luiBG7hghdC851Pj2WAhb6E3R6b9tZj/XKhbg4fum+Kepug==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
     },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
@@ -5601,6 +5608,12 @@
         "base64-js": "^1.3.1",
         "ieee754": "^1.1.13"
       }
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/buffer-from": {
       "version": "1.1.2",
@@ -7883,6 +7896,15 @@
       "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
       "license": "MIT"
     },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "node_modules/electron-to-chromium": {
       "version": "1.5.80",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.80.tgz",
@@ -9481,6 +9503,47 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/gaxios": {
+      "version": "6.7.1",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-6.7.1.tgz",
+      "integrity": "sha512-LDODD4TMYx7XXdpwxAVRAIAuB0bzv0s+ywFonY46k126qzQHT9ygyoa9tncmOiQmmDrik65UYsEkv3lbfqQ3yQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "is-stream": "^2.0.0",
+        "node-fetch": "^2.6.9",
+        "uuid": "^9.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/gaxios/node_modules/is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/gcp-metadata": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-6.1.0.tgz",
+      "integrity": "sha512-Jh/AIwwgaxan+7ZUUmRLCjtchyDiqh4KjBJ5tW3plBZb5iL/BPcso8A5DlzeD9qlw0duCamnNdpFjxwaT0KyKg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "gaxios": "^6.0.0",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/gensequence": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/gensequence/-/gensequence-7.0.0.tgz",
@@ -10194,6 +10257,23 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/google-auth-library": {
+      "version": "9.15.1",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-9.15.1.tgz",
+      "integrity": "sha512-Jb6Z0+nvECVz+2lzSMt9u98UsoakXxA2HGHMCxh+so3n90XgYWkq5dur19JAJV7ONiJY22yBTyJB1TSkvPq9Ng==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "gaxios": "^6.1.1",
+        "gcp-metadata": "^6.1.0",
+        "gtoken": "^7.0.0",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/gopd": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
@@ -10219,6 +10299,19 @@
       "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/gtoken": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-7.1.0.tgz",
+      "integrity": "sha512-pCcEwRi+TKpMlxAQObHDQ56KawURgyAf6jtIY046fJ5tIv3zDe/LEIubckAO8fj6JnAxLdmWkUfNyulQ2iKdEw==",
+      "license": "MIT",
+      "dependencies": {
+        "gaxios": "^6.0.0",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
     },
     "node_modules/h3": {
       "version": "1.13.1",
@@ -10637,7 +10730,6 @@
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
       "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "agent-base": "^7.1.2",
@@ -11950,6 +12042,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/json-bigint": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
+      "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bignumber.js": "^9.0.0"
+      }
+    },
     "node_modules/json-buffer": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
@@ -12071,6 +12172,27 @@
       },
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/jwa": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.0.tgz",
+      "integrity": "sha512-jrZ2Qx916EA+fq9cEAeCROWPTfCwi1IVHqT2tapuqLEVVDKFDENFw1oL+MwrTvH6msKxsd1YTDVw6uKEcsrLEA==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.0.tgz",
+      "integrity": "sha512-KDncfTmOZoOMTFG4mBlG0qUIOlc03fmzH+ru6RgYVZhPkyiy/92Owlt/8UEN+a4TXR1FQetfIpJE8ApdvdVxTg==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^2.0.0",
+        "safe-buffer": "^5.0.1"
       }
     },
     "node_modules/keyv": {
@@ -13837,7 +13959,6 @@
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
       "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "whatwg-url": "^5.0.0"
@@ -16939,7 +17060,6 @@
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -19383,7 +19503,6 @@
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/tree-kill": {
@@ -21008,6 +21127,19 @@
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "license": "MIT"
     },
+    "node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/v8-to-istanbul": {
       "version": "9.3.0",
       "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.3.0.tgz",
@@ -21436,7 +21568,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
       "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-      "dev": true,
       "license": "BSD-2-Clause"
     },
     "node_modules/well-known-symbols": {
@@ -21476,7 +21607,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
       "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "tr46": "~0.0.3",
@@ -22230,6 +22360,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/api": "^1.9.0",
+        "google-auth-library": "^9.15.1",
         "json5": "^2.2.3",
         "moment-timezone": "^0.5.46"
       }

--- a/src/ax/ai/anthropic/api.ts
+++ b/src/ax/ai/anthropic/api.ts
@@ -310,11 +310,11 @@ export class AxAIAnthropic extends AxBaseAI<
     super(aiImpl, {
       name: 'Anthropic',
       apiURL: 'https://api.anthropic.com/v1',
-      headers: {
+      headers: async () => ({
         'anthropic-version': '2023-06-01',
         'anthropic-beta': 'prompt-caching-2024-07-31',
         'x-api-key': apiKey,
-      },
+      }),
       modelInfo: axModelInfoAnthropic,
       models: { model: _config.model },
       options,

--- a/src/ax/ai/azure-openai/api.ts
+++ b/src/ax/ai/azure-openai/api.ts
@@ -69,6 +69,6 @@ export class AxAIAzureOpenAI extends AxAIOpenAI {
       ).href
     )
 
-    super.setHeaders({ 'api-key': apiKey })
+    super.setHeaders(async () => ({ 'api-key': apiKey }))
   }
 }

--- a/src/ax/ai/base.ts
+++ b/src/ax/ai/base.ts
@@ -36,7 +36,7 @@ export interface AxBaseAIFeatures {
 export interface AxBaseAIArgs {
   name: string
   apiURL: string
-  headers: Record<string, string>
+  headers: () => Promise<Record<string, string>>
   modelInfo: Readonly<AxModelInfo[]>
   models: Readonly<{ model: string; embedModel?: string }>
   options?: Readonly<AxAIServiceOptions>
@@ -83,7 +83,7 @@ export class AxBaseAI<
 
   protected apiURL: string
   protected name: string
-  protected headers: Record<string, string>
+  protected headers: () => Promise<Record<string, string>>
   protected supportFor: AxBaseAIFeatures | ((model: string) => AxBaseAIFeatures)
 
   // Add private metrics tracking properties
@@ -168,7 +168,7 @@ export class AxBaseAI<
     this.apiURL = apiURL
   }
 
-  public setHeaders(headers: Record<string, string>): void {
+  public setHeaders(headers: () => Promise<Record<string, string>>): void {
     this.headers = headers
   }
 
@@ -393,7 +393,7 @@ export class AxBaseAI<
         {
           name: apiConfig.name,
           url: this.apiURL,
-          headers: this.buildHeaders(apiConfig.headers),
+          headers: await this.buildHeaders(apiConfig.headers),
           stream: modelConfig.stream,
           debug: this.debug,
           fetch: this.fetch,
@@ -552,7 +552,7 @@ export class AxBaseAI<
         {
           name: apiConfig.name,
           url: this.apiURL,
-          headers: this.buildHeaders(apiConfig.headers),
+          headers: await this.buildHeaders(apiConfig.headers),
           debug: this.debug,
           fetch: this.fetch,
           span,
@@ -586,10 +586,10 @@ export class AxBaseAI<
     return res
   }
 
-  private buildHeaders(
+  private async buildHeaders(
     headers: Record<string, string> = {}
-  ): Record<string, string> {
-    return { ...headers, ...this.headers }
+  ): Promise<Record<string, string>> {
+    return { ...headers, ...(await this.headers()) }
   }
 }
 

--- a/src/ax/ai/cohere/api.ts
+++ b/src/ax/ai/cohere/api.ts
@@ -309,7 +309,7 @@ export class AxAICohere extends AxBaseAI<
     super(aiImpl, {
       name: 'Cohere',
       apiURL: 'https://api.cohere.ai/v1',
-      headers: { Authorization: `Bearer ${apiKey}` },
+      headers: async () => ({ Authorization: `Bearer ${apiKey}` }),
       modelInfo: axModelInfoCohere,
       models: { model: _config.model },
       supportFor: { functions: true, streaming: true },

--- a/src/ax/ai/google-gemini/auth.ts
+++ b/src/ax/ai/google-gemini/auth.ts
@@ -1,0 +1,82 @@
+import { GoogleAuth } from 'google-auth-library'
+import type {
+  GoogleAuthOptions,
+  JSONClient,
+} from 'google-auth-library/build/src/auth/googleauth.js'
+import type { GetAccessTokenResponse } from 'google-auth-library/build/src/auth/oauth2client.js'
+
+/**
+ * This class is used to authenticate with the Google Vertex AI API.
+ */
+export class GoogleVertexAuth {
+  private auth: GoogleAuth
+  private client?: JSONClient
+  private currentToken?: string
+  private tokenExpiry?: number
+
+  constructor(config: GoogleAuthOptions = {}) {
+    this.auth = new GoogleAuth({
+      scopes: ['https://www.googleapis.com/auth/cloud-platform'],
+      ...config,
+    })
+  }
+
+  async getAuthenticatedClient() {
+    if (!this.client) {
+      this.client = (await this.auth.getClient()) as JSONClient
+    }
+    return this.client
+  }
+
+  async getAccessToken() {
+    // Check if we have a valid cached token
+    if (
+      this.currentToken &&
+      this.tokenExpiry &&
+      Date.now() < this.tokenExpiry
+    ) {
+      return this.currentToken
+    }
+
+    const client = await this.getAuthenticatedClient()
+    const tokenResponse = await client.getAccessToken()
+
+    // Cache the token
+    this.currentToken = tokenResponse.token ?? undefined
+
+    // Set expiry
+    const expiry = this.getExpiry(tokenResponse)
+
+    // Set expiry 5 minutes before actual expiry to be safe
+    const fiveMinutes = 5 * 60 * 1000
+    this.tokenExpiry = expiry - fiveMinutes
+
+    return this.currentToken
+  }
+
+  /**
+   * Get the expiry date from the token response.
+   */
+  getExpiry(tokenResponse: GetAccessTokenResponse) {
+    // Default to 1 hour (the typical expiry for a token)
+    const oneHour = 3600 * 1000
+    let expiry = Date.now() + oneHour
+
+    let responseExpiry = tokenResponse.res?.data?.expiry_date
+    if (responseExpiry) {
+      if (typeof responseExpiry === 'number') {
+        expiry = responseExpiry
+      } else if (responseExpiry instanceof Date) {
+        expiry = responseExpiry.getTime()
+      } else if (typeof responseExpiry === 'string') {
+        expiry = new Date(responseExpiry).getTime()
+      } else {
+        console.warn('Unknown expiry type', responseExpiry)
+      }
+    } else {
+      console.warn('No expiry date found in response', tokenResponse.res?.data)
+    }
+
+    return expiry
+  }
+}

--- a/src/ax/ai/huggingface/api.ts
+++ b/src/ax/ai/huggingface/api.ts
@@ -178,7 +178,7 @@ export class AxAIHuggingFace extends AxBaseAI<
     super(aiImpl, {
       name: 'HuggingFace',
       apiURL: 'https://api-inference.huggingface.co',
-      headers: { Authorization: `Bearer ${apiKey}` },
+      headers: async () => ({ Authorization: `Bearer ${apiKey}` }),
       modelInfo: axModelInfoHuggingFace,
       models: { model: _config.model },
       options,

--- a/src/ax/ai/openai/api.ts
+++ b/src/ax/ai/openai/api.ts
@@ -438,7 +438,7 @@ export class AxAIOpenAI extends AxBaseAI<
     super(aiImpl, {
       name: 'OpenAI',
       apiURL: apiURL ? apiURL : 'https://api.openai.com/v1',
-      headers: { Authorization: `Bearer ${apiKey}` },
+      headers: async () => ({ Authorization: `Bearer ${apiKey}` }),
       modelInfo,
       models: {
         model: _config.model as string,

--- a/src/ax/ai/reka/api.ts
+++ b/src/ax/ai/reka/api.ts
@@ -288,7 +288,7 @@ export class AxAIReka extends AxBaseAI<
     super(aiImpl, {
       name: 'Reka',
       apiURL: apiURL ? apiURL : 'https://api.reka.ai/v1/chat',
-      headers: { 'X-Api-Key': apiKey },
+      headers: async () => ({ 'X-Api-Key': apiKey }),
       modelInfo,
       models: {
         model: _config.model as string,

--- a/src/ax/package.json
+++ b/src/ax/package.json
@@ -34,9 +34,10 @@
     "postbuild": "node ../../scripts/postbuild.js"
   },
   "dependencies": {
+    "@opentelemetry/api": "^1.9.0",
+    "google-auth-library": "^9.15.1",
     "json5": "^2.2.3",
-    "moment-timezone": "^0.5.46",
-    "@opentelemetry/api": "^1.9.0"
+    "moment-timezone": "^0.5.46"
   },
   "ava": {
     "failFast": true,


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Feature

- **What is the current behavior?** (You can also link to an open issue here)
Currently you must provide a long-lived apiKey key. This is not how the Vertex API is designed to work, though -- it's designed around an oauth2 / ADC flow with short-lived tokens.

- **What is the new behavior (if this is a feature change)?**
Correctly implements oauth2 / ADC flow for authenticating to Vertex API

- **Testing**
Tested with examples. Everything works.

Config in `src/examples/chain-of-thought.ts`:
```TypeScript
const ai = new AxAI({
  name: 'google-gemini',
  projectId: '<PROJECT_ID>',
  region: '<REGION>',
  config: { model: AxAIGoogleGeminiModel.Gemini15Flash },
})
```
=>
```sh
$ npm run tsx src/examples/chain-of-thought.ts
{
  reason: 'The context states that "France is a unitary semi-presidential republic with its capital in Paris".',
  answer: [ 'Paris' ]
}
{
  latency: {
    chat: {
      mean: 0.2908749999999998,
      p95: 0.2908749999999998,
      p99: 0.2908749999999998,
      samples: [Array]
    },
    embed: { mean: 0, p95: 0, p99: 0, samples: [] }
  },
  errors: {
    chat: { count: 0, rate: 0, total: 1 },
    embed: { count: 0, rate: 0, total: 0 }
  }
}
```