### PR TITLE
chore: fix prompt language

### DIFF
--- a/src/ax/dsp/prompt.ts
+++ b/src/ax/dsp/prompt.ts
@@ -457,7 +457,7 @@ const renderOutputFields = (fields: readonly AxField[]) => {
     const type = field.type?.name ? toFieldType(field.type) : 'string'
 
     const requiredMsg = field.isOptional
-      ? `Only include this ${type} field is it's value is available`
+      ? `Only include this ${type} field if its value is available`
       : `This ${type} field must be included`
 
     const description = field.description


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- Bug fix - incorrect prompt language
- **What is the current behavior?** (You can also link to an open issue here)
- From `./src/examples/extract.ts`:
  - `Ticket Number: (Only include this number field is it's value is available)`
  - `Customer Number: (Only include this number field is it's value is available)`
- **What is the new behavior (if this is a feature change)?**
- From `./src/examples/extract.ts`:
  - `Ticket Number: (Only include this number field if its value is available)`
  - `Customer Number: (Only include this number field if its value is available)`
