### PR TITLE
feat: add AI SDK v6 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -418,7 +418,7 @@ Optional packages:
 
 ```bash
 npm install @ax-llm/ax-ai-aws-bedrock     # AWS Bedrock provider
-npm install @ax-llm/ax-ai-sdk-provider    # Vercel AI SDK v5 integration
+npm install @ax-llm/ax-ai-sdk-provider    # Vercel AI SDK v6 integration
 npm install @ax-llm/ax-tools              # MCP stdio transport, JS runtime extras
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ax-llm/ax-monorepo",
-  "version": "21.0.12",
+  "version": "21.0.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@ax-llm/ax-monorepo",
-      "version": "21.0.12",
+      "version": "21.0.14",
       "license": "Apache-2.0",
       "workspaces": [
         "src/*",
@@ -37,14 +37,14 @@
       }
     },
     "node_modules/@ai-sdk/gateway": {
-      "version": "2.0.14",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-2.0.14.tgz",
-      "integrity": "sha512-QU+ZVizSXN/V5uWgwapXrCLvkUEmmJeojAbikMH4gLgbeQF3oRugcQm3D8X9B+Rnestbz5cevNap7vKyJT/jfA==",
+      "version": "3.0.121",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-3.0.121.tgz",
+      "integrity": "sha512-uY248djJRxa5W68MHiyqO8WLdOeKQoRClGg7PVX/VPhVW8SJNM7/l5DcrA5WAM3YfQrLyNkgZa2VOu8T0t8LUw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/provider": "2.0.0",
-        "@ai-sdk/provider-utils": "3.0.17",
-        "@vercel/oidc": "3.0.5"
+        "@ai-sdk/provider": "3.0.10",
+        "@ai-sdk/provider-utils": "4.0.27",
+        "@vercel/oidc": "3.2.0"
       },
       "engines": {
         "node": ">=18"
@@ -54,9 +54,9 @@
       }
     },
     "node_modules/@ai-sdk/provider": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-2.0.0.tgz",
-      "integrity": "sha512-6o7Y2SeO9vFKB8lArHXehNuusnpddKPk7xqL7T2/b+OvXMRIXUO1rR4wcv1hAFUAT9avGZshty3Wlua/XA7TvA==",
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.10.tgz",
+      "integrity": "sha512-Q3BZ27qfpYqnCYGvE3vt+Qi6LGOF9R5Nmzn+9JoM1lCRsD9mYaIhfJLkSunN48nfGXJ6n+XNV0J/XVpqGQl7Dw==",
       "license": "Apache-2.0",
       "dependencies": {
         "json-schema": "^0.4.0"
@@ -66,14 +66,14 @@
       }
     },
     "node_modules/@ai-sdk/provider-utils": {
-      "version": "3.0.17",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-3.0.17.tgz",
-      "integrity": "sha512-TR3Gs4I3Tym4Ll+EPdzRdvo/rc8Js6c4nVhFLuvGLX/Y4V9ZcQMa/HTiYsHEgmYrf1zVi6Q145UEZUfleOwOjw==",
+      "version": "4.0.27",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-4.0.27.tgz",
+      "integrity": "sha512-ubkAJ+xODouwtmN1tYlvTPphH1hPOBfZaEQe8U7skGvFAnIRs9PPpsq57bC2+Ky/MB4yzhd6YOsxTAx9sGpazw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/provider": "2.0.0",
-        "@standard-schema/spec": "^1.0.0",
-        "eventsource-parser": "^3.0.6"
+        "@ai-sdk/provider": "3.0.10",
+        "@standard-schema/spec": "^1.1.0",
+        "eventsource-parser": "^3.0.8"
       },
       "engines": {
         "node": ">=18"
@@ -6809,9 +6809,9 @@
       }
     },
     "node_modules/@standard-schema/spec": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.0.0.tgz",
-      "integrity": "sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
       "license": "MIT"
     },
     "node_modules/@tailwindcss/typography": {
@@ -7048,9 +7048,9 @@
       "license": "ISC"
     },
     "node_modules/@vercel/oidc": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/@vercel/oidc/-/oidc-3.0.5.tgz",
-      "integrity": "sha512-fnYhv671l+eTTp48gB4zEsTW/YtRgRPnkI2nT7x6qw5rkI1Lq2hTmQIpHPgyThI0znLK+vX2n9XxKdXZ7BUbbw==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@vercel/oidc/-/oidc-3.2.0.tgz",
+      "integrity": "sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">= 20"
@@ -7346,15 +7346,15 @@
       }
     },
     "node_modules/ai": {
-      "version": "5.0.100",
-      "resolved": "https://registry.npmjs.org/ai/-/ai-5.0.100.tgz",
-      "integrity": "sha512-+ANP4EJomTcUKdEF3UpVAWEl6DGn+ozDLxVZKXmTV7NRfyEC2cLYcKwoU4o3sKJpqXMUKNzpFlJFBKOcsKdMyg==",
+      "version": "6.0.193",
+      "resolved": "https://registry.npmjs.org/ai/-/ai-6.0.193.tgz",
+      "integrity": "sha512-VQOTOse8+X8kMtg61DNSXlYJzwOW4NjMLDJNk/qxClWsFe4oiyFJDHGGG1oezfGcFzuYuQe/8Z7r4kwiZWh2YQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/gateway": "2.0.14",
-        "@ai-sdk/provider": "2.0.0",
-        "@ai-sdk/provider-utils": "3.0.17",
-        "@opentelemetry/api": "1.9.0"
+        "@ai-sdk/gateway": "3.0.121",
+        "@ai-sdk/provider": "3.0.10",
+        "@ai-sdk/provider-utils": "4.0.27",
+        "@opentelemetry/api": "^1.9.0"
       },
       "engines": {
         "node": ">=18"
@@ -10719,9 +10719,9 @@
       "license": "MIT"
     },
     "node_modules/eventsource-parser": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.6.tgz",
-      "integrity": "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.0.tgz",
+      "integrity": "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==",
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"
@@ -19769,13 +19769,14 @@
     },
     "src/aisdk": {
       "name": "@ax-llm/ax-ai-sdk-provider",
-      "version": "21.0.12",
+      "version": "21.0.14",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/provider-utils": "^3.0.10",
-        "@ax-llm/ax": "21.0.12",
-        "ai": "^5.0.100",
-        "zod": "^3.23.8"
+        "@ai-sdk/provider": "^3.0.10",
+        "@ai-sdk/provider-utils": "^4.0.27",
+        "@ax-llm/ax": "21.0.14",
+        "ai": "^6.0.193",
+        "zod": "^3.25.76"
       },
       "devDependencies": {
         "@types/react": "^19.0.5"
@@ -19783,11 +19784,11 @@
     },
     "src/aws-bedrock": {
       "name": "@ax-llm/ax-ai-aws-bedrock",
-      "version": "21.0.12",
+      "version": "21.0.14",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/client-bedrock-runtime": "^3.709.0",
-        "@ax-llm/ax": "21.0.12"
+        "@ax-llm/ax": "21.0.14"
       },
       "peerDependencies": {
         "@ax-llm/ax": "14.0.31"
@@ -19795,7 +19796,7 @@
     },
     "src/ax": {
       "name": "@ax-llm/ax",
-      "version": "21.0.12",
+      "version": "21.0.14",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/api": "^1.9.0"
@@ -19848,8 +19849,8 @@
       "version": "11.0.61",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ax-llm/ax": "21.0.12",
-        "@ax-llm/ax-tools": "21.0.12",
+        "@ax-llm/ax": "21.0.14",
+        "@ax-llm/ax-tools": "21.0.14",
         "@opentelemetry/exporter-metrics-otlp-http": "^0.208.0",
         "@opentelemetry/exporter-prometheus": "^0.218.0",
         "@opentelemetry/exporter-trace-otlp-http": "^0.203.0",
@@ -19865,10 +19866,10 @@
     },
     "src/tools": {
       "name": "@ax-llm/ax-tools",
-      "version": "21.0.12",
+      "version": "21.0.14",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ax-llm/ax": "21.0.12"
+        "@ax-llm/ax": "21.0.14"
       },
       "devDependencies": {}
     }

--- a/src/aisdk/README.md
+++ b/src/aisdk/README.md
@@ -6,70 +6,40 @@ Install the ax provider package
 npm i @ax-llm/ax-ai-sdk-provider
 ```
 
-### AI SDK v5 Compatibility
+### AI SDK v6 Compatibility
 
-This provider is fully compatible with **AI SDK v5** and implements the `LanguageModelV2` specification. It supports:
+This provider is compatible with **AI SDK v6** and implements the `LanguageModelV3` specification. It supports:
 
-- ✅ **Text Generation**: Standard text completion and chat functionality
-- ✅ **Tool Calling**: Function calls with proper serialization/deserialization
-- ✅ **Streaming**: Enhanced streaming with proper lifecycle events (`stream-start`, `text-start`, `text-delta`, `text-end`, `finish`)
-- ✅ **Multi-modal**: Support for text and file inputs (images, documents)
-- ✅ **Token Usage**: Accurate tracking with `inputTokens`, `outputTokens`, and `totalTokens`
+- **Text Generation**: Standard text completion and chat functionality
+- **Tool Calling**: Function calls with proper serialization/deserialization
+- **Streaming**: Streaming lifecycle events (`stream-start`, `text-start`, `text-delta`, `text-end`, `finish`)
+- **Multi-modal**: Support for text and file inputs (images, documents)
+- **Token Usage**: AI SDK v6 usage shape with nested `inputTokens` and `outputTokens`
 
-> **Note**: If you're upgrading from AI SDK v4, this provider handles all the necessary conversions between v1 and v2 specification formats automatically.
+AI SDK v6 renamed `CoreMessage` to `ModelMessage`, moved React Server Component helpers such as `streamUI` to `@ai-sdk/rsc`, and uses `LanguageModelV3` provider models.
 
 ## Usage
 
