### PR TITLE
Fix: support for Gemini Flash <= 2.0

### DIFF
--- a/src/ax/ai/google-gemini/api.ts
+++ b/src/ax/ai/google-gemini/api.ts
@@ -392,7 +392,7 @@ class AxAIGoogleGeminiImpl
         req.modelConfig?.stopSequences ?? this.config.stopSequences,
       responseMimeType: 'text/plain',
 
-      ...(thinkingConfig ? { thinkingConfig } : {}),
+      ...(Object.keys(thinkingConfig).length > 0 ? { thinkingConfig } : {}),
     }
 
     const safetySettings = this.config.safetySettings


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix

- **What is the current behavior?** (You can also link to an open issue here)
Commit 8c9c8c4 broke support for Gemini Flash models 2.0 and before:

```
$ npm --env run tsx src/examples/chain-of-thought.ts
...
  [cause]: [AxAIServiceStatusError: HTTP 400 - Bad Request
...
```

- **What is the new behavior (if this is a feature change)?**
Inference fixed:

```
$ npm --env run tsx src/examples/chain-of-thought.ts

Question: What is the capital of France?

Assistant:
Reason: The context mentions that Paris is the capital of France.

Answer: ["Paris"]

{ answer: [ 'Paris' ] }
{
  latency: {
    chat: {
      mean: 583.665417,
      p95: 583.665417,
      p99: 583.665417,
      samples: [Array]
    },
    embed: { mean: 0, p95: 0, p99: 0, samples: [] }
  },
  errors: {
    chat: { count: 0, rate: 0, total: 1 },
    embed: { count: 0, rate: 0, total: 0 }
  }
}
```
- **Other information**:
