### PR TITLE
fix: metric functions should return numbers, not booleans

### DIFF
--- a/src/ax/ai/google-gemini/api.ts
+++ b/src/ax/ai/google-gemini/api.ts
@@ -356,7 +356,7 @@ class AxAIGoogleGeminiImpl
     }
 
     // Then, override based on prompt-specific config
-    if (config.thinkingTokenBudget) {
+    if (config?.thinkingTokenBudget) {
       //The thinkingBudget must be an integer in the range 0 to 24576
       switch (config.thinkingTokenBudget) {
         case 'none':
@@ -381,9 +381,9 @@ class AxAIGoogleGeminiImpl
       }
     }
 
-    if (config.showThoughts !== undefined) {
+    if (config?.showThoughts !== undefined) {
       // Only override includeThoughts if thinkingTokenBudget is not 'none'
-      if (config.thinkingTokenBudget !== 'none') {
+      if (config?.thinkingTokenBudget !== 'none') {
         thinkingConfig.includeThoughts = config.showThoughts
       }
     }

--- a/src/ax/ai/openai/api.ts
+++ b/src/ax/ai/openai/api.ts
@@ -255,7 +255,7 @@ class AxAIOpenAIImpl<
     }
 
     // Then, override based on prompt-specific config
-    if (config.thinkingTokenBudget) {
+    if (config?.thinkingTokenBudget) {
       switch (config.thinkingTokenBudget) {
         case 'none':
           reqValue.reasoning_effort = undefined // Explicitly set to undefined


### PR DESCRIPTION
**Description**

This PR fixes a bug where some metric functions in examples and documentation were returning boolean values instead of numbers, which violates the  type definition.

**Issue**
The  type is defined to return a , but some examples were returning  values:


This causes:
- Incorrect evaluation displays (showing "INCORRECT" for correct predictions)
- Potential issues in optimization algorithms that expect numeric scores

**Files Fixed**
-  - Changed  to return 
-  - Updated documentation example

**Testing**
✅ Examples now correctly return numeric scores
✅ Type definitions are satisfied