### PR TITLE
feat: Allow disabling thought token budget with override

### DIFF
--- a/src/ax/ai/google-gemini/api.test.ts
+++ b/src/ax/ai/google-gemini/api.test.ts
@@ -1,0 +1,148 @@
+import { describe, it, expect } from 'vitest'
+import {
+  AxAIGoogleGeminiImpl,
+  axAIGoogleGeminiDefaultConfig,
+} from './api.js' // Assuming AxAIGoogleGeminiImpl can be imported
+import type {
+  AxAIGoogleGeminiConfig,
+  AxAIGoogleGeminiModel,
+  AxAIGoogleGeminiGenerationConfig,
+} from './types.js'
+import type {
+  AxInternalChatRequest,
+  AxAIPromptConfig,
+} from '../types.js'
+
+// Helper to create a minimal AxAIGoogleGeminiImpl instance for testing createChatReq
+const createTestInstance = (
+  configOverrides?: Partial<AxAIGoogleGeminiConfig>
+) => {
+  const fullConfig: AxAIGoogleGeminiConfig = {
+    ...axAIGoogleGeminiDefaultConfig(),
+    apiKey: 'test-key', // apiKey might be needed by constructor or methods
+    ...(configOverrides as AxAIGoogleGeminiConfig),
+  }
+  // Constructor: AxAIGoogleGeminiImpl(config, isVertex, endpointId, apiKey, options)
+  return new AxAIGoogleGeminiImpl(fullConfig, false, undefined, 'test-key')
+}
+
+describe('AxAIGoogleGeminiImpl.createChatReq', () => {
+  const baseInternalReq: AxInternalChatRequest<AxAIGoogleGeminiModel> = {
+    model: 'gemini-1.5-flash-latest' as AxAIGoogleGeminiModel, // Example model
+    chatPrompt: [{ role: 'user', content: 'Hello' }],
+  }
+
+  it('should set thinkingBudget to 0 in generationConfig.thinkingConfig when thinkingTokenBudget is "disable"', () => {
+    const instance = createTestInstance()
+    const promptConfig: AxAIPromptConfig = {
+      thinkingTokenBudget: 'disable',
+    }
+    const [, chatReq] = instance.createChatReq(baseInternalReq, promptConfig)
+
+    expect(chatReq.generationConfig?.thinkingConfig?.thinkingBudget).toBe(0)
+  })
+
+  it('should set thinkingBudget in generationConfig.thinkingConfig when thinkingTokenBudget is "minimal"', () => {
+    const instance = createTestInstance()
+    const promptConfig: AxAIPromptConfig = {
+      thinkingTokenBudget: 'minimal',
+    }
+    const [, chatReq] = instance.createChatReq(baseInternalReq, promptConfig)
+
+    expect(chatReq.generationConfig?.thinkingConfig?.thinkingBudget).toBe(200)
+  })
+
+  it('should set thinkingBudget for "low"', () => {
+    const instance = createTestInstance()
+    const promptConfig: AxAIPromptConfig = { thinkingTokenBudget: 'low' }
+    const [, chatReq] = instance.createChatReq(baseInternalReq, promptConfig)
+    expect(chatReq.generationConfig?.thinkingConfig?.thinkingBudget).toBe(800)
+  })
+
+  it('should set thinkingBudget for "medium"', () => {
+    const instance = createTestInstance()
+    const promptConfig: AxAIPromptConfig = { thinkingTokenBudget: 'medium' }
+    const [, chatReq] = instance.createChatReq(baseInternalReq, promptConfig)
+    expect(chatReq.generationConfig?.thinkingConfig?.thinkingBudget).toBe(5000)
+  })
+
+  it('should set thinkingBudget for "high"', () => {
+    const instance = createTestInstance()
+    const promptConfig: AxAIPromptConfig = { thinkingTokenBudget: 'high' }
+    const [, chatReq] = instance.createChatReq(baseInternalReq, promptConfig)
+    expect(chatReq.generationConfig?.thinkingConfig?.thinkingBudget).toBe(10000)
+  })
+
+  it('should set thinkingBudget for "highest"', () => {
+    const instance = createTestInstance()
+    const promptConfig: AxAIPromptConfig = { thinkingTokenBudget: 'highest' }
+    const [, chatReq] = instance.createChatReq(baseInternalReq, promptConfig)
+    expect(chatReq.generationConfig?.thinkingConfig?.thinkingBudget).toBe(24500)
+  })
+
+  it('should use instance thinkingTokenBudget if promptConfig.thinkingTokenBudget is undefined', () => {
+    // In Gemini, instance config has `this.config.thinking.thinkingTokenBudget`
+    const instanceWithThinkingBudget = createTestInstance({
+      thinking: { includeThoughts: true, thinkingTokenBudget: 1234 },
+    })
+    const promptConfig: AxAIPromptConfig = {
+      // thinkingTokenBudget is undefined
+    }
+    const [, chatReq] = instanceWithThinkingBudget.createChatReq(baseInternalReq, promptConfig)
+    // The logic:
+    // 1. if (this.config.thinking?.thinkingTokenBudget) { thinkingConfig.thinkingBudget = this.config.thinking.thinkingTokenBudget }
+    // 2. if (config.thinkingTokenBudget && config.thinkingTokenBudget !== 'disable') { switch ... thinkingConfig.thinkingBudget = ... }
+    // So, if promptConfig.thinkingTokenBudget is undefined, the instance one (1234) should apply.
+    expect(chatReq.generationConfig?.thinkingConfig?.thinkingBudget).toBe(1234)
+  })
+
+  it('should overwrite instance thinkingTokenBudget if promptConfig.thinkingTokenBudget is "minimal"', () => {
+    const instanceWithThinkingBudget = createTestInstance({
+      thinking: { includeThoughts: true, thinkingTokenBudget: 1234 },
+    })
+    const promptConfig: AxAIPromptConfig = {
+      thinkingTokenBudget: 'minimal', // This is 200
+    }
+    const [, chatReq] = instanceWithThinkingBudget.createChatReq(baseInternalReq, promptConfig)
+    expect(chatReq.generationConfig?.thinkingConfig?.thinkingBudget).toBe(200)
+  })
+
+  it('should set thinkingBudget to 0 (overriding instance budget) when promptConfig.thinkingTokenBudget is "disable"', () => {
+    const instanceWithThinkingBudget = createTestInstance({
+      thinking: { includeThoughts: true, thinkingTokenBudget: 1234 },
+    })
+    const promptConfig: AxAIPromptConfig = {
+      thinkingTokenBudget: 'disable',
+    }
+    const [, chatReq] = instanceWithThinkingBudget.createChatReq(baseInternalReq, promptConfig)
+    // With the new logic, 'disable' in promptConfig sets thinkingBudget to 0,
+    // overriding the instance-set value of 1234.
+    expect(chatReq.generationConfig?.thinkingConfig?.thinkingBudget).toBe(0)
+    // If 'disable' should always clear it, the implementation of createChatReq would need:
+    // if (config.thinkingTokenBudget === 'disable' && chatReq.generationConfig?.thinkingConfig) {
+    //   delete chatReq.generationConfig.thinkingConfig.thinkingBudget;
+    // }
+    // or ensure thinkingConfig itself is not set if only budget was in it.
+  })
+
+  it('should ensure thinkingConfig is defined if includeThoughts is true, even if budget is disabled', () => {
+    const instance = createTestInstance({
+      thinking: { includeThoughts: true }, // Instance wants thoughts
+    });
+    const promptConfig: AxAIPromptConfig = {
+      thinkingTokenBudget: 'disable', // But disable budget for this call
+    };
+    const [, chatReq] = instance.createChatReq(baseInternalReq, promptConfig);
+
+    // thinkingConfig should exist because of includeThoughts
+    expect(chatReq.generationConfig?.thinkingConfig).toBeDefined();
+    expect(chatReq.generationConfig?.thinkingConfig?.includeThoughts).toBe(true);
+    // thinkingBudget should be 0 due to 'disable'
+    expect(chatReq.generationConfig?.thinkingConfig?.thinkingBudget).toBe(0);
+    // This case is different from the previous one. Here, the instance config for thinkingBudget is *not* set.
+    // So `this.config.thinking.thinkingTokenBudget` doesn't set it.
+    // Then `promptConfig.thinkingTokenBudget === 'disable'` prevents the switch from setting it.
+    // So it correctly remains undefined.
+  })
+
+})

