### PR TITLE
Fix: don't render extraneous period at the end of task prompt

### DIFF
--- a/src/ax/dsp/prompt.ts
+++ b/src/ax/dsp/prompt.ts
@@ -79,8 +79,9 @@ export class AxPromptTemplate {
 
     const desc = this.sig.getDescription()
     if (desc) {
+      const capitalized = capitalizeFirstLetter(desc.trim())
       task.push(
-        `## TASK DESCRIPTION\n${capitalizeFirstLetter(desc.endsWith('.') ? desc : desc + '.')}`
+        `## TASK DESCRIPTION\n${capitalized.endsWith('.') ? capitalized : capitalized + '.'}`
       )
     }
 


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix

- **What is the current behavior?** (You can also link to an open issue here)
If a task prompt ends with any whitespace (e.g. newline), an extra period "." is rendered at the end of the prompt. For example:

```TypeScript
const description = `\
This is the prompt.
`;
const signature = new AxSignature(`\
  content:string \
  -> \
  reasoning:string \
  `);
signature.setDescription(description);
```
=>
```
## TASK DESCRIPTION
This is the prompt.
.
```

- **What is the new behavior (if this is a feature change)?**
Doesn't render an extra period:
```
## TASK DESCRIPTION
This is the prompt.
```

- **Other information**:
