### PR TITLE
fix(ai): record streaming token usage as deltas, not cumulative

### DIFF
--- a/src/ax/ai/base.test.ts
+++ b/src/ax/ai/base.test.ts
@@ -9,6 +9,7 @@ import {
   setChatRequestEvents,
   setChatResponseEvents,
 } from './base.js'; // Import new functions
+import { resetAIMetricsInstruments } from './metrics.js';
 import type {
   AxAIServiceImpl,
   AxAIServiceOptions,
@@ -270,6 +271,185 @@ describe('AxBaseAI', () => {
     expect(metrics.latency.chat.samples).toHaveLength(1);
     expect(metrics.errors.chat.count).toBe(0);
   }, 10000);
+
+  describe('streaming token usage diffing', () => {
+    type CounterTracker = {
+      sums: Record<string, number>;
+      meter: AxAIServiceOptions['meter'];
+    };
+
+    // Builds a fake OTel meter that records every `counter.add(value)` into a
+    // sums map, keyed by counter name. Only counters listed in `tracked` are
+    // accumulated; the rest are no-ops. Returns both the sums and the meter
+    // for assertions.
+    const makeMetricsTestHarness = (tracked: readonly string[]): CounterTracker => {
+      const sums: Record<string, number> = Object.fromEntries(
+        tracked.map((name) => [name, 0])
+      );
+      const makeCounter = (name: string) => ({
+        add: vi.fn((value: number) => {
+          if (name in sums) sums[name] += value;
+        }),
+      });
+      const noop = () => ({ add: vi.fn(), record: vi.fn() });
+      const meter = {
+        createCounter: vi.fn((name: string) =>
+          name in sums ? makeCounter(name) : noop()
+        ),
+        createHistogram: vi.fn(noop),
+        createGauge: vi.fn(noop),
+        createUpDownCounter: vi.fn(noop),
+        createObservableCounter: vi.fn(),
+        createObservableGauge: vi.fn(),
+        createObservableUpDownCounter: vi.fn(),
+        addBatchObservableCallback: vi.fn(),
+        removeBatchObservableCallback: vi.fn(),
+      } as unknown as AxAIServiceOptions['meter'];
+      return { sums, meter };
+    };
+
+    const fiveChunkSSE = () => {
+      const body = [1, 2, 3, 4, 5]
+        .map((i) => `data: {"chunk":${i}}\n\n`)
+        .join('');
+      return vi.fn().mockResolvedValue(
+        new Response(new TextEncoder().encode(body), {
+          status: 200,
+          headers: { 'Content-Type': 'text/event-stream' },
+        })
+      );
+    };
+
+    const drain = async (response: unknown) => {
+      expect(response).toBeInstanceOf(ReadableStream);
+      if (response instanceof ReadableStream) {
+        const reader = response.getReader();
+        // Only consumed to drive the pipeline — assertions are on counters.
+        while (!(await reader.read()).done) {}
+      }
+    };
+
+    // Build a minimal streaming AxAIServiceImpl. `onDelta` runs once per
+    // streamed event (5 total, one per SSE chunk in fiveChunkSSE) and
+    // returns the usage to surface from getTokenUsage(); returning
+    // undefined leaves usage absent for that delta.
+    const makeStreamingImpl = (
+      onDelta: (deltaIdx: number) => AxTokenUsage | undefined,
+      reqName = 'test'
+    ): AxAIServiceImpl<
+      string,
+      string,
+      unknown,
+      unknown,
+      unknown,
+      unknown,
+      unknown
+    > => {
+      let deltaIdx = 0;
+      let usage: AxTokenUsage | undefined;
+      return {
+        createChatReq: () => [{ name: reqName, headers: {} }, {}],
+        createChatResp: () => ({ results: [] }),
+        createChatStreamResp: () => {
+          deltaIdx += 1;
+          const next = onDelta(deltaIdx);
+          if (next) usage = next;
+          return { results: [{ index: 0, content: 'x' }] };
+        },
+        getModelConfig: () => ({ maxTokens: 100, temperature: 0, stream: true }),
+        getTokenUsage: () => usage,
+      };
+    };
+
+    beforeEach(() => resetAIMetricsInstruments());
+    afterEach(() => resetAIMetricsInstruments());
+
+    it('deduplicates cumulative streaming token usage into deltas', async () => {
+      const { sums, meter } = makeMetricsTestHarness([
+        'ax_llm_input_tokens_total',
+        'ax_llm_output_tokens_total',
+      ]);
+
+      // Each delta reports a running total, not an increment — the failure mode.
+      const impl = makeStreamingImpl((i) => ({
+        promptTokens: 100,
+        completionTokens: i * 5,
+        totalTokens: 100 + i * 5,
+      }));
+
+      const ai = new AxBaseAI(impl, baseConfig);
+      ai.setOptions({ fetch: fiveChunkSSE(), meter });
+      await drain(
+        await ai.chat({ chatPrompt: [{ role: 'user', content: 'test' }] })
+      );
+
+      // Final cumulative after 5 deltas: 100 prompt, 25 completion. Pre-fix the
+      // counters would have summed to 5x these values.
+      expect(sums.ax_llm_input_tokens_total).toBe(100);
+      expect(sums.ax_llm_output_tokens_total).toBe(25);
+    }, 10000);
+
+    it('records cumulative streaming usage when usage is reported on a single event', async () => {
+      const { sums, meter } = makeMetricsTestHarness([
+        'ax_llm_input_tokens_total',
+        'ax_llm_output_tokens_total',
+      ]);
+
+      // Only the last delta carries usage.
+      const impl = makeStreamingImpl((i) =>
+        i === 5
+          ? { promptTokens: 80, completionTokens: 42, totalTokens: 122 }
+          : undefined
+      );
+
+      const ai = new AxBaseAI(impl, baseConfig);
+      ai.setOptions({ fetch: fiveChunkSSE(), meter });
+      await drain(
+        await ai.chat({ chatPrompt: [{ role: 'user', content: 'test' }] })
+      );
+
+      expect(sums.ax_llm_input_tokens_total).toBe(80);
+      expect(sums.ax_llm_output_tokens_total).toBe(42);
+    }, 10000);
+
+    it('prices long-context cost from cumulative usage, not per-delta increments', async () => {
+      const { sums, meter } = makeMetricsTestHarness([
+        'ax_llm_estimated_cost_total',
+      ]);
+
+      // Anthropic-shape: large prompt set at first event, completion grows.
+      const impl = makeStreamingImpl(
+        (i) => ({
+          promptTokens: 250_000,
+          completionTokens: i * 100,
+          totalTokens: 250_000 + i * 100,
+        }),
+        'test-long'
+      );
+
+      const modelInfo: AxModelInfo[] = [
+        {
+          name: 'test-model',
+          promptTokenCostPer1M: 3,
+          completionTokenCostPer1M: 15,
+          longContextThreshold: 200_000,
+          longContextPromptTokenCostPer1M: 6,
+          longContextCompletionTokenCostPer1M: 22.5,
+        },
+      ];
+
+      const ai = new AxBaseAI(impl, { ...baseConfig, modelInfo });
+      ai.setOptions({ fetch: fiveChunkSSE(), meter });
+      await drain(
+        await ai.chat({ chatPrompt: [{ role: 'user', content: 'test' }] })
+      );
+
+      // 250k prompt @ $6/1M + 500 completion @ $22.5/1M.
+      const expectedCost =
+        (250_000 * 6) / 1_000_000 + (500 * 22.5) / 1_000_000;
+      expect(sums.ax_llm_estimated_cost_total).toBeCloseTo(expectedCost, 6);
+    }, 10000);
+  });
 
   it('should handle errors in metrics', async () => {
     // Create an implementation that throws an error

--- a/src/ax/ai/base.ts
+++ b/src/ax/ai/base.ts
@@ -55,6 +55,7 @@ import type {
   AxModelConfig,
   AxModelInfo,
   AxModelUsage,
+  AxTokenUsage,
 } from './types.js';
 import { axValidateChatRequestMessage } from './validate.js';
 
@@ -351,6 +352,46 @@ export const axBaseAIDefaultCreativeConfig = (): AxModelConfig =>
     temperature: 0.4,
     frequencyPenalty: 0.2,
   });
+
+/**
+ * Returns a stateful diff over cumulative {@link AxTokenUsage} readings.
+ * Some providers (e.g. Anthropic) report a running cumulative on every
+ * streaming event, but the underlying OTel token counters are additive —
+ * recording the cumulative per-event would multiply the true cost by the
+ * event count. State is per call so concurrent streams don't share it.
+ *
+ * Every numeric field on `tokens` is treated as cumulative; non-numeric
+ * fields (e.g. serviceTier) are dropped from the delta — they don't make
+ * sense to repeat on every event and downstream OTel recording doesn't
+ * read them. Returns `undefined` when no field increased.
+ *
+ * This assumes all streaming providers report cumulative-or-once-at-end
+ * usage (true for Anthropic, OpenAI, Gemini today).
+ */
+const makeDiffTokenUsage = (): ((
+  cumulative: Readonly<AxTokenUsage>
+) => Partial<AxTokenUsage> | undefined) => {
+  const recorded: Record<string, number> = {};
+  return (tokens) => {
+    const delta: Partial<Record<keyof AxTokenUsage, unknown>> = {};
+    let anyIncrement = false;
+    for (const [key, cur] of Object.entries(tokens) as [
+      keyof AxTokenUsage,
+      AxTokenUsage[keyof AxTokenUsage],
+    ][]) {
+      if (typeof cur !== 'number') continue;
+      const prev = recorded[key] ?? 0;
+      // Clamp to handle the unlikely case of a provider reporting a decrease.
+      const inc = Math.max(0, cur - prev);
+      if (cur > prev) recorded[key] = cur;
+      if (inc > 0) {
+        delta[key] = inc;
+        anyIncrement = true;
+      }
+    }
+    return anyIncrement ? (delta as Partial<AxTokenUsage>) : undefined;
+  };
+};
 
 export class AxBaseAI<
   TModel,
@@ -727,107 +768,106 @@ export class AxBaseAI<
     }
   }
 
-  // Method to record token usage metrics
+  private recordEstimatedCost(
+    operationType: 'chat' | 'embed',
+    costUSD: number,
+    model: string,
+    customLabels?: Record<string, string>
+  ): void {
+    if (costUSD <= 0) return;
+    const metricsInstruments = this.getMetricsInstruments();
+    if (!metricsInstruments) return;
+    recordEstimatedCostMetric(
+      metricsInstruments,
+      operationType,
+      costUSD,
+      this.name,
+      model,
+      customLabels
+    );
+  }
+
   private recordTokenUsage(
-    modelUsage?: AxModelUsage,
-    optionsCustomLabels?: Record<string, string>,
-    operationType?: 'chat' | 'embed'
+    model: string,
+    tokens?: Partial<AxTokenUsage>,
+    optionsCustomLabels?: Record<string, string>
   ): void {
     const metricsInstruments = this.getMetricsInstruments();
-    if (metricsInstruments && modelUsage?.tokens) {
-      const {
+    if (!metricsInstruments || !tokens) return;
+    const {
+      promptTokens,
+      completionTokens,
+      totalTokens,
+      thoughtsTokens,
+      cacheReadTokens,
+      cacheCreationTokens,
+    } = tokens;
+    const customLabels = this.getMergedCustomLabels(optionsCustomLabels);
+
+    if (promptTokens) {
+      recordTokenMetric(
+        metricsInstruments,
+        'input',
         promptTokens,
+        this.name,
+        model,
+        customLabels
+      );
+    }
+
+    if (completionTokens) {
+      recordTokenMetric(
+        metricsInstruments,
+        'output',
         completionTokens,
+        this.name,
+        model,
+        customLabels
+      );
+    }
+
+    if (totalTokens) {
+      recordTokenMetric(
+        metricsInstruments,
+        'total',
         totalTokens,
+        this.name,
+        model,
+        customLabels
+      );
+    }
+
+    if (thoughtsTokens) {
+      recordTokenMetric(
+        metricsInstruments,
+        'thoughts',
         thoughtsTokens,
+        this.name,
+        model,
+        customLabels
+      );
+    }
+
+    if (cacheReadTokens) {
+      recordCacheTokenMetric(
+        metricsInstruments,
+        'read',
         cacheReadTokens,
+        this.name,
+        model,
+        customLabels
+      );
+    }
+
+    if (cacheCreationTokens) {
+      recordCacheTokenMetric(
+        metricsInstruments,
+        'write',
         cacheCreationTokens,
-      } = modelUsage.tokens;
-      const customLabels = this.getMergedCustomLabels(optionsCustomLabels);
-
-      if (promptTokens) {
-        recordTokenMetric(
-          metricsInstruments,
-          'input',
-          promptTokens,
-          this.name,
-          modelUsage.model,
-          customLabels
-        );
-      }
-
-      if (completionTokens) {
-        recordTokenMetric(
-          metricsInstruments,
-          'output',
-          completionTokens,
-          this.name,
-          modelUsage.model,
-          customLabels
-        );
-      }
-
-      if (totalTokens) {
-        recordTokenMetric(
-          metricsInstruments,
-          'total',
-          totalTokens,
-          this.name,
-          modelUsage.model,
-          customLabels
-        );
-      }
-
-      if (thoughtsTokens) {
-        recordTokenMetric(
-          metricsInstruments,
-          'thoughts',
-          thoughtsTokens,
-          this.name,
-          modelUsage.model,
-          customLabels
-        );
-      }
-
-      if (cacheReadTokens) {
-        recordCacheTokenMetric(
-          metricsInstruments,
-          'read',
-          cacheReadTokens,
-          this.name,
-          modelUsage.model,
-          customLabels
-        );
-      }
-
-      if (cacheCreationTokens) {
-        recordCacheTokenMetric(
-          metricsInstruments,
-          'write',
-          cacheCreationTokens,
-          this.name,
-          modelUsage.model,
-          customLabels
-        );
-      }
-
-      // Record estimated cost alongside token usage
-      if (operationType) {
-        const estimatedCost = this.estimateCostByName(
-          modelUsage.model,
-          modelUsage
-        );
-        if (estimatedCost > 0) {
-          recordEstimatedCostMetric(
-            metricsInstruments,
-            operationType,
-            estimatedCost,
-            this.name,
-            modelUsage.model,
-            customLabels
-          );
-        }
-      }
+        this.name,
+        model,
+        customLabels
+      );
     }
   }
 
@@ -1570,6 +1610,9 @@ export class AxBaseAI<
       }
 
       const respFn = this.aiImpl.createChatStreamResp.bind(this);