--- a/src/ax/ai/google-gemini/api.ts
+++ b/src/ax/ai/google-gemini/api.ts
@@ -355,9 +355,13 @@ class AxAIGoogleGeminiImpl
       thinkingConfig.thinkingBudget = this.config.thinking.thinkingTokenBudget
     }
 
+    // Then, override based on prompt-specific config
     if (config.thinkingTokenBudget) {
       //The thinkingBudget must be an integer in the range 0 to 24576
       switch (config.thinkingTokenBudget) {
+        case 'disable':
+          thinkingConfig.thinkingBudget = 0; // Explicitly set to 0
+          break;
         case 'minimal':
           thinkingConfig.thinkingBudget = 200
           break

--- a/src/ax/ai/openai/api.test.ts
+++ b/src/ax/ai/openai/api.test.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect } from 'vitest'
+import {
+  AxAIOpenAIImpl,
+  axAIOpenAIDefaultConfig,
+} from './api.js' // Assuming AxAIOpenAIImpl can be imported for testing
+import type {
+  AxAIOpenAIConfig,
+  AxAIOpenAIModel,
+} from './chat_types.js'
+import type {
+  AxInternalChatRequest,
+  AxAIPromptConfig,
+} from '../types.js'
+
+// Helper to create a minimal AxAIOpenAIImpl instance for testing createChatReq
+const createTestInstance = (
+  configOverrides?: Partial<AxAIOpenAIConfig<AxAIOpenAIModel>>
+) => {
+  const fullConfig: AxAIOpenAIConfig<AxAIOpenAIModel> = {
+    ...axAIOpenAIDefaultConfig(),
+    apiKey: 'test-key', // apiKey is often required by the base or impl
+    ...(configOverrides as AxAIOpenAIConfig<AxAIOpenAIModel>),
+  }
+  // The second argument to AxAIOpenAIImpl constructor is streamingUsage (boolean)
+  return new AxAIOpenAIImpl(fullConfig, false)
+}
+
+describe('AxAIOpenAIImpl.createChatReq', () => {
+  const baseInternalReq: AxInternalChatRequest<AxAIOpenAIModel> = {
+    model: 'gpt-4o' as AxAIOpenAIModel, // Example model
+    chatPrompt: [{ role: 'user', content: 'Hello' }],
+    // modelConfig, functions, functionCall can be added if needed by specific tests
+  }
+
+  it('should not set reasoning_effort when thinkingTokenBudget is "disable"', () => {
+    const instance = createTestInstance()
+    const promptConfig: AxAIPromptConfig = {
+      thinkingTokenBudget: 'disable',
+    }
+    const [, chatReq] = instance.createChatReq(baseInternalReq, promptConfig)
+
+    expect(chatReq.reasoning_effort).toBeUndefined()
+  })
+
+  it('should set reasoning_effort to "low" when thinkingTokenBudget is "minimal"', () => {
+    const instance = createTestInstance()
+    const promptConfig: AxAIPromptConfig = {
+      thinkingTokenBudget: 'minimal',
+    }
+    const [, chatReq] = instance.createChatReq(baseInternalReq, promptConfig)
+
+    expect(chatReq.reasoning_effort).toBe('low')
+  })
+
+  it('should set reasoning_effort to "medium" when thinkingTokenBudget is "low"', () => {
+    const instance = createTestInstance()
+    const promptConfig: AxAIPromptConfig = {
+      thinkingTokenBudget: 'low',
+    }
+    const [, chatReq] = instance.createChatReq(baseInternalReq, promptConfig)
+
+    expect(chatReq.reasoning_effort).toBe('medium')
+  })
+
+  it('should set reasoning_effort to "high" when thinkingTokenBudget is "medium"', () => {
+    const instance = createTestInstance()
+    const promptConfig: AxAIPromptConfig = {
+      thinkingTokenBudget: 'medium',
+    }
+    const [, chatReq] = instance.createChatReq(baseInternalReq, promptConfig)
+
+    expect(chatReq.reasoning_effort).toBe('high')
+  })
+
+  it('should set reasoning_effort to "high" when thinkingTokenBudget is "high"', () => {
+    const instance = createTestInstance()
+    const promptConfig: AxAIPromptConfig = {
+      thinkingTokenBudget: 'high',
+    }
+    const [, chatReq] = instance.createChatReq(baseInternalReq, promptConfig)
+
+    expect(chatReq.reasoning_effort).toBe('high')
+  })
+
+  it('should set reasoning_effort to "high" when thinkingTokenBudget is "highest"', () => {
+    const instance = createTestInstance()
+    const promptConfig: AxAIPromptConfig = {
+      thinkingTokenBudget: 'highest',
+    }
+    const [, chatReq] = instance.createChatReq(baseInternalReq, promptConfig)
+
+    expect(chatReq.reasoning_effort).toBe('high')
+  })
+
+  it('should not set reasoning_effort if thinkingTokenBudget is undefined in promptConfig but defined in instance config and is "disable"', () => {
+    // This case is tricky. The current implementation has two places where reasoning_effort can be set:
+    // 1. From this.config.reasoningEffort (instance config)
+    // 2. From promptConfig.thinkingTokenBudget (call-specific config)
+    // The promptConfig seems to take precedence or add to it.
+    // If promptConfig.thinkingTokenBudget is undefined, it falls back to this.config.reasoningEffort.
+    // The original code was:
+    // if (this.config.reasoningEffort) { reqValue.reasoning_effort = this.config.reasoningEffort; }
+    // if (config.thinkingTokenBudget && config.thinkingTokenBudget !== 'disable') { ... }
+    // This means instance config always applies if present, and then promptConfig overwrites if present and not 'disable'.
+    // This test should verify that if promptConfig.thinkingTokenBudget is NOT set,
+    // and this.config.reasoningEffort was somehow set to a value that implies "disable" (which is not directly possible for reasoningEffort),
+    // or if this.config.thinkingTokenBudget (if it existed) was 'disable', it would be ignored.
+    // The current implementation has `this.config.reasoningEffort` not `this.config.thinkingTokenBudget`.
+    // Let's test the scenario where `this.config.reasoningEffort` is set, and `promptConfig.thinkingTokenBudget` is undefined.
+
+    const instanceWithReasoningEffort = createTestInstance({ reasoningEffort: 'auto' }); // some baseline
+    const promptConfig: AxAIPromptConfig = {
+      // thinkingTokenBudget is undefined
+    }
+    const [, chatReq] = instanceWithReasoningEffort.createChatReq(baseInternalReq, promptConfig)
+    // It should use the instance's reasoningEffort
+    expect(chatReq.reasoning_effort).toBe('auto');
+  })
+
+  it('should overwrite instance reasoning_effort if promptConfig.thinkingTokenBudget is "minimal"', () => {
+    const instanceWithReasoningEffort = createTestInstance({ reasoningEffort: 'auto' });
+    const promptConfig: AxAIPromptConfig = {
+      thinkingTokenBudget: 'minimal',
+    }
+    const [, chatReq] = instanceWithReasoningEffort.createChatReq(baseInternalReq, promptConfig)
+    expect(chatReq.reasoning_effort).toBe('low'); // promptConfig overrides instance default
+  })
+
+  it('should clear instance reasoning_effort if promptConfig.thinkingTokenBudget is "disable"', () => {
+    const instanceWithReasoningEffort = createTestInstance({ reasoningEffort: 'auto' });
+    const promptConfig: AxAIPromptConfig = {
+      thinkingTokenBudget: 'disable',
+    }
+    const [, chatReq] = instanceWithReasoningEffort.createChatReq(baseInternalReq, promptConfig)
+    // The logic is:
+    // 1. `reqValue.reasoning_effort = this.config.reasoningEffort;` (if this.config.reasoningEffort exists)
+    // 2. `if (config.thinkingTokenBudget && config.thinkingTokenBudget !== 'disable') { ... }`
+    // If thinkingTokenBudget is 'disable', the second block is skipped.
+    // So, `reasoning_effort` remains what `this.config.reasoningEffort` set it to.
+    // This means "disable" does NOT clear a pre-existing reasoning_effort from instance config.
+    // This seems like a potential bug or unintended interaction based on the subtask description.
+    // The subtask: "If it's "disable", reasoning_effort should not be set in the API request."
+    // This implies it *should* be undefined.
+    // With the new logic, 'disable' will explicitly set it to undefined.
+    expect(chatReq.reasoning_effort).toBeUndefined();
+    // If the requirement is that 'disable' *always* removes it, the implementation of createChatReq needs changing:
+    // e.g., after the two blocks, add:
+    // if (config.thinkingTokenBudget === 'disable') { delete reqValue.reasoning_effort; }
+    // Or, the initial if (this.config.reasoningEffort) block should also check config.thinkingTokenBudget !== 'disable'
+  })
+
+})

--- a/src/ax/ai/openai/api.ts
+++ b/src/ax/ai/openai/api.ts
@@ -254,8 +254,12 @@ class AxAIOpenAIImpl<
       }
     }
 
+    // Then, override based on prompt-specific config
     if (config.thinkingTokenBudget) {
       switch (config.thinkingTokenBudget) {
+        case 'disable':
+          reqValue.reasoning_effort = undefined; // Explicitly set to undefined
+          break;
         case 'minimal':
           reqValue.reasoning_effort = 'low'
           break

--- a/src/ax/dsp/generate.test.ts
+++ b/src/ax/dsp/generate.test.ts
@@ -7,6 +7,7 @@ import type { AxChatResponse } from '../ai/types.js'
 
 import { AxGen } from './generate.js'
 import type { AxSignature } from './sig.js'
+import type { AxProgramForwardOptions } from './program.js'
 
 function createStreamingResponse(
   chunks: AxChatResponse['results']
@@ -118,6 +119,30 @@ describe('AxGen forward and streamingForward', () => {
     expect(response.output).toContain('chunk 1')
     expect(response.output).toContain('chunk 2')
     expect(response.output).toContain('chunk 3')
+  })
+})
+
+describe('AxProgramForwardOptions types', () => {
+  it('should allow "disable" as a value for thinkingTokenBudget', () => {
+    const options: AxProgramForwardOptions = {
+      ai: new AxMockAIService({
+        features: { functions: false, streaming: false },
+      }), // Mock AI service
+      thinkingTokenBudget: 'disable',
+    }
+    // If this compiles, the type test passes implicitly.
+    // We can add a simple assertion to make the test explicit.
+    expect(options.thinkingTokenBudget).toBe('disable')
+  })
+
+  it('should allow other valid values for thinkingTokenBudget', () => {
+    const options: AxProgramForwardOptions = {
+      ai: new AxMockAIService({
+        features: { functions: false, streaming: false },
+      }), // Mock AI service
+      thinkingTokenBudget: 'minimal',
+    }
+    expect(options.thinkingTokenBudget).toBe('minimal')
   })
 })
 

--- a/src/ax/dsp/program.ts
+++ b/src/ax/dsp/program.ts
@@ -47,7 +47,7 @@ export type AxProgramForwardOptions = {
   fastFail?: boolean
   debug?: boolean
   debugHideSystemPrompt?: boolean
-  thinkingTokenBudget?: 'minimal' | 'low' | 'medium' | 'high' | 'highest'
+  thinkingTokenBudget?: 'minimal' | 'low' | 'medium' | 'high' | 'highest' | 'disable'
   traceLabel?: string
 }
 


### PR DESCRIPTION
Adds a "disable" option to `thinkingTokenBudget` in `AxProgramForwardOptions` and ensures this option explicitly overrides any instance-level budget configurations for OpenAI and Google Gemini services.

When `thinkingTokenBudget` is set to "disable":
- For OpenAI, `reasoning_effort` will be set to `undefined`.
- For Google Gemini, `thinkingBudget` in `thinkingConfig` will be set to `0`.

This provides a definitive way to turn off thought/reasoning budget features for a specific AI request, irrespective of the AI service's default instance configuration.

The following modifications were made:

- `AxProgramForwardOptions` in `src/ax/dsp/program.ts` was updated to include "disable" in the `thinkingTokenBudget` type (completed in a previous commit but relevant here).
- Modified `createChatReq` in `src/ax/ai/openai/api.ts`:
    - If `thinkingTokenBudget` is "disable", `reasoning_effort` is explicitly set to `undefined`, overriding any instance-level setting.
    - Unit tests in `src/ax/ai/openai/api.test.ts` were updated to reflect this overriding behavior.
- Modified `createChatReq` in `src/ax/ai/google-gemini/api.ts`:
    - If `thinkingTokenBudget` is "disable", `thinkingBudget` in `thinkingConfig` is explicitly set to `0`, overriding any instance-level setting.
    - Unit tests in `src/ax/ai/google-gemini/api.test.ts` were updated to reflect this overriding behavior.

- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

- **What is the current behavior?** (You can also link to an open issue here)

- **What is the new behavior (if this is a feature change)?**

- **Other information**:
