### PR TITLE
fix: TypeError: Cannot read properties of undefined (reading 'length')

### DIFF
--- a/src/ax/dsp/generate.ts
+++ b/src/ax/dsp/generate.ts
@@ -342,8 +342,8 @@ export class AxGen<
     // If there are multiple results, filter out the ones that don't have function calls
     // Anthropic for example generates chain-of-though content before function calls which
     // we want to ignore
-    if (res.results.length > 1) {
-      results = res.results.filter((r) => r.functionCalls)
+    if (results.length > 1) {
+      results = results.filter((r) => r.functionCalls)
     }
 
     for (const result of results) {


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix

- **What is the current behavior?** (You can also link to an open issue here)
Currently we occasionally see the following error:
```
TypeError: Cannot read properties of undefined (reading 'length')
    at AxGen.processResponse (file:///home/josh/Projects/bigb/api/node_modules/.deno/@ax-llm+ax@11.0.5/node_modules/@ax-llm/ax/index.js:5820:21)
    at AxGen.forwardCore (file:///home/josh/Projects/bigb/api/node_modules/.deno/@ax-llm+ax@11.0.5/node_modules/@ax-llm/ax/index.js:5711:24)
    at eventLoopTick (ext:core/01_core.js:177:7)
    at async AxGen._forward2 (file:///home/josh/Projects/bigb/api/node_modules/.deno/@ax-llm+ax@11.0.5/node_modules/@ax-llm/ax/index.js:5876:28)
    ...
```

- **What is the new behavior (if this is a feature change)?**
No error when results empty

- **Other information**:
