### PR TITLE
Allow json examples to pass validation

### DIFF
--- a/src/ax/dsp/util.ts
+++ b/src/ax/dsp/util.ts
@@ -47,6 +47,8 @@ export const validateValue = (
         return val instanceof Date || typeof val === 'string'
       case 'datetime':
         return val instanceof Date || typeof val === 'string'
+      case 'json':
+        return typeof val === 'object' || typeof val === 'string'
       default:
         return false // Unknown or unsupported type
     }


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix

- **What is the current behavior?** (You can also link to an open issue here)
Currently we cannot specify examples for "json" typed return values. It throws the following error:

```sh
Error: Validation failed: Expected 'answer' to be a json instead got 'string' ({ text: "Paris" })
    at validateValue (/Users/josh/Projects/ax/src/ax/dsp/util.ts:134:11)
```

- **What is the new behavior (if this is a feature change)?**
Examples for json-typed fields pass validation.
