### PR TITLE
fix(anthropic): emit cache_control on content blocks, not envelopes

### DIFF
--- a/src/ax/ai/anthropic/api.test.ts
+++ b/src/ax/ai/anthropic/api.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { AxAIAnthropic } from './api.js';
 import { AxAIAnthropicModel } from './types.js';
@@ -443,5 +443,300 @@ describe('AxAIAnthropic thinking configuration', () => {
     const body = capture.lastBody;
     expect(body.thinking).toEqual({ type: 'adaptive' });
     expect(body.output_config).toEqual({ effort: 'max' });
+  });
+});
+
+describe('AxAIAnthropic user message caching', () => {
+  let ai: AxAIAnthropic;
+  let capture: { lastBody?: any };
+  let fetch: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    ai = new AxAIAnthropic({
+      apiKey: 'key',
+      config: { model: AxAIAnthropicModel.Claude35Sonnet },
+    });
+    ({ capture, fetch } = createCaptureFetch('claude-3-5-sonnet-latest'));
+    ai.setOptions({ fetch });
+  });
+
+  it('string content + cache: true serializes to a single text block with block-level cache_control', async () => {
+    await ai.chat(
+      { chatPrompt: [{ role: 'user', content: 'hi', cache: true }] },
+      { stream: false }
+    );
+
+    expect(fetch).toHaveBeenCalled();
+    const body = capture.lastBody;
+    expect(body.messages[0].role).toBe('user');
+    expect(Array.isArray(body.messages[0].content)).toBe(true);
+    expect(body.messages[0].content).toHaveLength(1);
+    expect(body.messages[0].content[0]).toEqual({
+      type: 'text',
+      text: 'hi',
+      cache_control: { type: 'ephemeral' },
+    });
+    // Regression guard: cache_control must NOT sit on the message envelope.
+    expect(body.messages[0].cache_control).toBeUndefined();
+  });
+
+  it('string content without cache flag is preserved as a plain string', async () => {
+    await ai.chat(
+      { chatPrompt: [{ role: 'user', content: 'hi' }] },
+      { stream: false }
+    );
+
+    expect(fetch).toHaveBeenCalled();
+    const body = capture.lastBody;
+    expect(body.messages[0].content).toBe('hi');
+    expect(body.messages[0].cache_control).toBeUndefined();
+  });
+
+  it('array content + message-level cache attaches cache_control to the last block', async () => {
+    await ai.chat(
+      {
+        chatPrompt: [
+          {
+            role: 'user',
+            content: [
+              { type: 'text', text: 'a' },
+              { type: 'text', text: 'b' },
+            ],
+            cache: true,
+          },
+        ],
+      },
+      { stream: false }
+    );
+
+    expect(fetch).toHaveBeenCalled();
+    const body = capture.lastBody;
+    expect(body.messages[0].content[0].cache_control).toBeUndefined();
+    expect(body.messages[0].content[1].cache_control).toEqual({
+      type: 'ephemeral',
+    });
+    expect(body.messages[0].cache_control).toBeUndefined();
+  });
+
+  it('array content with per-block cache continues to honor block-level flag', async () => {
+    await ai.chat(
+      {
+        chatPrompt: [
+          {
+            role: 'user',
+            content: [
+              { type: 'text', text: 'a', cache: true },
+              { type: 'text', text: 'b' },
+            ],
+          },
+        ],
+      },
+      { stream: false }
+    );
+
+    expect(fetch).toHaveBeenCalled();
+    const body = capture.lastBody;
+    expect(body.messages[0].content[0].cache_control).toEqual({
+      type: 'ephemeral',
+    });
+    expect(body.messages[0].content[1].cache_control).toBeUndefined();
+  });
+
+  it('array content without any cache flag leaks no cache_control anywhere', async () => {
+    await ai.chat(
+      {
+        chatPrompt: [
+          {
+            role: 'user',
+            content: [
+              { type: 'text', text: 'a' },
+              { type: 'text', text: 'b' },
+            ],
+          },
+        ],
+      },
+      { stream: false }
+    );
+
+    expect(fetch).toHaveBeenCalled();
+    const body = capture.lastBody;
+    expect(body.messages[0].cache_control).toBeUndefined();
+    expect(body.messages[0].content[0].cache_control).toBeUndefined();
+    expect(body.messages[0].content[1].cache_control).toBeUndefined();
+  });
+
+  it('message-level cache on array content whose tail is an image attaches cache_control to that image block', async () => {
+    await ai.chat(
+      {
+        chatPrompt: [
+          {
+            role: 'user',
+            content: [
+              { type: 'text', text: 'describe' },
+              {
+                type: 'image',
+                mimeType: 'image/png',
+                image: 'aGVsbG8=',
+              },
+            ],
+            cache: true,
+          },
+        ],
+      },
+      { stream: false }
+    );
+
+    expect(fetch).toHaveBeenCalled();
+    const body = capture.lastBody;
+    expect(body.messages[0].content[0].cache_control).toBeUndefined();
+    expect(body.messages[0].content[1].type).toBe('image');
+    expect(body.messages[0].content[1].cache_control).toEqual({
+      type: 'ephemeral',
+    });
+    expect(body.messages[0].cache_control).toBeUndefined();
+  });
+});
+
+describe('AxAIAnthropic assistant message caching', () => {
+  let ai: AxAIAnthropic;
+  let capture: { lastBody?: any };
+  let fetch: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    ai = new AxAIAnthropic({
+      apiKey: 'key',
+      config: { model: AxAIAnthropicModel.Claude35Sonnet },
+    });
+    ({ capture, fetch } = createCaptureFetch('claude-3-5-sonnet-latest'));
+    ai.setOptions({ fetch });
+  });
+
+  it('string content + cache: true normalizes to a single text block with cache_control', async () => {
+    await ai.chat(
+      {
+        chatPrompt: [
+          { role: 'user', content: 'hi' },
+          { role: 'assistant', content: 'cached reply', cache: true },
+          { role: 'user', content: 'continue' },
+        ],
+      },
+      { stream: false }
+    );
+
+    expect(fetch).toHaveBeenCalled();
+    const body = capture.lastBody;
+    expect(body.messages[1].role).toBe('assistant');
+    expect(Array.isArray(body.messages[1].content)).toBe(true);
+    expect(body.messages[1].content[0]).toEqual({
+      type: 'text',
+      text: 'cached reply',
+      cache_control: { type: 'ephemeral' },
+    });
+    expect(body.messages[1].cache_control).toBeUndefined();
+  });
+
+  it('functionCalls + message-level cache marks each tool_use block (block-level, not envelope)', async () => {
+    await ai.chat(
+      {
+        chatPrompt: [
+          { role: 'user', content: 'hi' },
+          {
+            role: 'assistant',
+            content: '',
+            functionCalls: [
+              {
+                id: 'call_1',
+                type: 'function',
+                function: { name: 'lookup', params: '{"q":"x"}' },
+              },
+              {
+                id: 'call_2',
+                type: 'function',
+                function: { name: 'lookup', params: '{"q":"y"}' },
+              },
+            ],
+            cache: true,
+          },
+          {
+            role: 'function',
+            functionId: 'call_1',
+            result: 'r1',
+          },
+          {
+            role: 'function',
+            functionId: 'call_2',
+            result: 'r2',
+          },
+        ],
+      },
+      { stream: false }
+    );
+
+    expect(fetch).toHaveBeenCalled();
+    const body = capture.lastBody;
+    expect(body.messages[1].role).toBe('assistant');
+    expect(body.messages[1].cache_control).toBeUndefined();
+    expect(body.messages[1].content[0].type).toBe('tool_use');
+    expect(body.messages[1].content[0].cache_control).toEqual({
+      type: 'ephemeral',
+    });
+    expect(body.messages[1].content[1].cache_control).toEqual({
+      type: 'ephemeral',
+    });
+  });
+});
+
+describe('AxAIAnthropic function (tool_result) caching', () => {
+  let ai: AxAIAnthropic;
+  let capture: { lastBody?: any };
+  let fetch: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    ai = new AxAIAnthropic({
+      apiKey: 'key',
+      config: { model: AxAIAnthropicModel.Claude35Sonnet },
+    });
+    ({ capture, fetch } = createCaptureFetch('claude-3-5-sonnet-latest'));
+    ai.setOptions({ fetch });
+  });
+
+  it('function role + cache: true emits cache_control on the tool_result block (not a stray `cache` key, not the envelope)', async () => {
+    await ai.chat(
+      {
+        chatPrompt: [
+          { role: 'user', content: 'hi' },
+          {
+            role: 'assistant',
+            content: '',
+            functionCalls: [
+              {
+                id: 'call_1',
+                type: 'function',
+                function: { name: 'lookup', params: '{}' },
+              },
+            ],
+          },
+          {
+            role: 'function',
+            functionId: 'call_1',
+            result: 'result body',
+            cache: true,
+          },
+        ],
+      },
+      { stream: false }
+    );
+
+    expect(fetch).toHaveBeenCalled();
+    const body = capture.lastBody;
+    const toolResultMsg = body.messages[2];
+    expect(toolResultMsg.role).toBe('user');
+    expect(toolResultMsg.cache_control).toBeUndefined();
+    const block = toolResultMsg.content[0];
+    expect(block.type).toBe('tool_result');
+    expect(block.tool_use_id).toBe('call_1');
+    expect(block.cache_control).toEqual({ type: 'ephemeral' });
+    // Regression guard for the previous typo: must not be a `cache` field.
+    expect(block.cache).toBeUndefined();
   });
 });

--- a/src/ax/ai/anthropic/api.ts
+++ b/src/ax/ai/anthropic/api.ts
@@ -1098,7 +1098,9 @@ function createMessages(
             content: msg.result,
             tool_use_id: msg.functionId,
             ...(msg.isError ? { is_error: true } : {}),
-            ...(msg.cache ? { cache: { type: 'ephemeral' } } : {}),
+            ...(msg.cache
+              ? { cache_control: { type: 'ephemeral' as const } }
+              : {}),
           },
         ];
 
@@ -1111,10 +1113,15 @@ function createMessages(
         if (typeof msg.content === 'string') {
           return {
             role: 'user' as const,
-            content: msg.content,
-            ...(msg.cache
-              ? { cache_control: { type: 'ephemeral' as const } }
-              : {}),
+            content: msg.cache
+              ? [
+                  {
+                    type: 'text' as const,
+                    text: msg.content,
+                    cache_control: { type: 'ephemeral' as const },
+                  },
+                ]
+              : msg.content,
           };
         }
         const content = msg.content.map((v) => {
@@ -1143,6 +1150,19 @@ function createMessages(
               throw new Error('Invalid content type');
           }
         });
+        if (msg.cache && content.length > 0) {
+          const lastIdx = content.length - 1;
+          const lastBlock = content[lastIdx];
+          if (
+            lastBlock &&
+            (lastBlock.type === 'text' || lastBlock.type === 'image')
+          ) {
+            content[lastIdx] = {
+              ...lastBlock,
+              cache_control: { type: 'ephemeral' as const },
+            };
+          }
+        }
         return {
           role: 'user' as const,
           content,

--- a/src/ax/ai/anthropic/types.ts
+++ b/src/ax/ai/anthropic/types.ts
@@ -131,7 +131,7 @@ export type AxAIAnthropicChatRequest = {
                   type: 'image';
                   source: { type: 'base64'; media_type: string; data: string };
                 } & AxAIAnthropicChatRequestCacheParam)
-              | {
+              | ({
                   type: 'tool_result';
                   is_error?: boolean;
                   tool_use_id: string;
@@ -151,7 +151,7 @@ export type AxAIAnthropicChatRequest = {
                             };
                           } & AxAIAnthropicChatRequestCacheParam)
                       )[];
-                }
+                } & AxAIAnthropicChatRequestCacheParam)
             )[];
       }
     | {


### PR DESCRIPTION
## Summary

Three shapes the Anthropic provider currently emits when callers set `cache: true` are rejected outright by the Messages API with `HTTP 400 — Extra inputs are not permitted`. This makes any `cache: true` on a string-content user message, an array-content user message (in some configurations), or a function-role message hard-fail the entire chat call rather than silently miss the cache.

The three issues:

1. **String-content user message with `cache: true`** — was attaching `cache_control` to the user message envelope. The API only accepts `cache_control` on content blocks, not on the message itself.
2. **Array-content user message with message-level `cache: true`** — had no path to propagate the flag onto a block, so the cache intent was dropped. Now mirrors the existing assistant-side behavior of promoting the marker onto the tail text/image block.
3. **Function-role message with `cache: true`** — was emitting a stray `cache: { type: 'ephemeral' }` field on the `tool_result` block. Wrong key name, and not part of the request schema.

All three were verified end-to-end against the live Anthropic Messages API:
- Each old shape returns `HTTP 400` from the API.
- Each new shape produces `cache_creation_input_tokens` on the first call and `cache_read_input_tokens` on a repeat call — i.e., caching actually works.

The request type for the `tool_result` block is extended to include `cache_control`, which is supported by the API.

## Test plan

- [x] `npx vitest run src/ax/ai/anthropic/api.test.ts` (20/20 passing, including regression tests for each shape above)
- [x] `tsc --noEmit` clean
- [x] Live-API verification confirming each old shape errors and each new shape produces real cache writes/reads

🤖 Generated with [Claude Code](https://claude.com/claude-code)