-You can use it with the AI SDK, either with the AI provider or the Agent Provider
+Use `AxAIProvider` anywhere AI SDK v6 accepts a language model.
 
 ```typescript
-const ai = new AxAI({
-    name: "openai",
-    apiKey: process.env["OPENAI_APIKEY"] ?? "",
+import { generateText } from 'ai';
+import { ai } from '@ax-llm/ax';
+import { AxAIProvider } from '@ax-llm/ax-ai-sdk-provider';
+
+const axAI = ai({
+  name: 'openai',
+  apiKey: process.env.OPENAI_APIKEY ?? '',
 });
 
-// Create a model using the provider
-const model = new AxAIProvider(ai);
+const model = new AxAIProvider(axAI);
 
-export const foodAgent = new AxAgent({
-    name: "food-search",
-    description:
-        "Use this agent to find restaurants based on what the customer wants",
-    signature,
-    functions,
+const result = await generateText({
+  model,
+  prompt: 'Write a haiku about typed AI SDK providers.',
 });
 
-// Get vercel ai sdk state
-const aiState = getMutableAIState();
-
-// Create an agent for a specific task
-const foodAgent = new AxAgentProvider(ai, {
-    agent: foodAgent,
-    updateState: (state) => {
-        aiState.done({ ...aiState.get(), state });
-    },
-    generate: async ({ restaurant, priceRange }) => {
-        return (
-            <BotCard>
-                <h1>{restaurant as string} {priceRange as string}</h1>
-            </BotCard>
-        );
-    },
-});
-
-// Use with streamUI a critical part of building chat UIs in the AI SDK
-const result = await streamUI({
-    model,
-    initial: <SpinnerMessage />,
-    messages: [
-        // ...
-    ],
-    text: ({ content, done, delta }) => {
-        // ...
-    },
-    tools: {
-        // @ts-ignore
-        "find-food": foodAgent,
-    },
-});
+console.log(result.text);
 ```
+
+For React Server Component helpers such as `streamUI`, install `@ai-sdk/rsc` and import those helpers from that package.

--- a/src/aisdk/index.test.ts
+++ b/src/aisdk/index.test.ts
@@ -1,10 +1,11 @@
-import type { LanguageModelV2CallOptions } from '@ai-sdk/provider';
+import type { LanguageModelV3CallOptions } from '@ai-sdk/provider';
 import type { AxAIService, AxChatResponse } from '@ax-llm/ax/index.js';
+import { generateText, streamText, tool } from 'ai';
 import { describe, expect, it, vi } from 'vitest';
+import { z } from 'zod';
 
 import { AxAIProvider } from './index.js';
 
-// Mock AxAIService
 const createMockAIService = (
   responses: Partial<AxChatResponse>[] = []
 ): AxAIService => {
@@ -16,7 +17,6 @@ const createMockAIService = (
       callCount++;
 
       if (options?.stream) {
-        // Return a mock ReadableStream for streaming
         return new ReadableStream({
           start(controller) {
             controller.enqueue(response);
@@ -35,14 +35,141 @@ describe('AxAIProvider', () => {
     expect(AxAIProvider).toBeDefined();
   });
 
-  it('should implement LanguageModelV2 interface', () => {
+  it('should implement LanguageModelV3 interface', () => {
     const mockAI = createMockAIService();
     const provider = new AxAIProvider(mockAI);
 
-    expect(provider.specificationVersion).toBe('v2');
+    expect(provider.specificationVersion).toBe('v3');
     expect(provider.supportedUrls).toEqual({});
     expect(provider.provider).toBe('test-model');
     expect(provider.modelId).toBe('test-model');
+  });
+
+  describe('AI SDK Core integration', () => {
+    it('generates text through AI SDK Core', async () => {
+      const mockAI = createMockAIService([
+        {
+          results: [{ content: 'Hello from Ax', finishReason: 'stop' }],
+          modelUsage: {
+            tokens: { promptTokens: 4, completionTokens: 3, totalTokens: 7 },
+          },
+        },
+      ]);
+      const provider = new AxAIProvider(mockAI);
+
+      const { rawFinishReason, text, usage, finishReason } = await generateText(
+        {
+          model: provider,
+          prompt: 'Hello',
+        }
+      );
+
+      expect(text).toBe('Hello from Ax');
+      expect(finishReason).toBe('stop');
+      expect(rawFinishReason).toBe('stop');
+      expect(usage).toMatchObject({
+        inputTokens: 4,
+        outputTokens: 3,
+        totalTokens: 7,
+      });
+      expect(mockAI.chat).toHaveBeenCalledWith(
+        expect.objectContaining({
+          chatPrompt: [
+            { role: 'user', content: [{ type: 'text', text: 'Hello' }] },
+          ],
+        }),
+        { stream: false }
+      );
+    });
+
+    it('maps AI SDK tools and Ax tool calls', async () => {
+      const mockAI = createMockAIService([
+        {
+          results: [
+            {
+              functionCalls: [
+                {
+                  id: 'call_weather',
+                  type: 'function',
+                  function: {
+                    name: 'weather',
+                    params: { location: 'Paris' },
+                  },
+                },
+              ],
+              finishReason: 'function_call',
+            },
+          ],
+        },
+      ]);
+      const provider = new AxAIProvider(mockAI);
+
+      const { finishReason, toolCalls } = await generateText({
+        model: provider,
+        tools: {
+          weather: tool({
+            description: 'Get weather information',
+            inputSchema: z.object({ location: z.string() }),
+          }),
+        },
+        prompt: 'Weather in Paris?',
+      });
+
+      expect(mockAI.chat).toHaveBeenCalledWith(
+        expect.objectContaining({
+          functionCall: 'auto',
+          functions: [
+            expect.objectContaining({
+              name: 'weather',
+              description: 'Get weather information',
+              parameters: expect.objectContaining({ type: 'object' }),
+            }),
+          ],
+        }),
+        { stream: false }
+      );
+      expect(finishReason).toBe('tool-calls');
+      expect(toolCalls).toEqual([
+        expect.objectContaining({
+          toolCallId: 'call_weather',
+          toolName: 'weather',
+          input: { location: 'Paris' },
+        }),
+      ]);
+    });
+
+    it('streams text through AI SDK Core', async () => {
+      const mockAI = createMockAIService([
+        {
+          results: [{ content: 'Streaming text', finishReason: 'stop' }],
+          modelUsage: {
+            tokens: { promptTokens: 2, completionTokens: 2, totalTokens: 4 },
+          },
+        },
+      ]);
+      const provider = new AxAIProvider(mockAI);
+
+      const result = streamText({
+        model: provider,
+        prompt: 'Stream test',
+      });
+      const chunks: string[] = [];
+
+      for await (const delta of result.textStream) {
+        chunks.push(delta);
+      }
+
+      expect(chunks.join('')).toBe('Streaming text');
+      await expect(result.finishReason).resolves.toBe('stop');
+      await expect(result.usage).resolves.toMatchObject({
+        inputTokens: 2,
+        outputTokens: 2,
+        totalTokens: 4,
+      });
+      expect(mockAI.chat).toHaveBeenCalledWith(expect.any(Object), {
+        stream: true,
+      });
+    });
   });
 
   describe('doGenerate', () => {
@@ -65,7 +192,7 @@ describe('AxAIProvider', () => {
       const mockAI = createMockAIService([mockResponse]);
       const provider = new AxAIProvider(mockAI);
 
-      const options: LanguageModelV2CallOptions = {
+      const options: LanguageModelV3CallOptions = {
         prompt: [{ role: 'user', content: [{ type: 'text', text: 'Hello' }] }],
       };
 
@@ -76,11 +203,19 @@ describe('AxAIProvider', () => {
         type: 'text',
         text: 'Hello, world!',
       });
-      expect(result.finishReason).toBe('stop');
+      expect(result.finishReason).toEqual({ unified: 'stop', raw: 'stop' });
       expect(result.usage).toEqual({
-        inputTokens: 10,
-        outputTokens: 5,
-        totalTokens: 15,
+        inputTokens: {
+          total: 10,
+          noCache: undefined,
+          cacheRead: undefined,
+          cacheWrite: undefined,
+        },
+        outputTokens: {
+          total: 5,
+          text: undefined,
+          reasoning: undefined,
+        },
       });
       expect(result.warnings).toEqual([]);
     });
@@ -91,7 +226,7 @@ describe('AxAIProvider', () => {
       ]);
       const provider = new AxAIProvider(mockAI);
 
-      const options: LanguageModelV2CallOptions = {
+      const options: LanguageModelV3CallOptions = {
         prompt: [{ role: 'user', content: [{ type: 'text', text: 'Hello' }] }],
       };
 
@@ -164,7 +299,7 @@ describe('AxAIProvider', () => {
       const mockAI = createMockAIService([mockResponse]);
       const provider = new AxAIProvider(mockAI);
 
-      const options: LanguageModelV2CallOptions = {
+      const options: LanguageModelV3CallOptions = {
         prompt: [
           {
             role: 'user',
@@ -195,7 +330,10 @@ describe('AxAIProvider', () => {
         toolName: 'getWeather',
         input: '{"location":"New York"}',
       });
-      expect(result.finishReason).toBe('tool-calls');
+      expect(result.finishReason).toEqual({
+        unified: 'tool-calls',
+        raw: 'function_call',
+      });
     });
 
     it('should handle string function params correctly', async () => {
@@ -220,7 +358,7 @@ describe('AxAIProvider', () => {
       const mockAI = createMockAIService([mockResponse]);
       const provider = new AxAIProvider(mockAI);
 
-      const options: LanguageModelV2CallOptions = {
+      const options: LanguageModelV3CallOptions = {
         prompt: [
           { role: 'user', content: [{ type: 'text', text: 'Calculate 5+3' }] },
         ],
@@ -257,7 +395,7 @@ describe('AxAIProvider', () => {
       const mockAI = createMockAIService([mockResponse]);
       const provider = new AxAIProvider(mockAI);
 
-      const options: LanguageModelV2CallOptions = {
+      const options: LanguageModelV3CallOptions = {
         prompt: [
           { role: 'user', content: [{ type: 'text', text: 'Stream test' }] },
         ],
@@ -279,7 +417,6 @@ describe('AxAIProvider', () => {
         reader.releaseLock();
       }
 
-      // Verify proper streaming lifecycle
       expect(chunks[0]).toEqual({
         type: 'stream-start',
         warnings: [],
@@ -303,11 +440,19 @@ describe('AxAIProvider', () => {
 
       expect(chunks[4]).toEqual({
         type: 'finish',
-        finishReason: 'stop',
+        finishReason: { unified: 'stop', raw: 'stop' },
         usage: {
-          inputTokens: 8,
-          outputTokens: 3,
-          totalTokens: 11,
+          inputTokens: {
+            total: 8,
+            noCache: undefined,
+            cacheRead: undefined,
+            cacheWrite: undefined,
+          },
+          outputTokens: {
+            total: 3,
+            text: undefined,
+            reasoning: undefined,
+          },
         },
       });
     });
@@ -318,7 +463,7 @@ describe('AxAIProvider', () => {
       ]);
       const provider = new AxAIProvider(mockAI);
 
-      const options: LanguageModelV2CallOptions = {
+      const options: LanguageModelV3CallOptions = {
         prompt: [
           { role: 'user', content: [{ type: 'text', text: 'Stream test' }] },
         ],
@@ -380,7 +525,7 @@ describe('AxAIProvider', () => {
       ]);
       const provider = new AxAIProvider(mockAI);
 
-      const options: LanguageModelV2CallOptions = {
+      const options: LanguageModelV3CallOptions = {
         prompt: [
           {
             role: 'user',
@@ -413,7 +558,6 @@ describe('AxAIProvider', () => {
 
       await provider.doGenerate(options);
 
-      // Verify the chat method was called with properly converted prompt
       expect(mockAI.chat).toHaveBeenCalledWith(
         expect.objectContaining({
           chatPrompt: expect.arrayContaining([

--- a/src/aisdk/package.json
+++ b/src/aisdk/package.json
@@ -18,6 +18,7 @@
     "clean": "rm -rf dist",
     "test": "run-s test:*",
     "test:type-check": "tsc --noEmit",
+    "test:unit": "vitest run",
     "test:lint": "biome lint .",
     "test:format": "biome format .",
     "fix": "run-s fix:*",
@@ -30,10 +31,11 @@
     "postbuild": "node ../../scripts/postbuild.js"
   },
   "dependencies": {
-    "@ai-sdk/provider-utils": "^3.0.10",
+    "@ai-sdk/provider": "^3.0.10",
+    "@ai-sdk/provider-utils": "^4.0.27",
     "@ax-llm/ax": "21.0.14",
-    "ai": "^5.0.100",
-    "zod": "^3.23.8"
+    "ai": "^6.0.193",
+    "zod": "^3.25.76"
   },
   "bugs": {
     "url": "https://github.com/@ax-llm/ax/issues"

--- a/src/aisdk/provider.ts
+++ b/src/aisdk/provider.ts
@@ -1,24 +1,19 @@
 // cspell:ignore Streamable
 
-import {
-  type ReadableStream,
-  TransformStream,
-  type TransformStreamDefaultController,
-} from 'node:stream/web';
 import type {
   JSONValue,
-  LanguageModelV2,
-  LanguageModelV2CallOptions,
-  LanguageModelV2CallWarning,
-  LanguageModelV2Content,
-  LanguageModelV2FinishReason,
-  LanguageModelV2FunctionTool,
-  LanguageModelV2Prompt,
-  LanguageModelV2StreamPart,
-  LanguageModelV2ToolCall,
-  LanguageModelV2ToolChoice,
-  LanguageModelV2Usage,
-  SharedV2ProviderMetadata,
+  LanguageModelV3,
+  LanguageModelV3CallOptions,
+  LanguageModelV3Content,
+  LanguageModelV3FinishReason,
+  LanguageModelV3FunctionTool,
+  LanguageModelV3Prompt,
+  LanguageModelV3StreamPart,
+  LanguageModelV3ToolCall,
+  LanguageModelV3ToolChoice,
+  LanguageModelV3Usage,
+  SharedV3ProviderMetadata,
+  SharedV3Warning,
 } from '@ai-sdk/provider';
 import type {
   AxAgentic,
@@ -30,8 +25,9 @@ import type {
   AxFunctionJSONSchema,
   AxGenIn,
   AxGenOut,
+  AxTokenUsage,
 } from '@ax-llm/ax/index.js';
-import type { CoreMessage } from 'ai';
+import type { ModelMessage } from 'ai';
 import { customAlphabet } from 'nanoid';
 import type { ReactNode } from 'react';
 import { z } from 'zod';
@@ -75,11 +71,11 @@ function toJSONValue(value: unknown): JSONValue | undefined {
 }
 
 function mergeProviderMetadata(
-  base?: SharedV2ProviderMetadata,
-  next?: SharedV2ProviderMetadata
-): SharedV2ProviderMetadata | undefined {
+  base?: SharedV3ProviderMetadata,
+  next?: SharedV3ProviderMetadata
+): SharedV3ProviderMetadata | undefined {
   if (!base && !next) return undefined;
-  const merged: SharedV2ProviderMetadata = {};
+  const merged: SharedV3ProviderMetadata = {};
   for (const source of [base, next]) {
     if (!source) continue;
     for (const [provider, metadata] of Object.entries(source)) {
@@ -95,8 +91,8 @@ function mergeProviderMetadata(
 function createProviderMetadata(
   res: Readonly<AxResponseLike>,
   provider: string
-): SharedV2ProviderMetadata | undefined {
-  let metadata: SharedV2ProviderMetadata | undefined;
+): SharedV3ProviderMetadata | undefined {
+  let metadata: SharedV3ProviderMetadata | undefined;
 
   if (res.providerMetadata) {
     metadata = {};
@@ -160,7 +156,7 @@ export class AxAgentProvider<IN extends AxGenIn, OUT extends AxGenOut> {
   private readonly config?: AxConfig;
   private readonly funcInfo: AxFunction;
   private generateFunction: Renderer<OUT>;
-  private updateState: (msgs: readonly CoreMessage[]) => void;
+  private updateState: (msgs: readonly ModelMessage[]) => void;
 
   constructor({
     agent,
@@ -169,7 +165,7 @@ export class AxAgentProvider<IN extends AxGenIn, OUT extends AxGenOut> {
     config,
   }: Readonly<{
     agent: AxAgentic<IN, OUT>;
-    updateState: (msgs: readonly CoreMessage[]) => void;
+    updateState: (msgs: readonly ModelMessage[]) => void;
     generate: Renderer<OUT>;
     config?: Readonly<AxConfig>;
   }>) {
@@ -228,8 +224,8 @@ export class AxAgentProvider<IN extends AxGenIn, OUT extends AxGenOut> {
   }
 }
 
-export class AxAIProvider implements LanguageModelV2 {
-  readonly specificationVersion = 'v2' as const;
+export class AxAIProvider implements LanguageModelV3 {
+  readonly specificationVersion = 'v3' as const;
   readonly supportedUrls: Record<string, RegExp[]> = {};
 
   private readonly ai: AxAIService;
@@ -248,8 +244,8 @@ export class AxAIProvider implements LanguageModelV2 {
   }
 
   async doGenerate(
-    options: LanguageModelV2CallOptions
-  ): Promise<Awaited<ReturnType<LanguageModelV2['doGenerate']>>> {
+    options: LanguageModelV3CallOptions
+  ): Promise<Awaited<ReturnType<LanguageModelV3['doGenerate']>>> {
     const req = createChatRequest(options);
     const res = (await this.ai.chat(req, {
       stream: false,
@@ -260,7 +256,7 @@ export class AxAIProvider implements LanguageModelV2 {
       throw new Error('No choice returned');
     }
 
-    const content: LanguageModelV2Content[] = [];
+    const content: LanguageModelV3Content[] = [];
 
     if (choice.content) {
       content.push({ type: 'text', text: choice.content });
@@ -286,22 +282,16 @@ export class AxAIProvider implements LanguageModelV2 {
     return {
       content,
       finishReason: mapAxFinishReason(choice.finishReason),
-      usage: {
-        inputTokens: res.modelUsage?.tokens?.promptTokens ?? 0,
-        outputTokens: res.modelUsage?.tokens?.completionTokens ?? 0,
-        totalTokens:
-          (res.modelUsage?.tokens?.promptTokens ?? 0) +
-          (res.modelUsage?.tokens?.completionTokens ?? 0),
-      },
+      usage: createUsage(res.modelUsage?.tokens),
       ...(providerMetadata ? { providerMetadata } : {}),
       ...(response ? { response } : {}),
-      warnings: [] as LanguageModelV2CallWarning[],
+      warnings: [] as SharedV3Warning[],
     };
   }
 
   async doStream(
-    options: LanguageModelV2CallOptions
-  ): Promise<Awaited<ReturnType<LanguageModelV2['doStream']>>> {
+    options: LanguageModelV3CallOptions
+  ): Promise<Awaited<ReturnType<LanguageModelV3['doStream']>>> {
     const req = createChatRequest(options);
 
     const res = (await this.ai.chat(req, {
@@ -309,14 +299,14 @@ export class AxAIProvider implements LanguageModelV2 {
     })) as ReadableStream<AxChatResponse>;
 
     return {
-      stream: res.pipeThrough(new AxToSDKTransformer(this.provider)) as any,
+      stream: res.pipeThrough(new AxToSDKTransformer(this.provider)),
     };
   }
 }
 
 function prepareToolsAndToolChoice(
-  tools: Array<LanguageModelV2FunctionTool>,
-  toolChoice?: LanguageModelV2ToolChoice
+  tools: Array<LanguageModelV3FunctionTool>,
+  toolChoice?: LanguageModelV3ToolChoice
 ): Pick<AxChatRequest, 'functions' | 'functionCall'> {
   // when the tools array is empty, change it to undefined to prevent errors:
   if (!tools || tools.length === 0) {
@@ -357,7 +347,7 @@ function prepareToolsAndToolChoice(
 }
 
 function convertToAxChatPrompt(
-  prompt: Readonly<LanguageModelV2Prompt>
+  prompt: Readonly<LanguageModelV3Prompt>
 ): AxChatRequest['chatPrompt'] {
   const messages: AxChatRequest['chatPrompt'] = [];
 
@@ -465,6 +455,9 @@ function convertToAxChatPrompt(
       }
       case 'tool': {
         for (const part of content) {
+          if (part.type !== 'tool-result') {
+            throw new Error(`Unsupported part: ${part.type}`);
+          }
           messages.push({
             role: 'function' as const,
             functionId: part.toolCallId,
@@ -488,16 +481,21 @@ function convertToAxChatPrompt(
 
 function mapAxFinishReason(
   finishReason: AxChatResponseResult['finishReason']
-): LanguageModelV2FinishReason {
+): LanguageModelV3FinishReason {
+  const raw = finishReason;
   switch (finishReason) {
     case 'stop':
-      return 'stop';
+      return { unified: 'stop', raw };
     case 'length':
-      return 'length';
+      return { unified: 'length', raw };
     case 'function_call':
-      return 'tool-calls';
+      return { unified: 'tool-calls', raw };
+    case 'content_filter':
+      return { unified: 'content-filter', raw };
+    case 'error':
+      return { unified: 'error', raw };
     default:
-      return 'other';
+      return { unified: 'other', raw };
   }
 }
 
@@ -511,7 +509,7 @@ function createChatRequest({
   frequencyPenalty,
   presencePenalty,
   //seed,
-}: Readonly<LanguageModelV2CallOptions>): AxChatRequest {
+}: Readonly<LanguageModelV3CallOptions>): AxChatRequest {
   const req: AxChatRequest = {
     chatPrompt: convertToAxChatPrompt(prompt),
     ...(frequencyPenalty != null ? { frequencyPenalty } : {}),
@@ -523,7 +521,7 @@ function createChatRequest({
 
   if (tools && tools.length > 0) {
     const functionTools = tools.filter(
-      (tool): tool is LanguageModelV2FunctionTool => tool.type === 'function'
+      (tool): tool is LanguageModelV3FunctionTool => tool.type === 'function'
     );
     return { ...req, ...prepareToolsAndToolChoice(functionTools, toolChoice) };
   }
@@ -531,20 +529,63 @@ function createChatRequest({
   return req;
 }
 
+function createUsage(tokens?: Readonly<AxTokenUsage>): LanguageModelV3Usage {
+  return {
+    inputTokens: {
+      total: tokens?.promptTokens,
+      noCache: undefined,
+      cacheRead: tokens?.cacheReadTokens,
+      cacheWrite: tokens?.cacheCreationTokens,
+    },
+    outputTokens: {
+      total: tokens?.completionTokens,
+      text: undefined,
+      reasoning: tokens?.reasoningTokens,
+    },
+  };
+}
+
+function addUsage(
+  usage: Readonly<LanguageModelV3Usage>,
+  tokens?: Readonly<AxTokenUsage>
+): LanguageModelV3Usage {
+  return {
+    inputTokens: {
+      ...usage.inputTokens,
+      total: (usage.inputTokens.total ?? 0) + (tokens?.promptTokens ?? 0),
+    },
+    outputTokens: {
+      ...usage.outputTokens,
+      total: (usage.outputTokens.total ?? 0) + (tokens?.completionTokens ?? 0),
+    },
+  };
+}
+
 class AxToSDKTransformer extends TransformStream<
   AxChatResponse,
-  LanguageModelV2StreamPart
+  LanguageModelV3StreamPart
 > {
-  private usage: LanguageModelV2Usage = {
-    inputTokens: 0,
-    outputTokens: 0,
-    totalTokens: 0,
+  private usage: LanguageModelV3Usage = {
+    inputTokens: {
+      total: 0,
+      noCache: undefined,
+      cacheRead: undefined,
+      cacheWrite: undefined,
+    },
+    outputTokens: {
+      total: 0,
+      text: undefined,
+      reasoning: undefined,
+    },
   };
 
-  private finishReason: LanguageModelV2FinishReason = 'other';
+  private finishReason: LanguageModelV3FinishReason = {
+    unified: 'other',
+    raw: undefined,
+  };
 
-  private functionCalls: LanguageModelV2ToolCall[] = [];
-  private providerMetadata: SharedV2ProviderMetadata | undefined;
+  private functionCalls: LanguageModelV3ToolCall[] = [];
+  private providerMetadata: SharedV3ProviderMetadata | undefined;
   private responseMetadataSent = false;
   private hasStarted = false;
   private textStarted = false;
@@ -554,13 +595,13 @@ class AxToSDKTransformer extends TransformStream<
     const transformer = {
       transform: (
         chunk: Readonly<AxChatResponse>,
-        controller: TransformStreamDefaultController<LanguageModelV2StreamPart>
+        controller: TransformStreamDefaultController<LanguageModelV3StreamPart>
       ) => {
         // Emit stream-start event only once
         if (!this.hasStarted) {
           controller.enqueue({
             type: 'stream-start',
-            warnings: [] as LanguageModelV2CallWarning[],
+            warnings: [] as SharedV3Warning[],
           });
           this.hasStarted = true;
         }
@@ -606,18 +647,7 @@ class AxToSDKTransformer extends TransformStream<
         }
 
         if (chunk.modelUsage) {
-          this.usage = {
-            inputTokens:
-              (this.usage.inputTokens ?? 0) +
-              (chunk.modelUsage?.tokens?.promptTokens ?? 0),
-            outputTokens:
-              (this.usage.outputTokens ?? 0) +
-              (chunk.modelUsage.tokens?.completionTokens ?? 0),
-            totalTokens:
-              (this.usage.totalTokens ?? 0) +
-              (chunk.modelUsage?.tokens?.promptTokens ?? 0) +
-              (chunk.modelUsage.tokens?.completionTokens ?? 0),
-          };
+          this.usage = addUsage(this.usage, chunk.modelUsage.tokens);
         }
 
         if (choice.functionCalls) {
@@ -646,7 +676,7 @@ class AxToSDKTransformer extends TransformStream<
                 obj.input = JSON.stringify(fc.function.params);
               }
             }
-            this.finishReason = 'tool-calls';
+            this.finishReason = { unified: 'tool-calls', raw: 'function_call' };
           }
         }
 
@@ -669,7 +699,7 @@ class AxToSDKTransformer extends TransformStream<
         }
       },
       flush: (
-        controller: TransformStreamDefaultController<LanguageModelV2StreamPart>
+        controller: TransformStreamDefaultController<LanguageModelV3StreamPart>
       ) => {
         // End text stream if it was started
         if (this.textStarted) {

--- a/src/ax/skills/ax-ai.md
+++ b/src/ax/skills/ax-ai.md
@@ -272,15 +272,19 @@ const bedrock = new AxAIBedrock({
 ## Vercel AI SDK Integration
 
 ```typescript
+import { generateText } from 'ai';
 import { ai } from '@ax-llm/ax';
 import { AxAIProvider } from '@ax-llm/ax-ai-sdk-provider';
-import { generateText } from 'ai';
 
-const axAI = ai({ name: 'openai', apiKey: process.env.OPENAI_APIKEY! });
+const axAI = ai({
+  name: 'openai',
+  apiKey: process.env.OPENAI_APIKEY ?? '',
+});
 const model = new AxAIProvider(axAI);
+
 const result = await generateText({
   model,
-  messages: [{ role: 'user', content: 'Hello!' }],
+  prompt: 'Hello!',
 });
 ```
 


### PR DESCRIPTION
- **What kind of change does this PR introduce?**

Feature / compatibility update.

- **What is the current behavior?**

`@ax-llm/ax-ai-sdk-provider` targets Vercel AI SDK v5 and implements the `LanguageModelV2` provider interface. Its tests exercise the provider methods directly, but do not verify compatibility through AI SDK Core APIs like `generateText` and `streamText`.

- **What is the new behavior (if this is a feature change)?**

Adds Vercel AI SDK v6 support by migrating `AxAIProvider` to `LanguageModelV3`, updating AI SDK dependencies, and mapping v6 finish reason, usage, metadata, prompt, tool, and stream shapes.

Also adds public AI SDK Core compatibility coverage for `generateText`, `streamText`, and tool calls, and wires Vitest into the provider package test script. README and Ax skill docs now show v6-style usage.

- **Other information**:

Verified with:

```bash
npm test --workspace=@ax-llm/ax-ai-sdk-provider
npm run build --workspace=@ax-llm/ax-ai-sdk-provider
```
