### PR TITLE
Structured outputs for Ollama

### DIFF
--- a/src/ax/ai/ollama/api.ts
+++ b/src/ax/ai/ollama/api.ts
@@ -7,8 +7,7 @@ import type {
   AxAIOpenAIChatRequest,
   AxAIOpenAIConfig,
 } from '../openai/chat_types.js';
-import type { AxChatResponse } from '../types.js';
-import type { AxAIServiceOptions } from '../types.js';
+import type { AxAIServiceOptions, AxChatResponse } from '../types.js';
 
 /**
  * Extracts <think>...</think> content from a full (non-streaming) response.
@@ -80,6 +79,7 @@ export type AxAIOllamaAIConfig = AxAIOpenAIConfig<string, string>;
 
 type AxAIOllamaChatRequest = AxAIOpenAIChatRequest<string> & {
   think?: boolean;
+  format?: object | string;
 };
 
 /**
@@ -155,14 +155,29 @@ export class AxAIOllama<TModelKey> extends AxAIOpenAIBase<
       req: Readonly<AxAIOllamaChatRequest>,
       serviceOptions: Readonly<AxAIServiceOptions>
     ): AxAIOllamaChatRequest => {
-      if (!serviceOptions.thinkingTokenBudget) {
-        return req;
+      const updated = { ...req };
+
+      // Convert OpenAI-style response_format to Ollama's native format parameter
+      // for constrained decoding / structured outputs.
+      if (updated.response_format) {
+        const rf = updated.response_format as
+          | { type: string }
+          | { type: 'json_schema'; json_schema: any };
+        if ('json_schema' in rf && rf.type === 'json_schema') {
+          // Extract the raw JSON Schema from OpenAI's wrapper
+          updated.format = rf.json_schema?.schema ?? rf.json_schema;
+        } else if (rf.type === 'json_object') {
+          updated.format = 'json';
+        }
+        delete updated.response_format;
       }
 
-      return {
-        ...req,
-        think: serviceOptions.thinkingTokenBudget !== 'none',
-      };
+      // Handle thinking budget
+      if (serviceOptions.thinkingTokenBudget) {
+        updated.think = serviceOptions.thinkingTokenBudget !== 'none';
+      }
+
+      return updated;
     };
 
     const chatRespProcessor = (resp: AxChatResponse): AxChatResponse => ({
@@ -205,6 +220,7 @@ export class AxAIOllama<TModelKey> extends AxAIOpenAIBase<
       supportFor: {
         functions: true,
         streaming: true,
+        structuredOutputs: true,
         hasThinkingBudget: true,
         hasShowThoughts: true,
         media: {

--- a/src/ax/ai/ollama/api.ts
+++ b/src/ax/ai/ollama/api.ts
@@ -79,7 +79,6 @@ export type AxAIOllamaAIConfig = AxAIOpenAIConfig<string, string>;
 
 type AxAIOllamaChatRequest = AxAIOpenAIChatRequest<string> & {
   think?: boolean;
-  format?: object | string;
 };
 
 /**
@@ -157,20 +156,10 @@ export class AxAIOllama<TModelKey> extends AxAIOpenAIBase<
     ): AxAIOllamaChatRequest => {
       const updated = { ...req };
 
-      // Convert OpenAI-style response_format to Ollama's native format parameter
-      // for constrained decoding / structured outputs.
-      if (updated.response_format) {
-        const rf = updated.response_format as
-          | { type: string }
-          | { type: 'json_schema'; json_schema: any };
-        if ('json_schema' in rf && rf.type === 'json_schema') {
-          // Extract the raw JSON Schema from OpenAI's wrapper
-          updated.format = rf.json_schema?.schema ?? rf.json_schema;
-        } else if (rf.type === 'json_object') {
-          updated.format = 'json';
-        }
-        delete updated.response_format;
-      }
+      // Note: response_format is NOT converted here. The Ollama adapter uses
+      // the OpenAI-compatible /v1/chat/completions endpoint, which handles
+      // response_format natively (same as OpenAI's API). The `format` field
+      // is only used by Ollama's native /api/chat endpoint.
 
       // Handle thinking budget
       if (serviceOptions.thinkingTokenBudget) {


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- This is a feature. OpenAI, Gemini and several other LLM APIs support structured outputs (ex: json schema) using constrained decoding. ax supports structured outputs via zod schema specification and this is passed along to LLM APIs via the individual adapters. However, the Ollama adapter is not support this. Several models deployed via ollama support structured outputs and ollama API also supports structured outputs. Hving this feature would be helpful to developers working with ax and ollama backend.

- **What is the current behavior?** (You can also link to an open issue here)
- ax ollama adapter does not support structured outputs

- **What is the new behavior (if this is a feature change)?**
- ax ollama adapter accepts json_schema from the generator and sends the response_format flag to the ollama api

- **Other information**:
