### PR TITLE
feat: support image URLs (fileUri) in image input fields

### DIFF
--- a/src/ax/ai/anthropic/api.ts
+++ b/src/ax/ai/anthropic/api.ts
@@ -1183,11 +1183,17 @@ function createMessages(
             case 'image':
               return {
                 type: 'image' as const,
-                source: {
-                  type: 'base64' as const,
-                  media_type: v.mimeType,
-                  data: v.image,
-                },
+                source:
+                  'fileUri' in v
+                    ? {
+                        type: 'url' as const,
+                        url: v.fileUri,
+                      }
+                    : {
+                        type: 'base64' as const,
+                        media_type: v.mimeType,
+                        data: v.image,
+                      },
                 ...(v.cache
                   ? { cache_control: { type: 'ephemeral' as const } }
                   : {}),

--- a/src/ax/ai/anthropic/types.ts
+++ b/src/ax/ai/anthropic/types.ts
@@ -130,7 +130,9 @@ export type AxAIAnthropicChatRequest = {
                 } & AxAIAnthropicChatRequestCacheParam)
               | ({
                   type: 'image';
-                  source: { type: 'base64'; media_type: string; data: string };
+                  source:
+                    | { type: 'base64'; media_type: string; data: string }
+                    | { type: 'url'; url: string };
                 } & AxAIAnthropicChatRequestCacheParam)
               | ({
                   type: 'tool_result';

--- a/src/ax/ai/base.ts
+++ b/src/ax/ai/base.ts
@@ -338,7 +338,11 @@ function hashContentPart(
   if (part.type === 'text') {
     hasher.update(`text:${part.text}`);
   } else if (part.type === 'image') {
-    hasher.update(`image:${part.mimeType}:${part.image.slice(0, 100)}`);
+    if ('fileUri' in part) {
+      hasher.update(`image:${part.mimeType}:${part.fileUri}`);
+    } else {
+      hasher.update(`image:${part.mimeType}:${part.image.slice(0, 100)}`);
+    }
   } else if (part.type === 'audio') {
     hasher.update(`audio:${part.format}:${part.data.slice(0, 100)}`);
   } else if (part.type === 'file') {

--- a/src/ax/ai/google-gemini/api.test.ts
+++ b/src/ax/ai/google-gemini/api.test.ts
@@ -2174,3 +2174,87 @@ describe('AxAIGoogleGemini Live audio chat', () => {
     }
   });
 });
+
+describe('AxAIGoogleGemini image content mapping', () => {
+  it('maps inline base64 images to inlineData', async () => {
+    const ai = new AxAIGoogleGemini({
+      apiKey: 'key',
+      config: { model: AxAIGoogleGeminiModel.Gemini25Flash },
+      models: [],
+    });
+
+    const capture: { lastBody?: any } = {};
+    ai.setOptions({
+      fetch: createMockFetch(
+        {
+          candidates: [
+            { content: { parts: [{ text: 'ok' }] }, finishReason: 'STOP' },
+          ],
+        },
+        capture
+      ),
+    });
+
+    await ai.chat(
+      {
+        chatPrompt: [
+          {
+            role: 'user',
+            content: [
+              { type: 'image', mimeType: 'image/png', image: 'base64data' },
+            ],
+          },
+        ],
+      },
+      { stream: false }
+    );
+
+    const parts = capture.lastBody?.contents?.[0]?.parts;
+    expect(parts).toContainEqual({
+      inlineData: { mimeType: 'image/png', data: 'base64data' },
+    });
+  });
+
+  it('maps fileUri images to fileData', async () => {
+    const ai = new AxAIGoogleGemini({
+      apiKey: 'key',
+      config: { model: AxAIGoogleGeminiModel.Gemini25Flash },
+      models: [],
+    });
+
+    const capture: { lastBody?: any } = {};
+    ai.setOptions({
+      fetch: createMockFetch(
+        {
+          candidates: [
+            { content: { parts: [{ text: 'ok' }] }, finishReason: 'STOP' },
+          ],
+        },
+        capture
+      ),
+    });
+
+    await ai.chat(
+      {
+        chatPrompt: [
+          {
+            role: 'user',
+            content: [
+              {
+                type: 'image',
+                mimeType: 'image/png',
+                fileUri: 'gs://my-bucket/cat.png',
+              },
+            ],
+          },
+        ],
+      },
+      { stream: false }
+    );
+
+    const parts = capture.lastBody?.contents?.[0]?.parts;
+    expect(parts).toContainEqual({
+      fileData: { mimeType: 'image/png', fileUri: 'gs://my-bucket/cat.png' },
+    });
+  });
+});

--- a/src/ax/ai/google-gemini/api.ts
+++ b/src/ax/ai/google-gemini/api.ts
@@ -255,6 +255,24 @@ export interface AxAIGoogleGeminiArgs<TModelKey> {
   modelInfo?: AxModelInfo[];
 }
 
+// Maps an image/file content part to a Gemini part: fileUri -> fileData,
+// otherwise inline base64 -> inlineData. Image base64 lives on `image`,
+// file base64 on `data`.
+const toGeminiMediaPart = (
+  c:
+    | { mimeType: string; image: string }
+    | { mimeType: string; data: string }
+    | { mimeType: string; fileUri: string }
+) =>
+  'fileUri' in c
+    ? { fileData: { mimeType: c.mimeType, fileUri: c.fileUri } }
+    : {
+        inlineData: {
+          mimeType: c.mimeType,
+          data: 'image' in c ? c.image : c.data,
+        },
+      };
+
 class AxAIGoogleGeminiImpl
   implements
     AxAIServiceImpl<
@@ -772,19 +790,8 @@ class AxAIGoogleGeminiImpl
                   case 'text':
                     return { text: c.text };
                   case 'image':
-                    // Support both inline data and fileUri formats
-                    if ('fileUri' in c) {
-                      return {
-                        fileData: {
-                          mimeType: c.mimeType,
-                          fileUri: c.fileUri,
-                        },
-                      };
-                    } else {
-                      return {
-                        inlineData: { mimeType: c.mimeType, data: c.image },
-                      };
-                    }
+                  case 'file':
+                    return toGeminiMediaPart(c);
                   case 'audio':
                     return {
                       inlineData: {
@@ -793,20 +800,6 @@ class AxAIGoogleGeminiImpl
                         data: c.data,
                       },
                     };
-                  case 'file':
-                    // Support both inline data and fileUri formats
-                    if ('fileUri' in c) {
-                      return {
-                        fileData: {
-                          mimeType: c.mimeType,
-                          fileUri: c.fileUri,
-                        },
-                      };
-                    } else {
-                      return {
-                        inlineData: { mimeType: c.mimeType, data: c.data },
-                      };
-                    }
                   default:
                     throw new Error(
                       `Chat prompt content type not supported (index: ${idx})`
@@ -1847,15 +1840,8 @@ class AxAIGoogleGeminiImpl
                   parts.push({ text: c.text });
                   break;
                 case 'image':
-                  if ('fileUri' in c) {
-                    parts.push({
-                      fileData: { mimeType: c.mimeType, fileUri: c.fileUri },
-                    });
-                  } else {
-                    parts.push({
-                      inlineData: { mimeType: c.mimeType, data: c.image },
-                    });
-                  }
+                case 'file':
+                  parts.push(toGeminiMediaPart(c));
                   break;
                 case 'audio':
                   parts.push({
@@ -1865,17 +1851,6 @@ class AxAIGoogleGeminiImpl
                       data: c.data,
                     },
                   });
-                  break;
-                case 'file':
-                  if ('fileUri' in c) {
-                    parts.push({
-                      fileData: { mimeType: c.mimeType, fileUri: c.fileUri },
-                    });
-                  } else {
-                    parts.push({
-                      inlineData: { mimeType: c.mimeType, data: c.data },
-                    });
-                  }
                   break;
               }
             }
@@ -2012,15 +1987,8 @@ class AxAIGoogleGeminiImpl
                 parts.push({ text: c.text });
                 break;
               case 'image':
-                if ('fileUri' in c) {
-                  parts.push({
-                    fileData: { mimeType: c.mimeType, fileUri: c.fileUri },
-                  });
-                } else {
-                  parts.push({
-                    inlineData: { mimeType: c.mimeType, data: c.image },
-                  });
-                }
+              case 'file':
+                parts.push(toGeminiMediaPart(c));
                 break;
               case 'audio':
                 parts.push({
@@ -2030,17 +1998,6 @@ class AxAIGoogleGeminiImpl
                     data: c.data,
                   },
                 });
-                break;
-              case 'file':
-                if ('fileUri' in c) {
-                  parts.push({
-                    fileData: { mimeType: c.mimeType, fileUri: c.fileUri },
-                  });
-                } else {
-                  parts.push({
-                    inlineData: { mimeType: c.mimeType, data: c.data },
-                  });
-                }
                 break;
             }
           }

--- a/src/ax/ai/google-gemini/api.ts
+++ b/src/ax/ai/google-gemini/api.ts
@@ -772,9 +772,19 @@ class AxAIGoogleGeminiImpl
                   case 'text':
                     return { text: c.text };
                   case 'image':
-                    return {
-                      inlineData: { mimeType: c.mimeType, data: c.image },
-                    };
+                    // Support both inline data and fileUri formats
+                    if ('fileUri' in c) {
+                      return {
+                        fileData: {
+                          mimeType: c.mimeType,
+                          fileUri: c.fileUri,
+                        },
+                      };
+                    } else {
+                      return {
+                        inlineData: { mimeType: c.mimeType, data: c.image },
+                      };
+                    }
                   case 'audio':
                     return {
                       inlineData: {
@@ -1837,9 +1847,15 @@ class AxAIGoogleGeminiImpl
                   parts.push({ text: c.text });
                   break;
                 case 'image':
-                  parts.push({
-                    inlineData: { mimeType: c.mimeType, data: c.image },
-                  });
+                  if ('fileUri' in c) {
+                    parts.push({
+                      fileData: { mimeType: c.mimeType, fileUri: c.fileUri },
+                    });
+                  } else {
+                    parts.push({
+                      inlineData: { mimeType: c.mimeType, data: c.image },
+                    });
+                  }
                   break;
                 case 'audio':
                   parts.push({
@@ -1996,9 +2012,15 @@ class AxAIGoogleGeminiImpl
                 parts.push({ text: c.text });
                 break;
               case 'image':
-                parts.push({
-                  inlineData: { mimeType: c.mimeType, data: c.image },
-                });
+                if ('fileUri' in c) {
+                  parts.push({
+                    fileData: { mimeType: c.mimeType, fileUri: c.fileUri },
+                  });
+                } else {
+                  parts.push({
+                    inlineData: { mimeType: c.mimeType, data: c.image },
+                  });
+                }
                 break;
               case 'audio':
                 parts.push({

--- a/src/ax/ai/openai/api.ts
+++ b/src/ax/ai/openai/api.ts
@@ -683,7 +683,10 @@ function createMessages<TModel>(
                 case 'text':
                   return { type: 'text' as const, text: c.text };
                 case 'image': {
-                  const url = `data:${c.mimeType};base64,${c.image}`;
+                  const url =
+                    'fileUri' in c
+                      ? c.fileUri
+                      : `data:${c.mimeType};base64,${c.image}`;
                   return {
                     type: 'image_url' as const,
                     image_url: { url, details: c.details ?? 'auto' },

--- a/src/ax/ai/processor.ts
+++ b/src/ax/ai/processor.ts
@@ -117,7 +117,7 @@ export async function axProcessContentForProvider(
           } else if (item.altText) {
             // Fallback to alt text
             processedContent.push({ type: 'text', text: item.altText });
-          } else if (options.imageToText) {
+          } else if (options.imageToText && 'image' in item) {
             // Use AI vision service to describe image
             try {
               const description = await options.imageToText(item.image);

--- a/src/ax/ai/types.ts
+++ b/src/ax/ai/types.ts
@@ -400,9 +400,23 @@ export type AxChatRequest<TModel = string> = {
                   cache?: boolean;
                 }
               | {
+                  /** Image content type with inline base64 data */
                   type: 'image';
                   mimeType: string;
                   image: string;
+                  details?: 'high' | 'low' | 'auto';
+                  cache?: boolean;
+                  /** Optimization preference for image processing */
+                  optimize?: 'quality' | 'size' | 'auto';
+                  /** Fallback text description when images aren't supported */
+                  altText?: string;
+                }
+              | {
+                  /** Image content type with a URI (e.g. https:// or gs:// URL) */
+                  type: 'image';
+                  /** Image URI (e.g., https:// or gs:// URL) */
+                  fileUri: string;
+                  mimeType: string;
                   details?: 'high' | 'low' | 'auto';
                   cache?: boolean;
                   /** Optimization preference for image processing */

--- a/src/ax/ai/validate.ts
+++ b/src/ax/ai/validate.ts
@@ -136,15 +136,23 @@ export function axValidateChatRequestMessage(item: AxChatRequestMessage): void {
                 'image' in contentItem && typeof contentItem.image === 'string'
                   ? contentItem.image
                   : undefined;
+              const fileUri =
+                'fileUri' in contentItem &&
+                typeof contentItem.fileUri === 'string'
+                  ? contentItem.fileUri
+                  : undefined;
               const mimeType =
                 'mimeType' in contentItem &&
                 typeof contentItem.mimeType === 'string'
                   ? contentItem.mimeType
                   : undefined;
 
-              if (!image || image.trim() === '') {
+              if (
+                (!image || image.trim() === '') &&
+                (!fileUri || fileUri.trim() === '')
+              ) {
                 throw new Error(
-                  `User message image content at index ${index} cannot be empty, received: ${value(image)}`
+                  `User message image content at index ${index} must have either data or fileUri, received: ${value(image ?? fileUri)}`
                 );
               }
               if (!mimeType || mimeType.trim() === '') {

--- a/src/ax/dsp/loggers.ts
+++ b/src/ax/dsp/loggers.ts
@@ -40,7 +40,8 @@ const formatChatMessage = (
           return colorize(item.text, 'green');
         }
         if (item.type === 'image') {
-          const content = hideContent ? '[Image]' : `[Image: ${item.image}]`;
+          const source = 'fileUri' in item ? item.fileUri : item.image;
+          const content = hideContent ? '[Image]' : `[Image: ${source}]`;
           return colorize(content, 'green');
         }
         if (item.type === 'audio') {

--- a/src/ax/dsp/prompt.test.ts
+++ b/src/ax/dsp/prompt.test.ts
@@ -686,6 +686,157 @@ describe('AxPromptTemplate.render', () => {
     });
   });
 
+  describe('Image field handling', () => {
+    it('should render image field with data (base64)', () => {
+      const sig = new AxSignature('imageInput:image -> responseText:string');
+      const pt = new AxPromptTemplate(sig);
+
+      const result = pt.render(
+        {
+          imageInput: {
+            mimeType: 'image/png',
+            data: 'base64data',
+          },
+        },
+        {}
+      );
+
+      expect(result).toHaveLength(2); // system + user message
+
+      const userMessage = result.find((m) => m.role === 'user');
+      expect(userMessage).toBeDefined();
+      expect(userMessage!.content).toHaveLength(2);
+      expect(userMessage!.content[0]).toEqual({
+        type: 'text',
+        text: 'Image Input: \n',
+      });
+      expect(userMessage!.content[1]).toEqual({
+        type: 'image',
+        mimeType: 'image/png',
+        image: 'base64data',
+      });
+    });
+
+    it('should render image field with fileUri (URL)', () => {
+      const sig = new AxSignature('imageInput:image -> responseText:string');
+      const pt = new AxPromptTemplate(sig);
+
+      const result = pt.render(
+        {
+          imageInput: {
+            mimeType: 'image/png',
+            fileUri: 'https://example.com/cat.png',
+          },
+        },
+        {}
+      );
+
+      expect(result).toHaveLength(2); // system + user message
+
+      const userMessage = result.find((m) => m.role === 'user');
+      expect(userMessage).toBeDefined();
+      expect(userMessage!.content).toHaveLength(2);
+      expect(userMessage!.content[0]).toEqual({
+        type: 'text',
+        text: 'Image Input: \n',
+      });
+      expect(userMessage!.content[1]).toEqual({
+        type: 'image',
+        mimeType: 'image/png',
+        fileUri: 'https://example.com/cat.png',
+      });
+    });
+
+    it('should render array of images with mixed formats', () => {
+      const sig = new AxSignature('imageInputs:image[] -> responseText:string');
+      const pt = new AxPromptTemplate(sig);
+
+      const result = pt.render(
+        {
+          imageInputs: [
+            {
+              mimeType: 'image/png',
+              data: 'base64data1',
+            },
+            {
+              mimeType: 'image/jpeg',
+              fileUri: 'https://example.com/dog.jpg',
+            },
+          ],
+        },
+        {}
+      );
+
+      expect(result).toHaveLength(2); // system + user message
+
+      const userMessage = result.find((m) => m.role === 'user');
+      expect(userMessage).toBeDefined();
+      expect(userMessage!.content).toHaveLength(3);
+
+      expect(userMessage!.content[0]).toEqual({
+        type: 'text',
+        text: 'Image Inputs: \n',
+      });
+
+      // First image with data
+      expect(userMessage!.content[1]).toEqual({
+        type: 'image',
+        mimeType: 'image/png',
+        image: 'base64data1',
+      });
+
+      // Second image with fileUri
+      expect(userMessage!.content[2]).toEqual({
+        type: 'image',
+        mimeType: 'image/jpeg',
+        fileUri: 'https://example.com/dog.jpg',
+      });
+    });
+
+    it('should validate image field requirements', () => {
+      const sig = new AxSignature('imageInput:image -> responseText:string');
+      const pt = new AxPromptTemplate(sig);
+
+      // Missing mimeType
+      expect(() =>
+        pt.render(
+          {
+            imageInput: {
+              data: 'base64data',
+            },
+          },
+          {}
+        )
+      ).toThrow(/mimeType.*data.*fileUri/);
+
+      // Missing both data and fileUri
+      expect(() =>
+        pt.render(
+          {
+            imageInput: {
+              mimeType: 'image/png',
+            },
+          },
+          {}
+        )
+      ).toThrow(/mimeType.*data.*fileUri/);
+
+      // Both data and fileUri present
+      expect(() =>
+        pt.render(
+          {
+            imageInput: {
+              mimeType: 'image/png',
+              data: 'base64data',
+              fileUri: 'https://example.com/cat.png',
+            },
+          },
+          {}
+        )
+      ).toThrow(/mimeType.*data.*fileUri/);
+    });
+  });
+
   describe('Examples as alternating message pairs (new default behavior)', () => {
     it('should render multiple examples as alternating user/assistant pairs', () => {
       const signature = new AxSignature(

--- a/src/ax/dsp/prompt.ts
+++ b/src/ax/dsp/prompt.ts
@@ -1157,7 +1157,9 @@ export class AxPromptTemplate {
     if (field.type?.name === 'image') {
       const validateImage = (
         value: Readonly<AxFieldValue>
-      ): { mimeType: string; data: string } => {
+      ):
+        | { mimeType: string; data: string }
+        | { mimeType: string; fileUri: string } => {
         if (!value) {
           throw new Error('Image field value is required.');
         }
@@ -1168,10 +1170,21 @@ export class AxPromptTemplate {
         if (!('mimeType' in value)) {
           throw new Error('Image field must have mimeType');
         }
-        if (!('data' in value)) {
-          throw new Error('Image field must have data');
+
+        // Support both data and fileUri formats
+        const hasData = 'data' in value;
+        const hasFileUri = 'fileUri' in value;
+
+        if (!hasData && !hasFileUri) {
+          throw new Error('Image field must have either data or fileUri');
         }
-        return value as { mimeType: string; data: string };
+        if (hasData && hasFileUri) {
+          throw new Error('Image field cannot have both data and fileUri');
+        }
+
+        return value as
+          | { mimeType: string; data: string }
+          | { mimeType: string; fileUri: string };
       };
 
       let result: ChatRequestUserMessage = [
@@ -1186,20 +1199,34 @@ export class AxPromptTemplate {
           (value as unknown[]).map((v) => {
             // Cast to unknown[] before map
             const validated = validateImage(v as AxFieldValue);
-            return {
-              type: 'image',
-              mimeType: validated.mimeType,
-              image: validated.data,
-            };
+            return 'fileUri' in validated
+              ? {
+                  type: 'image',
+                  mimeType: validated.mimeType,
+                  fileUri: validated.fileUri,
+                }
+              : {
+                  type: 'image',
+                  mimeType: validated.mimeType,
+                  image: validated.data,
+                };
           })
         );
       } else {
         const validated = validateImage(value);
-        result.push({
-          type: 'image',
-          mimeType: validated.mimeType,
-          image: validated.data,
-        });
+        result.push(
+          'fileUri' in validated
+            ? {
+                type: 'image',
+                mimeType: validated.mimeType,
+                fileUri: validated.fileUri,
+              }
+            : {
+                type: 'image',
+                mimeType: validated.mimeType,
+                image: validated.data,
+              }
+        );
       }
       return result;
     }

--- a/src/ax/dsp/prompt.ts
+++ b/src/ax/dsp/prompt.ts
@@ -1187,6 +1187,21 @@ export class AxPromptTemplate {
           | { mimeType: string; fileUri: string };
       };
 
+      const toImagePart = (value: Readonly<AxFieldValue>) => {
+        const validated = validateImage(value);
+        return 'fileUri' in validated
+          ? {
+              type: 'image' as const,
+              mimeType: validated.mimeType,
+              fileUri: validated.fileUri,
+            }
+          : {
+              type: 'image' as const,
+              mimeType: validated.mimeType,
+              image: validated.data,
+            };
+      };
+
       let result: ChatRequestUserMessage = [
         { type: 'text', text: `${field.title}: ` as string },
       ];
@@ -1196,37 +1211,10 @@ export class AxPromptTemplate {
           throw new Error('Image field value must be an array.');
         }
         result = result.concat(
-          (value as unknown[]).map((v) => {
-            // Cast to unknown[] before map
-            const validated = validateImage(v as AxFieldValue);
-            return 'fileUri' in validated
-              ? {
-                  type: 'image',
-                  mimeType: validated.mimeType,
-                  fileUri: validated.fileUri,
-                }
-              : {
-                  type: 'image',
-                  mimeType: validated.mimeType,
-                  image: validated.data,
-                };
-          })
+          (value as unknown[]).map((v) => toImagePart(v as AxFieldValue))
         );
       } else {
-        const validated = validateImage(value);
-        result.push(
-          'fileUri' in validated
-            ? {
-                type: 'image',
-                mimeType: validated.mimeType,
-                fileUri: validated.fileUri,
-              }
-            : {
-                type: 'image',
-                mimeType: validated.mimeType,
-                image: validated.data,
-              }
-        );
+        result.push(toImagePart(value));
       }
       return result;
     }

--- a/src/ax/dsp/types.ts
+++ b/src/ax/dsp/types.ts
@@ -105,7 +105,11 @@ export type AxFieldValue =
   | null
   | undefined
   | { mimeType: string; data: string }
-  | { mimeType: string; data: string }[]
+  | { mimeType: string; fileUri: string }
+  | (
+      | { mimeType: string; data: string }
+      | { mimeType: string; fileUri: string }
+    )[]
   | {
       format?: string;
       data?: string;

--- a/src/ax/dsp/util.ts
+++ b/src/ax/dsp/util.ts
@@ -49,43 +49,21 @@ export const validateValue = (
     }
   };
 
-  const validImage = (val: Readonly<AxFieldValue>): boolean => {
+  // image and file share the same shape: mimeType + exactly one of data | fileUri
+  const validMediaContent = (val: Readonly<AxFieldValue>): boolean => {
     if (!val || typeof val !== 'object' || !('mimeType' in val)) {
       return false;
     }
-
-    // Support both data and fileUri formats
-    const hasData = 'data' in val;
-    const hasFileUri = 'fileUri' in val;
-
-    if (!hasData && !hasFileUri) {
-      return false;
-    }
-    if (hasData && hasFileUri) {
-      return false; // Cannot have both
-    }
-
-    return true;
+    return 'data' in val !== 'fileUri' in val;
   };
 
-  if (field.type?.name === 'image') {
-    let msg: string | undefined;
-    if (Array.isArray(value)) {
-      for (const item of value) {
-        if (!validImage(item)) {
-          msg =
-            'object ({ mimeType: string; data: string } | { mimeType: string; fileUri: string })';
-          break;
-        }
-      }
-    } else if (!validImage(value)) {
-      msg =
-        'object ({ mimeType: string; data: string } | { mimeType: string; fileUri: string })';
-    }
-
-    if (msg) {
+  if (field.type?.name === 'image' || field.type?.name === 'file') {
+    const mediaMsg =
+      'object ({ mimeType: string; data: string } | { mimeType: string; fileUri: string })';
+    const items = Array.isArray(value) ? value : [value];
+    if (items.some((item) => !validMediaContent(item))) {
       throw new Error(
-        `Validation failed: Expected '${field.name}' to be type '${msg}' instead got '${value}'`
+        `Validation failed: Expected '${field.name}' to be type '${mediaMsg}' instead got '${value}'`
       );
     }
     return;
@@ -116,48 +94,6 @@ export const validateValue = (
       }
     } else if (!validAudio(value)) {
       msg = 'string or object ({ data: string; format?: string })';
-    }
-
-    if (msg) {
-      throw new Error(
-        `Validation failed: Expected '${field.name}' to be type '${msg}' instead got '${value}'`
-      );
-    }
-    return;
-  }
-
-  const validFile = (val: Readonly<AxFieldValue>): boolean => {
-    if (!val || typeof val !== 'object' || !('mimeType' in val)) {
-      return false;
-    }
-
-    // Support both data and fileUri formats
-    const hasData = 'data' in val;
-    const hasFileUri = 'fileUri' in val;
-
-    if (!hasData && !hasFileUri) {
-      return false;
-    }
-    if (hasData && hasFileUri) {
-      return false; // Cannot have both
-    }
-
-    return true;
-  };
-
-  if (field.type?.name === 'file') {
-    let msg: string | undefined;
-    if (Array.isArray(value)) {
-      for (const item of value) {
-        if (!validFile(item)) {
-          msg =
-            'object ({ mimeType: string; data: string } | { mimeType: string; fileUri: string })';
-          break;
-        }
-      }
-    } else if (!validFile(value)) {
-      msg =
-        'object ({ mimeType: string; data: string } | { mimeType: string; fileUri: string })';
     }
 
     if (msg) {

--- a/src/ax/dsp/util.ts
+++ b/src/ax/dsp/util.ts
@@ -50,14 +50,21 @@ export const validateValue = (
   };
 
   const validImage = (val: Readonly<AxFieldValue>): boolean => {
-    if (
-      !val ||
-      typeof val !== 'object' ||
-      !('mimeType' in val) ||
-      !('data' in val)
-    ) {
+    if (!val || typeof val !== 'object' || !('mimeType' in val)) {
       return false;
     }
+
+    // Support both data and fileUri formats
+    const hasData = 'data' in val;
+    const hasFileUri = 'fileUri' in val;
+
+    if (!hasData && !hasFileUri) {
+      return false;
+    }
+    if (hasData && hasFileUri) {
+      return false; // Cannot have both
+    }
+
     return true;
   };
 
@@ -66,12 +73,14 @@ export const validateValue = (
     if (Array.isArray(value)) {
       for (const item of value) {
         if (!validImage(item)) {
-          msg = 'object ({ mimeType: string; data: string })';
+          msg =
+            'object ({ mimeType: string; data: string } | { mimeType: string; fileUri: string })';
           break;
         }
       }
     } else if (!validImage(value)) {
-      msg = 'object ({ mimeType: string; data: string })';
+      msg =
+        'object ({ mimeType: string; data: string } | { mimeType: string; fileUri: string })';
     }
 
     if (msg) {


### PR DESCRIPTION
## What

Adds URL support to `image` input fields, mirroring the existing `file` field's `data` / `fileUri` pattern. Images can now be supplied by URL instead of only inline base64.

```ts
const analyze = ax('photo:image -> answer:string');

// existing — inline base64
await analyze.forward(llm, { photo: { mimeType: 'image/jpeg', data } });

// new — by URL
await analyze.forward(llm, {
  photo: { mimeType: 'image/jpeg', fileUri: 'https://example.com/photo.jpg' },
});
```

An image field value now accepts **either** `{ mimeType, data }` (base64, unchanged) **or** `{ mimeType, fileUri }` (URL). Supplying both, or neither, is rejected — same rule the `file` type already enforces.

## How

The internal `image` content block gains a second union member carrying `fileUri` (parallel to how `file` is modeled). Each provider maps the URL variant to its native form:

| Provider | base64 (existing) | URL (new) |
|----------|-------------------|-----------|
| OpenAI | `image_url.url` = data URI | `image_url.url` = the URL directly |
| Anthropic | `source: { type: 'base64', … }` | `source: { type: 'url', url }` |
| Gemini | `inlineData: { data }` | `fileData: { fileUri }` (e.g. `gs://` / Files API URIs) |

Validation (`dsp/util.ts`, `dsp/prompt.ts`, `ai/validate.ts`), content hashing (`ai/base.ts`), logging (`dsp/loggers.ts`) and the unsupported-provider content processor (`ai/processor.ts`) were updated to narrow on the URL variant. `AxFieldValue` exposes the new shape to callers.

> Note on Gemini: `fileData.fileUri` accepts Google-hosted URIs (Files API / `gs://`), consistent with the existing `file` behavior — not arbitrary public `http(s)` URLs. OpenAI and Anthropic accept public URLs.

## Tests

- `dsp/prompt.test.ts` — image render with `data`, with `fileUri`, mixed arrays, and validation (missing mimeType / missing both / both present).
- `google-gemini/api.test.ts` — request mapping: base64 → `inlineData`, `fileUri` → `fileData`.
- Type-check clean; full unit suite green (the 2 unrelated `jsRuntime` sandbox failures are a Windows-only Node permission-model artifact).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
