### PR TITLE
fix(google-gemini): implement missing googleSearch option

### DIFF
--- a/src/ax/ai/google-gemini/api.ts
+++ b/src/ax/ai/google-gemini/api.ts
@@ -302,6 +302,10 @@ class AxAIGoogleGeminiImpl
       })
     }
 
+    if (this.options?.googleSearch) {
+      tools.push({ google_search: {} })
+    }
+
     if (this.options?.urlContext) {
       tools.push({ url_context: {} })
     }

--- a/src/ax/ai/google-gemini/types.ts
+++ b/src/ax/ai/google-gemini/types.ts
@@ -108,6 +108,7 @@ export type AxAIGoogleGeminiTool = {
   function_declarations?: AxAIGoogleGeminiToolFunctionDeclaration[]
   code_execution?: object
   google_search_retrieval?: AxAIGoogleGeminiToolGoogleSearchRetrieval
+  google_search?: object
   url_context?: object
 }
 


### PR DESCRIPTION
- Add support for `googleSearch` option in `AxAIGoogleGeminiOptionsTools` interface
- Add `google_search` type to `AxAIGoogleGeminiTool` for Google Search grounding

**What kind of change does this PR introduce?** 
Bug fix

**What is the current behavior?** (You can also link to an open issue here)
Grounding with `google_search_retrieval` will be sunset in Sep 2025 along with Gemini 1.5 family of models
the `google_search` tool option exists but was not being passed into the tools list if enabled

**What is the new behavior (if this is a feature change)?**
the `google_search` tool should now be successfully passed into the tools array for the google models to use (if enabled)

**Other information**:
