### PR TITLE
Guard package global bundle export in postbuild

### DIFF
--- a/scripts/postbuild.js
+++ b/scripts/postbuild.js
@@ -40,13 +40,16 @@ packageJson.exports = {
     import: './index.js',
     require: './index.cjs',
   },
-  './index.global.js': './index.global.js',
   './*': {
     types: './*.d.ts',
     import: './*.js',
     require: './*.cjs',
   },
 };
+
+if (existsSync(path.join(buildPath, 'index.global.js'))) {
+  packageJson.exports['./index.global.js'] = './index.global.js';
+}
 
 // Remove devDependencies and scripts
 delete packageJson.devDependencies;

--- a/scripts/postbuild.test.js
+++ b/scripts/postbuild.test.js
@@ -80,4 +80,33 @@ describe('Postbuild Script', () => {
     expect(generatedPackageJson.devDependencies).toBeUndefined();
     expect(generatedPackageJson.scripts).toBeUndefined();
   });
+
+  it('should omit the global bundle export when no global bundle exists', async () => {
+    const postbuildPath = path.join(__dirname, 'postbuild.js');
+    const { execSync } = await import('node:child_process');
+
+    execSync(`node ${postbuildPath}`, { cwd: testDir });
+
+    const generatedPackageJson = JSON.parse(
+      readFileSync(path.join(testDir, 'dist', 'package.json'), 'utf8')
+    );
+
+    expect(generatedPackageJson.exports['./index.global.js']).toBeUndefined();
+  });
+
+  it('should keep the global bundle export when the global bundle exists', async () => {
+    const postbuildPath = path.join(__dirname, 'postbuild.js');
+    const { execSync } = await import('node:child_process');
+
+    writeFileSync(path.join(testDir, 'dist', 'index.global.js'), '');
+    execSync(`node ${postbuildPath}`, { cwd: testDir });
+
+    const generatedPackageJson = JSON.parse(
+      readFileSync(path.join(testDir, 'dist', 'package.json'), 'utf8')
+    );
+
+    expect(generatedPackageJson.exports['./index.global.js']).toBe(
+      './index.global.js'
+    );
+  });
 });


### PR DESCRIPTION
## Summary
- only publish the `./index.global.js` subpath export when the built package actually contains `dist/index.global.js`
- add postbuild coverage for packages with and without a global bundle

Fixes #542.

## Verification
- npx vitest run scripts/postbuild.test.js
- npm view @ax-llm/ax-ai-sdk-provider@22.0.3 exports shows the published package advertises `./index.global.js`
- postbuild fixture without `dist/index.global.js` now omits the global export
- postbuild fixture with `dist/index.global.js` still keeps the global export