### PR TITLE
Fix: embedding requests to Google Vertex API

### DIFF
--- a/src/ax/ai/google-gemini/types.ts
+++ b/src/ax/ai/google-gemini/types.ts
@@ -185,3 +185,23 @@ export type AxAIGoogleGeminiBatchEmbedResponse = {
     values: number[]
   }[]
 }
+
+/**
+ * AxAIGoogleVertexBatchEmbedRequest: Structure for making an embedding request to the Google Vertex API.
+ */
+export type AxAIGoogleVertexBatchEmbedRequest = {
+  instances: {
+    content: string
+  }[]
+}
+
+/**
+ * AxAIGoogleVertexBatchEmbedResponse: Structure for handling responses from the Google Vertex API embedding requests.
+ */
+export type AxAIGoogleVertexBatchEmbedResponse = {
+  predictions: {
+    embeddings: {
+      values: number[]
+    }
+  }[]
+}


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix

- **What is the current behavior?** (You can also link to an open issue here)
Embedding requests to the Vertex API do not work:
```sh
➜  ax git:(main) ✗ npm run tsx src/examples/embedding.ts

> @ax-llm/ax-monorepo@10.0.38 tsx
> node --env-file=.env --import=tsx src/examples/embedding.ts

/Users/josh/Projects/ax/src/ax/util/apicall.ts:85
    throw new Error(
          ^


Error: API Response Error: https://us-central1-aiplatform.googleapis.com/v1/projects/gsuite-importer-436622/locations/us-central1/publishers/google/models/text-embedding-004:batchEmbedContents
Error: API Request
Error: 404, Not Found
...
```

- **What is the new behavior (if this is a feature change)?**
Embedding requests to the Vertex API work correctly:
```sh
➜  ax git:(fix-emb-vertex) ✗ npm run tsx src/examples/embedding.ts

> @ax-llm/ax-monorepo@10.0.38 tsx
> node --env-file=.env --import=tsx src/examples/embedding.ts

{
  embeddings: [
    [
         0.004205973,   -0.016312873,   -0.061666932,  0.0038516768,
        -0.031506833,   -0.008476874,    0.061710205,      0.041481,
         0.029845009,     0.06339856,    -0.04829267, -0.0057464475,
          0.02853662, -0.00067719404,    -0.01982539,  -0.028879909,
        -0.017067183,    0.013300819,    -0.10784503,   0.004566127,
         0.018048378,  -0.0033129563,   -0.032339156,  -0.054119483,
        -0.015690967,    0.012721628,    0.008894882,   0.019235175,
        ...
```

- **Other information**:
