### PR TITLE
AxBalancer: add service retries with exponential backoff

### DIFF
--- a/src/ax/ai/base.ts
+++ b/src/ax/ai/base.ts
@@ -84,6 +84,7 @@ export class AxBaseAI<
 
   protected apiURL: string
   protected name: string
+  protected id: string
   protected headers: () => Promise<Record<string, string>>
   protected supportFor: AxAIFeatures | ((model: string) => AxAIFeatures)
 
@@ -145,6 +146,7 @@ export class AxBaseAI<
     this.tracer = options.tracer
     this.modelInfo = modelInfo
     this.models = models
+    this.id = crypto.randomUUID()
 
     const model =
       this.models?.find((v) => v.key === defaults.model)?.model ??
@@ -169,6 +171,10 @@ export class AxBaseAI<
 
   public setName(name: string): void {
     this.name = name
+  }
+
+  public getId(): string {
+    return this.id
   }
 
   public setAPIURL(apiURL: string): void {

--- a/src/ax/ai/mock/api.ts
+++ b/src/ax/ai/mock/api.ts
@@ -28,6 +28,7 @@ export class AxMockAIService implements AxAIService {
   constructor(
     private readonly config: {
       name?: string
+      id?: string
       modelInfo?: Partial<AxModelInfoWithProvider>
       embedModelInfo?: AxModelInfoWithProvider
       features?: { functions?: boolean; streaming?: boolean }
@@ -46,10 +47,16 @@ export class AxMockAIService implements AxAIService {
       errorMessage?: string
       latencyMs?: number
     } = {}
-  ) {}
+  ) {
+    this.config.id = this.config.id ?? crypto.randomUUID()
+  }
 
   getName(): string {
     return this.config.name ?? 'mock-ai-service'
+  }
+
+  getId(): string {
+    return this.config.id ?? 'mock-ai-service-id'
   }
 
   getModelInfo(): Readonly<AxModelInfoWithProvider> {

--- a/src/ax/ai/types.ts
+++ b/src/ax/ai/types.ts
@@ -229,6 +229,7 @@ export type AxAIServiceActionOptions = {
 }
 
 export interface AxAIService {
+  getId(): string
   getName(): string
   getModelInfo(): Readonly<AxModelInfoWithProvider>
   getEmbedModelInfo(): Readonly<AxModelInfoWithProvider> | undefined

--- a/src/ax/ai/wrap.ts
+++ b/src/ax/ai/wrap.ts
@@ -127,6 +127,10 @@ export class AxAI implements AxAIService {
     return this.ai.getName()
   }
 
+  getId(): string {
+    return this.ai.getId()
+  }
+
   getModelInfo(): Readonly<AxModelInfoWithProvider> {
     return this.ai.getModelInfo()
   }


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Feature

- **What is the current behavior?** (You can also link to an open issue here)
Currently AxBalancer retries each service without backing off. This could result in slamming services with an outage

- **What is the new behavior (if this is a feature change)?**
AxBalancer backs off when the service is down
