### PR TITLE
refactor: Rename telemetry utility and streaming event name

### DIFF
--- a/src/ax/trace/trace.ts
+++ b/src/ax/trace/trace.ts
@@ -13,6 +13,7 @@ export const axSpanAttributes = {
 
   LLM_USAGE_PROMPT_TOKENS: 'gen_ai.usage.prompt_tokens',
   LLM_USAGE_COMPLETION_TOKENS: 'gen_ai.usage.completion_tokens',
+  LLM_USAGE_TOTAL_TOKENS: 'gen_ai.usage.total_tokens',
 
   // Vector DB
   DB_SYSTEM: 'db.system',


### PR DESCRIPTION
This commit includes the following refactoring changes to improve clarity and consistency in telemetry reporting:

1.  **Function Rename and Signature Change**:
    *   The function `setResponseAttr` in `src/ax/ai/base.ts` has been renamed to `setModelUsageAttr`.
    *   Its first parameter has been changed from `res: Readonly<AxChatResponse | AxEmbedResponse>` to `modelUsage: Readonly<AxModelUsage>`.
    *   The internal logic of the function has been updated to use the new `modelUsage` parameter directly.
    *   All call sites of this function (within `_chat2` and `_embed2`) have been updated to use the new name and pass `res.modelUsage` appropriately.

2.  **Streaming Event Name Change**:
    *   The event name used for telemetry in streaming responses (within `setModelUsageAttr`) has been changed from `'llm.streaming_chunk_usage'` to `'gen_ai.response.chunk'`.

Tests in `src/ax/ai/base.test.ts` have been updated to reflect these changes, primarily by expecting the new event name in streaming test assertions.

- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

- **What is the current behavior?** (You can also link to an open issue here)

- **What is the new behavior (if this is a feature change)?**

- **Other information**:
