### PR TITLE
fix(ai): expose includeRequestBodyInErrors on AxAIServiceOptions

### DIFF
--- a/src/ax/ai/base.test.ts
+++ b/src/ax/ai/base.test.ts
@@ -367,6 +367,68 @@ describe('AxBaseAI', () => {
     expect(mockFetch).toHaveBeenCalledTimes(3);
   });
 
+  describe('includeRequestBodyInErrors option', () => {
+    it('should round-trip through setOptions/getOptions', () => {
+      const ai = createTestAI();
+
+      ai.setOptions({ includeRequestBodyInErrors: false });
+      expect(ai.getOptions()).toMatchObject({
+        includeRequestBodyInErrors: false,
+      });
+
+      ai.setOptions({ includeRequestBodyInErrors: true });
+      expect(ai.getOptions()).toMatchObject({
+        includeRequestBodyInErrors: true,
+      });
+    });
+
+    it('should exclude request body from error string when set to false', async () => {
+      const sensitive = 'sensitive-marker-xyz-123';
+      const nonStreamingImpl = {
+        ...mockImpl,
+        getModelConfig: () => ({
+          maxTokens: 100,
+          temperature: 0,
+          stream: false,
+        }),
+        createChatReq: () => [
+          { name: 'test', headers: {} },
+          { payload: sensitive },
+        ],
+      };
+      const ai = createTestAI(undefined, nonStreamingImpl, {
+        ...baseConfig,
+        supportFor: { functions: true, streaming: false },
+      });
+
+      const errorFetch = vi.fn().mockResolvedValue(
+        new Response(JSON.stringify({ error: 'bad' }), {
+          status: 500,
+          statusText: 'Internal Server Error',
+          headers: { 'content-type': 'application/json' },
+        })
+      );
+
+      ai.setOptions({
+        fetch: errorFetch,
+        includeRequestBodyInErrors: false,
+        // @ts-expect-error - testing
+        retry: { maxRetries: 0 },
+      });
+
+      let caught: unknown;
+      try {
+        await ai.chat({ chatPrompt: [{ role: 'user', content: 'test' }] });
+      } catch (e) {
+        caught = e;
+      }
+
+      expect(caught).toBeDefined();
+      expect(String(caught)).not.toContain(sensitive);
+      expect(String(caught)).not.toContain('Request Body:');
+    });
+  });
+
   describe('function schema cleanup', () => {
     let ai: AxBaseAI<
       string,

--- a/src/ax/ai/base.ts
+++ b/src/ax/ai/base.ts
@@ -370,6 +370,7 @@ export class AxBaseAI<
   private customLabels?: Record<string, string>;
   private contextCache?: AxAIServiceOptions['contextCache'];
   private beta?: AxAIServiceOptions['beta'];
+  private includeRequestBodyInErrors?: AxAIServiceOptions['includeRequestBodyInErrors'];
 
   private modelInfo: readonly AxModelInfo[];
   private modelUsage?: AxModelUsage;
@@ -510,6 +511,7 @@ export class AxBaseAI<
     this.customLabels = options.customLabels;
     this.contextCache = options.contextCache;
     this.beta = options.beta;
+    this.includeRequestBodyInErrors = options.includeRequestBodyInErrors;
   }
 
   getOptions(): Readonly<AxAIServiceOptions> {
@@ -529,6 +531,7 @@ export class AxBaseAI<
       customLabels: this.customLabels,
       contextCache: this.contextCache,
       beta: this.beta,
+      includeRequestBodyInErrors: this.includeRequestBodyInErrors,
     };
   }
 
@@ -1506,6 +1509,9 @@ export class AxBaseAI<
             abortSignal: options?.abortSignal ?? this.abortSignal,
             corsProxy: this.corsProxy,
             retry: options?.retry ?? this.retry,
+            includeRequestBodyInErrors:
+              options?.includeRequestBodyInErrors ??
+              this.includeRequestBodyInErrors,
           },
           reqValue
         );
@@ -1536,6 +1542,9 @@ export class AxBaseAI<
           abortSignal: options?.abortSignal ?? this.abortSignal,
           corsProxy: this.corsProxy,
           retry: options?.retry ?? this.retry,
+          includeRequestBodyInErrors:
+            options?.includeRequestBodyInErrors ??
+            this.includeRequestBodyInErrors,
         },
         reqValue
       );
@@ -1883,6 +1892,9 @@ export class AxBaseAI<
           abortSignal: options?.abortSignal ?? this.abortSignal,
           corsProxy: this.corsProxy,
           retry: options?.retry ?? this.retry,
+          includeRequestBodyInErrors:
+            options?.includeRequestBodyInErrors ??
+            this.includeRequestBodyInErrors,
         },
         reqValue
       );
@@ -2207,6 +2219,9 @@ export class AxBaseAI<
           abortSignal: options?.abortSignal ?? this.abortSignal,
           corsProxy: this.corsProxy,
           retry: options?.retry ?? this.retry,
+          includeRequestBodyInErrors:
+            options?.includeRequestBodyInErrors ??
+            this.includeRequestBodyInErrors,
         },
         op.request
       );

--- a/src/ax/ai/types.ts
+++ b/src/ax/ai/types.ts
@@ -924,6 +924,17 @@ export type AxAIServiceOptions = {
    * @example { environment: 'production', feature: 'search' }
    */
   customLabels?: Record<string, string>;
+
+  /**
+   * Whether to include the request body in `AxAIServiceError` messages.
+   *
+   * When `false`, the request body is omitted from thrown errors. Useful when
+   * requests may contain sensitive data (API keys, PII) or large base64-encoded
+   * content that would bloat error logs.
+   *
+   * @default true
+   */
+  includeRequestBodyInErrors?: boolean;
 };
 
 export interface AxAIService<


### PR DESCRIPTION
## Problem

`AxAIServiceError` already accepts an `includeRequestBodyInErrors` flag and `AxAPIConfig` exposes it on every `apiCall()`, but there was no way to set it from `AxAI` (the service-level options). Consumers who want to suppress request bodies from error output — e.g. when payloads contain API keys, PII, or large base64-encoded content — had no path to do so via `AxAIServiceOptions`.

Closes #492 (follow-up to #475).

## Solution

- Add `includeRequestBodyInErrors?: boolean` to `AxAIServiceOptions`.
- Store it on `AxBaseAI` and forward it to every `apiCall()` site (cached chat path, standard chat, embed, context-cache operations). Per-call options override the service-level value, matching the existing pattern for `retry` and `abortSignal`.
- Default behaviour is unchanged: the flag is `undefined` until set, and `apicall.ts` continues to default to `true`.

## Testing

- New `setOptions`/`getOptions` round-trip test asserts the flag is read back exactly as set.
- New behaviour test triggers a 500 response and asserts the request-body marker is absent from the thrown error's string when `includeRequestBodyInErrors: false` is configured.
- `npx vitest run ai/base.test.ts util/apicall.test.ts` — all passing.
- `npx tsc --noEmit` and `npx biome check` on changed files — clean.