### PR TITLE
fix: only count last modelUsage chunk for streaming models

### DIFF
--- a/src/ax/dsp/processResponse.ts
+++ b/src/ax/dsp/processResponse.ts
@@ -53,15 +53,24 @@ export async function* processStreamingResponse<OUT extends AxGenOut>({
     args.functions !== undefined &&
     args.functions.length > 0;
 
+  // Each streamed chunk contains a `modelUsage` object, with accumulated token usage data.
+  // We'll only keep track of the latest modelUsage to push at the end.
+  let lastChunkUsage: AxModelUsage | undefined;
+
   // Handle ReadableStream async iteration for browser compatibility
   const reader = res.getReader();
   try {
     while (true) {
       const { done, value } = await reader.read();
-      if (done) break;
+      if (done) {
+        if (lastChunkUsage) {
+          usage.push(lastChunkUsage);
+        }
+        break;
+      }
       const v = value;
       if (v.modelUsage) {
-        usage.push(v.modelUsage);
+        lastChunkUsage = v.modelUsage;
       }
 
       for (const result of v.results) {


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
BugFix: streaming models used to append one `modelUsage` per chunk streamed instead of per-call. This lead to severly overinflated token usage counts.
- **What is the current behavior?** (You can also link to an open issue here)
Resolves https://github.com/ax-llm/ax/issues/199
- **What is the new behavior (if this is a feature change)?**
Only one modelUsage count per streaming response.
- **Other information**:

How can I test this properly?