### PR TITLE
fix: update typedef to support async version

### DIFF
--- a/src/ax/dsp/optimizer.ts
+++ b/src/ax/dsp/optimizer.ts
@@ -22,7 +22,7 @@ export type AxMetricFnArgs = Parameters<AxMetricFn>[0];
 // Multi-objective metric function for Pareto optimization
 export type AxMultiMetricFn = <T = any>(
   arg0: Readonly<{ prediction: T; example: AxExample }>
-) => Record<string, number>;
+) => Record<string, number> | Promise<Record<string, number>>;
 
 // Progress tracking interface for real-time updates
 export interface AxOptimizationProgress {


### PR DESCRIPTION
# This is a bug fix

Current behavior of the `AxMultiMetricFn` is only non-async while internally it is treated as async functions. This causes the library consumer to encounter type error when using it

Considering that we already use `await` everywhere the metricFn is called, it is safe to update the type definition so no more type error
