### PR TITLE
fix: add null checks for config parameter in AI implementations

### DIFF
--- a/src/ax/ai/google-gemini/api.ts
+++ b/src/ax/ai/google-gemini/api.ts
@@ -356,7 +356,7 @@ class AxAIGoogleGeminiImpl
     }
 
     // Then, override based on prompt-specific config
-    if (config.thinkingTokenBudget) {
+    if (config?.thinkingTokenBudget) {
       //The thinkingBudget must be an integer in the range 0 to 24576
       switch (config.thinkingTokenBudget) {
         case 'none':
@@ -381,9 +381,9 @@ class AxAIGoogleGeminiImpl
       }
     }
 
-    if (config.showThoughts !== undefined) {
+    if (config?.showThoughts !== undefined) {
       // Only override includeThoughts if thinkingTokenBudget is not 'none'
-      if (config.thinkingTokenBudget !== 'none') {
+      if (config?.thinkingTokenBudget !== 'none') {
         thinkingConfig.includeThoughts = config.showThoughts
       }
     }

--- a/src/ax/ai/openai/api.ts
+++ b/src/ax/ai/openai/api.ts
@@ -255,7 +255,7 @@ class AxAIOpenAIImpl<
     }
 
     // Then, override based on prompt-specific config
-    if (config.thinkingTokenBudget) {
+    if (config?.thinkingTokenBudget) {
       switch (config.thinkingTokenBudget) {
         case 'none':
           reqValue.reasoning_effort = undefined // Explicitly set to undefined


### PR DESCRIPTION
**Description**

This PR fixes a TypeError that occurs when the `config` parameter is undefined in the `createChatReq` methods of AI implementations.

**Issue**
The `config` parameter can be undefined when called from certain contexts (e.g., MiPRO optimizer), causing crashes when accessing `config.thinkingTokenBudget` and `config.showThoughts`.

**Solution**
Added optional chaining (`?.`) to safely access these properties in:
- Google Gemini API implementation
- OpenAI API implementation

**Testing**
✅ Verified that MiPRO optimization now works without crashing
✅ Existing functionality remains unchanged when config is properly provided

**Files Changed**
- `src/ax/ai/google-gemini/api.ts`
- `src/ax/ai/openai/api.ts`