### PR TITLE
feat: rename `max_tokens` to `max_completion_tokens` in `AxAIOpenAI`

### DIFF
--- a/src/ax/ai/openai/api.ts
+++ b/src/ax/ai/openai/api.ts
@@ -172,7 +172,7 @@ class AxAIOpenAIImpl<TModel, TEmbedModel>
         : undefined,
       tools,
       tool_choice: toolsChoice,
-      max_tokens: req.modelConfig?.maxTokens ?? this.config.maxTokens ?? 500,
+      max_completion_tokens: req.modelConfig?.maxTokens ?? this.config.maxTokens ?? 500,
       temperature: req.modelConfig?.temperature ?? this.config.temperature,
       top_p: req.modelConfig?.topP ?? this.config.topP ?? 1,
       n: req.modelConfig?.n ?? this.config.n,

--- a/src/ax/ai/openai/types.ts
+++ b/src/ax/ai/openai/types.ts
@@ -123,7 +123,7 @@ export type AxAIOpenAIChatRequest<TModel> = {
     | 'required'
     | { type: 'function'; function: { name: string } }
   response_format?: { type: string }
-  max_tokens: number
+  max_completion_tokens: number
   temperature?: number
   top_p?: number
   n?: number


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Feature

- **What is the current behavior?** (You can also link to an open issue here)
OpenAI has deprecated the `max_tokens` param for a while now but this currently works with their `gpt-*` models.
However, this param is not supported in the reasoning models (`o1` and `o3` series)
https://platform.openai.com/docs/api-reference/chat/create#chat-create-max_tokens

- **What is the new behavior (if this is a feature change)?**
By changing the param name from `max_tokens` to `max_completion_tokens` in the `openai` provider, users of the framework will be able to use the new reasoning models from OpenAI.

- **Other information**:
