### PR TITLE
fix: evalUtils missing from exports in index.ts

### DIFF
--- a/src/ax/index.ts
+++ b/src/ax/index.ts
@@ -347,6 +347,7 @@ import {AxMemory} from './mem/memory.js';
 import {AxMultiServiceRouter} from './ai/multiservice.js';
 import {AxRAG} from './prompts/rag.js';
 import {type AxAIMemory} from './mem/types.js';
+import {axEvalUtil} from './dsp/eval.js';
 
 // Value exports
 export { AxAI };
@@ -597,3 +598,4 @@ export type { AxStreamingFieldProcessorProcess };
 export type { AxTokenUsage };
 export type { AxTunable };
 export type { AxUsable };
+export type { axEvalUtil };


### PR DESCRIPTION
- **What kind of change does this PR introduce?** This is a bugfix. it adds evalUtils as an exported member of ax

- **What is the current behavior?** ([Issue 172](https://github.com/ax-llm/ax/issues/172))

- **What is the new behavior (if this is a feature change)?** This allows evalUtils to be imported and used 

- **Other information**:
