### PR TITLE
fix(mistral): remove unsupported params and fix image compatibility

### DIFF
--- a/src/ax/index.ts
+++ b/src/ax/index.ts
@@ -122,6 +122,7 @@ import {
   axAIMistralBestConfig,
   axAIMistralDefaultConfig,
   type AxAIMistralArgs,
+  type AxAIMistralChatRequest,
 } from './ai/mistral/api.js'
 import { AxAIMistralEmbedModels, AxAIMistralModel } from './ai/mistral/types.js'
 import {
@@ -699,6 +700,7 @@ export type { AxAIHuggingFaceResponse }
 export type { AxAIInputModelList }
 export type { AxAIMemory }
 export type { AxAIMistralArgs }
+export type { AxAIMistralChatRequest }
 export type { AxAIModelList }
 export type { AxAIModelListBase }
 export type { AxAIModels }


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix

- **What is the current behavior?** (You can also link to an open issue here)
When using the Mistral provider, the parameters max_completion_token and stream_options are passed but are not supported by the provider’s API, causing potential runtime issues or unexpected behavior. Additionally, the topP parameter may be undefined or not set, leading to inconsistencies in completion quality.

- **What is the new behavior (if this is a feature change)?**
This PR ensures max_completion_token and stream_options are no longer included in the request when using the Mistral provider. It also sets a default value of topP = 1 when not explicitly provided, aligning with typical usage expectations and improving generation stability.

- **Other information**:
This fix improves compatibility with Mistral's current API expectations and avoids silent failures or ignored parameters. It ensures better default behavior for users who do not manually configure topP.
