### PR TITLE
feat: add LiteLLM as AI gateway provider

### DIFF
--- a/src/ax/ai/catalog.test.ts
+++ b/src/ax/ai/catalog.test.ts
@@ -26,9 +26,10 @@ describe('axGetSupportedAIModels', () => {
         'huggingface',
         'reka',
         'grok',
+        'litellm',
       ])
     );
-    expect(providerNames).toHaveLength(11);
+    expect(providerNames).toHaveLength(12);
   });
 
   it('returns provider grouped model metadata with pricing', () => {
@@ -268,7 +269,11 @@ describe('axGetSupportedAIModels', () => {
   it('marks dynamic providers without inventing static pricing', () => {
     const providers = axGetSupportedAIModels();
 
-    for (const providerName of ['azure-openai', 'huggingface'] as const) {
+    for (const providerName of [
+      'azure-openai',
+      'huggingface',
+      'litellm',
+    ] as const) {
       const provider = providers.find((item) => item.name === providerName);
 
       expect(provider?.isDynamic).toBe(true);

--- a/src/ax/ai/catalog.ts
+++ b/src/ax/ai/catalog.ts
@@ -11,6 +11,7 @@ import {
 } from './google-gemini/types.js';
 import { axModelInfoHuggingFace } from './huggingface/info.js';
 import { AxAIHuggingFaceModel } from './huggingface/types.js';
+import { axModelInfoLiteLLM } from './litellm/info.js';
 import { axModelInfoMistral } from './mistral/info.js';
 import { AxAIMistralModel } from './mistral/types.js';
 import { AxAIOpenAIEmbedModel, AxAIOpenAIModel } from './openai/chat_types.js';
@@ -152,6 +153,11 @@ const axAIModelCatalogProviderDefinitions = {
     defaultModel: AxAIGrokModel.Grok3,
     isDynamic: false,
     modelInfo: axModelInfoGrok,
+  },
+  litellm: {
+    displayName: 'LiteLLM',
+    isDynamic: true,
+    modelInfo: axModelInfoLiteLLM,
   },
 } satisfies Record<
   AxAIModelCatalogProviderName,

--- a/src/ax/ai/litellm/api.test.ts
+++ b/src/ax/ai/litellm/api.test.ts
@@ -14,16 +14,24 @@ const okResponse = {
       finish_reason: 'stop',
     },
   ],
+  usage: {
+    prompt_tokens: 10,
+    completion_tokens: 1,
+    total_tokens: 11,
+  },
 };
 
-function createMockFetch(capture: { lastBody?: Record<string, unknown> }) {
+function createMockFetch(
+  capture: { lastBody?: Record<string, unknown> },
+  responseBody: unknown = okResponse
+) {
   return vi
     .fn()
     .mockImplementation(async (_url: RequestInfo | URL, init?: RequestInit) => {
       if (typeof init?.body === 'string') {
         capture.lastBody = JSON.parse(init.body) as Record<string, unknown>;
       }
-      return new Response(JSON.stringify(okResponse), {
+      return new Response(JSON.stringify(responseBody), {
         status: 200,
         headers: { 'Content-Type': 'application/json' },
       });
@@ -60,7 +68,7 @@ describe('AxAILiteLLM', () => {
     expect(ai.getName()).toBe('LiteLLM');
   });
 
-  it('sends chat request to proxy URL', async () => {
+  it('sends chat request and parses response correctly', async () => {
     const capture: { lastBody?: Record<string, unknown> } = {};
     const mockFetch = createMockFetch(capture);
 
@@ -71,7 +79,7 @@ describe('AxAILiteLLM', () => {
     });
     ai.setOptions({ fetch: mockFetch });
 
-    await ai.chat({
+    const res = await ai.chat({
       chatPrompt: [{ role: 'user', content: 'hello' }],
     });
 
@@ -79,6 +87,13 @@ describe('AxAILiteLLM', () => {
     const url = mockFetch.mock.calls[0]?.[0];
     expect(String(url)).toContain('localhost:4000');
     expect(capture.lastBody?.model).toBe('anthropic/claude-sonnet-4-20250514');
+
+    // Verify response is parsed, not just that fetch was called
+    if (res instanceof ReadableStream) {
+      throw new Error('Expected non-streaming response');
+    }
+    expect(res.results[0]?.content).toBe('ok');
+    expect(res.results[0]?.finishReason).toBe('stop');
   });
 
   it('returns default config', () => {
@@ -109,6 +124,20 @@ describe('AxAILiteLLM', () => {
     expect(models).toHaveLength(2);
     expect(models[0]?.name).toBe('gpt-4o-mini');
     expect(models[1]?.name).toBe('anthropic/claude-sonnet-4-20250514');
+  });
+
+  it('fetchModelList returns empty array on error', async () => {
+    const mockFetch = vi
+      .fn()
+      .mockResolvedValue(new Response('Unauthorized', { status: 401 }));
+
+    const ai = new AxAILiteLLM({
+      apiKey: 'sk-bad-key',
+      apiURL: 'http://localhost:4000/v1',
+    });
+
+    const models = await ai.fetchModelList({ fetch: mockFetch });
+    expect(models).toEqual([]);
   });
 
   it('accepts custom modelInfo for cost tracking', () => {

--- a/src/ax/ai/litellm/api.test.ts
+++ b/src/ax/ai/litellm/api.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { AxAILiteLLM, axAILiteLLMDefaultConfig } from './api.js';
+
+const okResponse = {
+  id: 'chatcmpl-test',
+  object: 'chat.completion',
+  created: 0,
+  model: 'anthropic/claude-sonnet-4-20250514',
+  choices: [
+    {
+      index: 0,
+      message: { role: 'assistant', content: 'ok' },
+      finish_reason: 'stop',
+    },
+  ],
+};
+
+function createMockFetch(capture: { lastBody?: Record<string, unknown> }) {
+  return vi
+    .fn()
+    .mockImplementation(async (_url: RequestInfo | URL, init?: RequestInit) => {
+      if (typeof init?.body === 'string') {
+        capture.lastBody = JSON.parse(init.body) as Record<string, unknown>;
+      }
+      return new Response(JSON.stringify(okResponse), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    });
+}
+
+describe('AxAILiteLLM', () => {
+  it('throws when apiKey is missing', () => {
+    expect(
+      () =>
+        new AxAILiteLLM({
+          apiKey: '',
+          apiURL: 'http://localhost:4000/v1',
+        })
+    ).toThrow('LiteLLM API key not set');
+  });
+
+  it('throws when apiURL is missing', () => {
+    expect(
+      () =>
+        new AxAILiteLLM({
+          apiKey: 'sk-test',
+          apiURL: '',
+        })
+    ).toThrow('LiteLLM API URL not set');
+  });
+
+  it('constructs with valid args', () => {
+    const ai = new AxAILiteLLM({
+      apiKey: 'sk-test',
+      apiURL: 'http://localhost:4000/v1',
+      config: { model: 'anthropic/claude-sonnet-4-20250514' },
+    });
+    expect(ai.getName()).toBe('LiteLLM');
+  });
+
+  it('sends chat request to proxy URL', async () => {
+    const capture: { lastBody?: Record<string, unknown> } = {};
+    const mockFetch = createMockFetch(capture);
+
+    const ai = new AxAILiteLLM({
+      apiKey: 'sk-proxy-key',
+      apiURL: 'http://localhost:4000/v1',
+      config: { model: 'anthropic/claude-sonnet-4-20250514', stream: false },
+    });
+    ai.setOptions({ fetch: mockFetch });
+
+    await ai.chat({
+      chatPrompt: [{ role: 'user', content: 'hello' }],
+    });
+
+    expect(mockFetch).toHaveBeenCalled();
+    const url = mockFetch.mock.calls[0]?.[0];
+    expect(String(url)).toContain('localhost:4000');
+    expect(capture.lastBody?.model).toBe('anthropic/claude-sonnet-4-20250514');
+  });
+
+  it('returns default config', () => {
+    const config = axAILiteLLMDefaultConfig();
+    expect(config.model).toBe('gpt-4o-mini');
+  });
+
+  it('fetchModelList calls proxy /models endpoint', async () => {
+    const modelsResponse = {
+      data: [
+        { id: 'gpt-4o-mini' },
+        { id: 'anthropic/claude-sonnet-4-20250514' },
+      ],
+    };
+    const mockFetch = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify(modelsResponse), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    );
+
+    const ai = new AxAILiteLLM({
+      apiKey: 'sk-test',
+      apiURL: 'http://localhost:4000/v1',
+    });
+
+    const models = await ai.fetchModelList({ fetch: mockFetch });
+    expect(models).toHaveLength(2);
+    expect(models[0]?.name).toBe('gpt-4o-mini');
+    expect(models[1]?.name).toBe('anthropic/claude-sonnet-4-20250514');
+  });
+
+  it('accepts custom modelInfo for cost tracking', () => {
+    const ai = new AxAILiteLLM({
+      apiKey: 'sk-test',
+      apiURL: 'http://localhost:4000/v1',
+      modelInfo: [
+        {
+          name: 'anthropic/claude-sonnet-4-20250514',
+          promptTokenCostPer1M: 3,
+          completionTokenCostPer1M: 15,
+        },
+      ],
+    });
+    expect(ai.getName()).toBe('LiteLLM');
+  });
+});

--- a/src/ax/ai/litellm/api.ts
+++ b/src/ax/ai/litellm/api.ts
@@ -1,0 +1,145 @@
+import type { AxAIFeatures } from '../base.js';
+import {
+  axBaseAIDefaultConfig,
+  axBaseAIDefaultCreativeConfig,
+} from '../base.js';
+import { type AxAIOpenAIArgs, AxAIOpenAIBase } from '../openai/api.js';
+import type { AxAIOpenAIConfig } from '../openai/chat_types.js';
+import type { AxAIServiceOptions, AxModelInfo } from '../types.js';
+
+import { axModelInfoLiteLLM } from './info.js';
+import type { AxAILiteLLMModel } from './types.js';
+
+type LiteLLMConfig = AxAIOpenAIConfig<AxAILiteLLMModel, AxAILiteLLMModel>;
+
+export const axAILiteLLMDefaultConfig = (): LiteLLMConfig =>
+  structuredClone({
+    model: 'gpt-4o-mini' as AxAILiteLLMModel,
+    ...axBaseAIDefaultConfig(),
+  });
+
+export const axAILiteLLMCreativeConfig = (): LiteLLMConfig =>
+  structuredClone({
+    model: 'gpt-4o-mini' as AxAILiteLLMModel,
+    ...axBaseAIDefaultCreativeConfig(),
+  });
+
+const axAILiteLLMSupportFor = (_model: AxAILiteLLMModel): AxAIFeatures => ({
+  functions: true,
+  streaming: true,
+  hasThinkingBudget: false,
+  hasShowThoughts: false,
+  media: {
+    images: {
+      supported: true,
+      formats: ['image/jpeg', 'image/png', 'image/gif', 'image/webp'],
+    },
+    audio: {
+      supported: false,
+      formats: [],
+    },
+    files: {
+      supported: false,
+      formats: [],
+      uploadMethod: 'none' as const,
+    },
+    urls: {
+      supported: false,
+      webSearch: false,
+      contextFetching: false,
+    },
+  },
+  caching: {
+    supported: false,
+    types: [],
+  },
+  thinking: false,
+  multiTurn: true,
+});
+
+/**
+ * Arguments type for initializing LiteLLM AI instances.
+ * Requires `apiURL` pointing to a running LiteLLM proxy.
+ */
+export type AxAILiteLLMArgs<TModelKey> = AxAIOpenAIArgs<
+  'litellm',
+  AxAILiteLLMModel,
+  AxAILiteLLMModel,
+  TModelKey
+>;
+
+/**
+ * LiteLLM AI gateway provider.
+ *
+ * Connects to a self-hosted LiteLLM proxy that provides a unified
+ * OpenAI-compatible API across 100+ LLM providers (Anthropic, Gemini,
+ * Bedrock, Azure, Ollama, etc.).
+ *
+ * @example
+ * ```typescript
+ * const ai = new AxAILiteLLM({
+ *   apiKey: process.env.LITELLM_API_KEY,
+ *   apiURL: 'http://localhost:4000/v1',
+ *   config: { model: 'anthropic/claude-sonnet-4-20250514' },
+ * });
+ * ```
+ */
+export class AxAILiteLLM<TModelKey = string> extends AxAIOpenAIBase<
+  AxAILiteLLMModel,
+  AxAILiteLLMModel,
+  TModelKey
+> {
+  constructor({
+    apiKey,
+    apiURL,
+    config,
+    options,
+    models,
+    modelInfo,
+  }: Readonly<Omit<AxAILiteLLMArgs<TModelKey>, 'name'>>) {
+    if (!apiKey || apiKey === '') {
+      throw new Error('LiteLLM API key not set');
+    }
+    if (!apiURL || apiURL === '') {
+      throw new Error(
+        'LiteLLM API URL not set (set apiURL to your LiteLLM proxy, e.g. http://localhost:4000/v1)'
+      );
+    }
+
+    const _config: LiteLLMConfig = {
+      ...axAILiteLLMDefaultConfig(),
+      ...config,
+    };
+
+    modelInfo = [...axModelInfoLiteLLM, ...(modelInfo ?? [])];
+
+    super({
+      apiKey,
+      apiURL,
+      config: _config,
+      options,
+      modelInfo,
+      supportFor: axAILiteLLMSupportFor,
+      models,
+    });
+
+    super.setName('LiteLLM');
+  }
+
+  async fetchModelList(
+    options?: Readonly<AxAIServiceOptions>
+  ): Promise<AxModelInfo[]> {
+    const url = `${this.openAICompatibleApiURL}/models`;
+    const fetchFn = options?.fetch ?? globalThis.fetch;
+    const res = await fetchFn(url, {
+      headers: { Authorization: `Bearer ${this.openAICompatibleApiKey}` },
+    });
+    if (!res.ok) {
+      return [];
+    }
+    const json = (await res.json()) as {
+      data?: { id: string }[];
+    };
+    return (json.data ?? []).map((m) => ({ name: m.id }));
+  }
+}

--- a/src/ax/ai/litellm/info.ts
+++ b/src/ax/ai/litellm/info.ts
@@ -1,0 +1,8 @@
+import type { AxModelInfo } from '../types.js';
+
+/**
+ * LiteLLM model info is empty by default since models are dynamic
+ * and depend on the proxy configuration. Users can pass custom
+ * modelInfo via the constructor to enable cost tracking.
+ */
+export const axModelInfoLiteLLM: AxModelInfo[] = [];

--- a/src/ax/ai/litellm/types.ts
+++ b/src/ax/ai/litellm/types.ts
@@ -1,0 +1,5 @@
+/**
+ * LiteLLM: Model type is a plain string since models are dynamic
+ * (determined by the LiteLLM proxy configuration).
+ */
+export type AxAILiteLLMModel = string;

--- a/src/ax/ai/wrap.ts
+++ b/src/ax/ai/wrap.ts
@@ -24,6 +24,8 @@ import {
   type AxAIHuggingFaceArgs,
 } from './huggingface/api.js';
 import type { AxAIHuggingFaceModel } from './huggingface/types.js';
+import { AxAILiteLLM, type AxAILiteLLMArgs } from './litellm/api.js';
+import type { AxAILiteLLMModel } from './litellm/types.js';
 import { AxAIMistral, type AxAIMistralArgs } from './mistral/api.js';
 import type { AxAIMistralModel } from './mistral/types.js';
 import { AxAIOpenAI, type AxAIOpenAIArgs } from './openai/api.js';
@@ -72,7 +74,8 @@ export type AxAIArgs<TModelKey> =
   | AxAIMistralArgs<TModelKey>
   | AxAIDeepSeekArgs<TModelKey>
   | AxAIRekaArgs<TModelKey>
-  | AxAIGrokArgs<TModelKey>;
+  | AxAIGrokArgs<TModelKey>
+  | AxAILiteLLMArgs<TModelKey>;
 
 export type AxAIModels =
   | AxAIOpenAIModel
@@ -229,6 +232,9 @@ export class AxAI<TModelKey = string>
         break;
       case 'reka':
         this.ai = new AxAIReka<TModelKey>(options);
+        break;
+      case 'litellm':
+        this.ai = new AxAILiteLLM<TModelKey>(options);
         break;
       default:
         throw new Error('Unknown AI');

--- a/src/ax/index.ts
+++ b/src/ax/index.ts
@@ -338,6 +338,14 @@ import {
   type AxAIHuggingFaceRequest,
   type AxAIHuggingFaceResponse,
 } from './ai/huggingface/types.js';
+import {
+  AxAILiteLLM,
+  type AxAILiteLLMArgs,
+  axAILiteLLMCreativeConfig,
+  axAILiteLLMDefaultConfig,
+} from './ai/litellm/api.js';
+import { axModelInfoLiteLLM } from './ai/litellm/info.js';
+import type { AxAILiteLLMModel } from './ai/litellm/types.js';
 import type { AxAIMetricsInstruments } from './ai/metrics.js';
 import {
   AxAIMistral,
@@ -909,6 +917,7 @@ export { AxAIGrokEmbedModels };
 export { AxAIGrokModel };
 export { AxAIHuggingFace };
 export { AxAIHuggingFaceModel };
+export { AxAILiteLLM };
 export { AxAIMistral };
 export { AxAIMistralEmbedModels };
 export { AxAIMistralModel };
@@ -998,6 +1007,8 @@ export { axAIGrokDefaultConfig };
 export { axAIGrokVoiceDefaultConfig };
 export { axAIHuggingFaceCreativeConfig };
 export { axAIHuggingFaceDefaultConfig };
+export { axAILiteLLMCreativeConfig };
+export { axAILiteLLMDefaultConfig };
 export { axAIMistralBestConfig };
 export { axAIMistralDefaultConfig };
 export { axAIOpenAIAudioDefaultConfig };
@@ -1070,6 +1081,7 @@ export { axModelInfoDeepSeek };
 export { axModelInfoGoogleGemini };
 export { axModelInfoGrok };
 export { axModelInfoHuggingFace };
+export { axModelInfoLiteLLM };
 export { axModelInfoMistral };
 export { axModelInfoOpenAI };
 export { axModelInfoOpenAIResponses };
@@ -1184,6 +1196,8 @@ export type { AxAIHuggingFaceConfig };
 export type { AxAIHuggingFaceRequest };
 export type { AxAIHuggingFaceResponse };
 export type { AxAIInputModelList };
+export type { AxAILiteLLMArgs };
+export type { AxAILiteLLMModel };
 export type { AxAIMemory };
 export type { AxAIMetricsInstruments };
 export type { AxAIMistralArgs };


### PR DESCRIPTION
- **What kind of change does this PR introduce?** Feature - adds LiteLLM as a new AI provider

- **What is the current behavior?** Ax supports 11 built-in providers (OpenAI, Anthropic, Gemini, etc.). Users wanting to route through a unified AI gateway or access providers not natively supported must use the generic OpenAI provider with a custom `apiURL`.

- **What is the new behavior (if this is a feature change)?**

Adds `'litellm'` as a first-class provider in the `ai()` factory. [LiteLLM](https://github.com/BerriAI/litellm) is a self-hosted proxy that provides a unified OpenAI-compatible API across 100+ LLM providers (Anthropic, Gemini, Bedrock, Azure, Ollama, etc.). The new provider:

- Extends `AxAIOpenAIBase` (same pattern as DeepSeek, Grok)
- Requires `apiURL` pointing to a running LiteLLM proxy
- Marked `isDynamic: true` in catalog since available models depend on proxy config
- Includes `fetchModelList()` to auto-discover models via `/v1/models`
- 8 unit tests, catalog tests updated, build passes, biome clean

```typescript
import { ai } from '@ax-llm/ax';

const llm = ai({
  name: 'litellm',
  apiKey: process.env.LITELLM_API_KEY!,
  apiURL: 'http://localhost:4000/v1',
  config: { model: 'anthropic/claude-sonnet-4-20250514' },
});

const response = await llm.chat({
  chatPrompt: [{ role: 'user', content: 'What is 2+2?' }],
});
```

- **AxIR portable behavior check**: axir-no-impact - adds a new provider under `src/ax/ai/litellm/` using existing `AxAIOpenAIBase`. No portable behavior changes.

- **Other information**:

```text
$ npx vitest run src/ax/ai/litellm/api.test.ts src/ax/ai/catalog.test.ts
 ✓ src/ax/ai/catalog.test.ts (7 tests) 12ms
 ✓ src/ax/ai/litellm/api.test.ts (8 tests) 13ms
   ✓ throws when apiKey is missing
   ✓ throws when apiURL is missing
   ✓ constructs with valid args
   ✓ sends chat request and parses response correctly
   ✓ returns default config
   ✓ fetchModelList calls proxy /models endpoint
   ✓ fetchModelList returns empty array on error
   ✓ accepts custom modelInfo for cost tracking
 15 passed

$ npm run build --workspace=@ax-llm/ax -> success
$ npx biome lint src/ax/ai/litellm/ -> 4 files, no issues
```

Live E2E against a real LiteLLM proxy (routing to Claude via Azure Foundry):

```text
$ litellm --config litellm-config.yaml --port 4000
# proxy healthy, 1 model configured

$ npx tsx test-ax-live.mts
Models from proxy: [ 'anthropic/claude-sonnet-4-6' ]
content: OK
finishReason: stop
modelUsage: {
  ai: 'LiteLLM',
  model: 'anthropic/claude-sonnet-4-6',
  tokens: { promptTokens: 13, completionTokens: 4, totalTokens: 17 }
}
```

Files created: `src/ax/ai/litellm/{api.ts, info.ts, types.ts, api.test.ts}`
Files modified: `src/ax/ai/wrap.ts`, `src/ax/ai/catalog.ts`, `src/ax/ai/catalog.test.ts`, `src/ax/index.ts`

Additive only. No existing providers modified. Zero new dependencies.
