### PR TITLE
Use correct TLD for Google Vertex "global" region

### DIFF
--- a/.cspell/project-words.txt
+++ b/.cspell/project-words.txt
@@ -1,4 +1,5 @@
 # New Words
+aiplatform
 agentic
 apicall
 APIKEY

--- a/src/ax/ai/google-gemini/api.ts
+++ b/src/ax/ai/google-gemini/api.ts
@@ -630,7 +630,8 @@ export class AxAIGoogleGemini extends AxBaseAI<
         path = 'publishers/google'
       }
 
-      apiURL = `https://${region}-aiplatform.googleapis.com/v1/projects/${projectId}/locations/${region}/${path}`
+      const tld = region === 'global' ? 'aiplatform' : `${region}-aiplatform`
+      apiURL = `https://${tld}.googleapis.com/v1/projects/${projectId}/locations/${region}/${path}`
       if (apiKey) {
         headers = async () => ({ Authorization: `Bearer ${apiKey}` })
       } else {


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix

- **What is the current behavior?** (You can also link to an open issue here)
Currently inference fails with 404 - Not Found for any model in the "global" region.
```
$ npm --env run tsx src/examples/chain-of-thought.ts
    ... snip ....
    responseBody: {
      httpStatus: 404,
      httpStatusText: 'Not Found',
    ... snip ...
```

- **What is the new behavior (if this is a feature change)?**
Inference works for "global" region.
```
$ npm --env run tsx src/examples/chain-of-thought.ts
Assistant:
Reason: The user is asking for the capital of France. I need to find the sentence in the context that explicitly states this information. The first sentence states "Paris is the capital and most populous city of France." The second sentence also mentions "France is a unitary semi-presidential republic with its capital in Paris". Both sentences confirm that Paris is the capital.
Answer: [
  "Paris"
]{ answer: [ 'Paris' ] }
{
  latency: {
    chat: {
      mean: 622.474792,
      p95: 622.474792,
      p99: 622.474792,
      samples: [Array]
    },
    embed: { mean: 0, p95: 0, p99: 0, samples: [] }
  },
  errors: {
    chat: { count: 0, rate: 0, total: 1 },
    embed: { count: 0, rate: 0, total: 0 }
  }
}
```
