### PR TITLE
Add Gemini 1.5 Flash 002 model, since Vertex defaults to 001

### DIFF
--- a/src/ax/ai/google-gemini/types.ts
+++ b/src/ax/ai/google-gemini/types.ts
@@ -7,6 +7,7 @@ export enum AxAIGoogleGeminiModel {
   Gemini20FlashThinking = 'gemini-2.0-flash-thinking-exp-01-21',
   Gemini1Pro = 'gemini-1.0-pro',
   Gemini15Flash = 'gemini-1.5-flash',
+  Gemini15Flash002 = 'gemini-1.5-flash-002',
   Gemini15Flash8B = 'gemini-1.5-flash-8b',
   Gemini15Pro = 'gemini-1.5-pro',
   Gemma2 = 'gemma-2-27b-it',


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Feature

- **What is the current behavior?** (You can also link to an open issue here)
There's no enum entry specifically for the Gemini 1.5 Flash 002 model

- **What is the new behavior (if this is a feature change)?**
Enum entry added
