### PR TITLE
fix(aisdk): request non-streaming response in doGenerate (#470)

### DIFF
--- a/src/aisdk/index.test.ts
+++ b/src/aisdk/index.test.ts
@@ -1,6 +1,6 @@
-import { describe, expect, it, vi } from 'vitest';
-import type { AxAIService, AxChatResponse } from '@ax-llm/ax/index.js';
 import type { LanguageModelV2CallOptions } from '@ai-sdk/provider';
+import type { AxAIService, AxChatResponse } from '@ax-llm/ax/index.js';
+import { describe, expect, it, vi } from 'vitest';
 
 import { AxAIProvider } from './index.js';
 
@@ -145,6 +145,26 @@ describe('AxAIProvider', () => {
         input: '{"location":"New York"}',
       });
       expect(result.finishReason).toBe('tool-calls');
+    });
+
+    it('should request a non-streaming response from the AI service', async () => {
+      const mockResponse: AxChatResponse = {
+        results: [{ content: 'ok', finishReason: 'stop' }],
+      };
+
+      const mockAI = createMockAIService([mockResponse]);
+      const provider = new AxAIProvider(mockAI);
+
+      const options: LanguageModelV2CallOptions = {
+        prompt: [{ role: 'user', content: [{ type: 'text', text: 'Hi' }] }],
+      };
+
+      await provider.doGenerate(options);
+
+      expect(mockAI.chat).toHaveBeenCalledWith(
+        expect.any(Object),
+        expect.objectContaining({ stream: false })
+      );
     });
 
     it('should handle string function params correctly', async () => {
@@ -330,7 +350,8 @@ describe('AxAIProvider', () => {
               result: 'Sunny, 22°C',
             },
           ]),
-        })
+        }),
+        expect.objectContaining({ stream: false })
       );
     });
   });

--- a/src/aisdk/provider.ts
+++ b/src/aisdk/provider.ts
@@ -8,19 +8,19 @@ import {
 import type {
   LanguageModelV2,
   LanguageModelV2CallOptions,
+  LanguageModelV2CallWarning,
+  LanguageModelV2Content,
   LanguageModelV2FinishReason,
   LanguageModelV2FunctionTool,
-  LanguageModelV2ToolCall,
   LanguageModelV2Prompt,
   LanguageModelV2StreamPart,
-  LanguageModelV2Usage,
-  LanguageModelV2Content,
+  LanguageModelV2ToolCall,
   LanguageModelV2ToolChoice,
-  LanguageModelV2CallWarning,
+  LanguageModelV2Usage,
 } from '@ai-sdk/provider';
 import type {
-  AxAIService,
   AxAgentic,
+  AxAIService,
   AxChatRequest,
   AxChatResponse,
   AxChatResponseResult,
@@ -149,7 +149,7 @@ export class AxAIProvider implements LanguageModelV2 {
     options: LanguageModelV2CallOptions
   ): Promise<Awaited<ReturnType<LanguageModelV2['doGenerate']>>> {
     const req = createChatRequest(options);
-    const res = (await this.ai.chat(req)) as AxChatResponse;
+    const res = (await this.ai.chat(req, { stream: false })) as AxChatResponse;
     const choice = res.results.at(0);
 
     if (!choice) {


### PR DESCRIPTION
## Problem

When using the `@ax-llm/ax-ai-sdk-provider` with `generateText` (or any non-streaming Vercel AI SDK entrypoint), the call crashes with:

```
TypeError: Cannot read properties of undefined (reading 'at')
    at AxAIProvider.doGenerate (provider.ts:153:32)
```

`AxAIProvider.doGenerate` was calling `this.ai.chat(req)` without the second `options` argument. `AxBaseAI.chat` defaults `stream` to `true` when no value is supplied, so the call returned a `ReadableStream<AxChatResponse>` cast as `AxChatResponse`. Accessing `res.results.at(0)` on the stream therefore threw — see the original report in #470.

## Solution

Explicitly pass `{ stream: false }` from `doGenerate` so the underlying service always returns a single `AxChatResponse`, matching the cast already used a line below. `doStream` continues to pass `{ stream: true }` and is unchanged.

## Testing

- `npx vitest run src/aisdk/index.test.ts` — 8/8 pass.
- New test asserts that `doGenerate` forwards `stream: false` to `ai.chat`.
- Existing `prompt conversion` test updated to expect the new second argument.

Closes #470.