### PR TITLE
Fix: deepseek r1 on together.ai returning empty result

### DIFF
--- a/src/ax/dsp/generate.ts
+++ b/src/ax/dsp/generate.ts
@@ -353,7 +353,7 @@ export class AxGen<
 
       mem.addResult(result, sessionId)
 
-      if (result.functionCalls) {
+      if (result.functionCalls?.length) {
         const funcs = parseFunctionCalls(ai, result.functionCalls, values)
 
         if (funcs) {


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix

- **What is the current behavior?** (You can also link to an open issue here)
Currently all calls to DeepSeek R1 on together.ai return empty results

- **What is the new behavior (if this is a feature change)?**
DeepSeek R1 output returned properly