+      const diffTokenUsage = makeDiffTokenUsage();
+      let recordedCost = 0;
+
       const wrappedRespFn =
         (state: object) => (resp: Readonly<TChatResponseDelta>) => {
           const res = respFn(resp, state);
@@ -1587,7 +1630,30 @@ export class AxBaseAI<
             }
           }
           this.modelUsage = res.modelUsage;
-          this.recordTokenUsage(res.modelUsage, options?.customLabels, 'chat');
+          if (res.modelUsage?.tokens) {
+            const deltaTokens = diffTokenUsage(res.modelUsage.tokens);
+            if (deltaTokens) {
+              this.recordTokenUsage(
+                res.modelUsage.model,
+                deltaTokens,
+                options?.customLabels
+              );
+              // Compute cumulative cost so long-context pricing tiers are accounted for,
+              // then diff it to get an accurate delta.
+              const curCost = this.estimateCostByName(
+                res.modelUsage.model,
+                res.modelUsage
+              );
+              const costDelta = Math.max(0, curCost - recordedCost);
+              if (curCost > recordedCost) recordedCost = curCost;
+              this.recordEstimatedCost(
+                'chat',
+                costDelta,
+                res.modelUsage.model,
+                options?.customLabels
+              );
+            }
+          }
 
           if (span?.isRecording()) {
             setChatResponseEvents(res, span, this.excludeContentFromTrace);
@@ -1721,7 +1787,17 @@ export class AxBaseAI<
 
     if (res.modelUsage) {
       this.modelUsage = res.modelUsage;
-      this.recordTokenUsage(res.modelUsage, options?.customLabels, 'chat');
+      this.recordTokenUsage(
+        res.modelUsage.model,
+        res.modelUsage.tokens,
+        options?.customLabels
+      );
+      this.recordEstimatedCost(
+        'chat',
+        this.estimateCostByName(res.modelUsage.model, res.modelUsage),
+        res.modelUsage.model,
+        options?.customLabels
+      );
     }
 
     if (span?.isRecording()) {
@@ -1931,7 +2007,19 @@ export class AxBaseAI<
       }
     }
     this.embedModelUsage = res.modelUsage;
-    this.recordTokenUsage(res.modelUsage, options?.customLabels, 'embed');
+    if (res.modelUsage) {
+      this.recordTokenUsage(
+        res.modelUsage.model,
+        res.modelUsage.tokens,
+        options?.customLabels
+      );
+      this.recordEstimatedCost(
+        'embed',
+        this.estimateCostByName(res.modelUsage.model, res.modelUsage),
+        res.modelUsage.model,
+        options?.customLabels
+      );
+    }
 
     if (span?.isRecording() && res.modelUsage?.tokens) {
       span.addEvent(axSpanEvents.GEN_AI_USAGE, {


### PR DESCRIPTION
## Summary

- Streaming providers like Anthropic emit running cumulative token usage on every event. The OTel token/cost counters in `recordTokenUsage` are additive, so we were multiplying true usage by the number of streamed events.
- This PR introduces a per-call diff for streaming token usage and splits cost recording so it can be driven separately.
- Cost is computed on cumulative usage *then* diffed, so long-context pricing tiers cross correctly mid-stream.

## Details

- `makeDiffTokenUsage()` in `src/ax/ai/base.ts` returns a stateful closure that diffs cumulative `AxTokenUsage` readings. State is per-call to avoid cross-stream contamination, and decreases are clamped to zero.
- `recordTokenUsage` no longer takes `operationType` and no longer records cost — that's now `recordEstimatedCost`, called by the three call sites (stream, non-stream chat, embed) so the stream can diff cost independently.

## Test plan

- [x] Three new tests in `base.test.ts`:
  - cumulative usage on every event is recorded as deltas
  - usage reported only on the final event still records correctly
  - long-context pricing tier is applied to cumulative usage, not to per-delta increments
- [x] `npx vitest run src/ax/ai/base.test.ts` — all 50 tests pass.