### PR TITLE
fix(bedrock): read Titan embedding dimensions from config

### DIFF
--- a/src/aws-bedrock/api.test.ts
+++ b/src/aws-bedrock/api.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest';
+
+import { AxAIBedrock } from './api.js';
+import type { BedrockTitanEmbedRequest } from './types.js';
+import { AxAIBedrockEmbedModel, AxAIBedrockModel } from './types.js';
+
+// Access the private implementation's request builder without hitting AWS.
+// createEmbedReq only assembles the Titan request body; the AWS SDK call is
+// deferred to the returned apiConfig.localCall, so this needs no credentials.
+async function buildEmbedReq(
+  ai: AxAIBedrock
+): Promise<BedrockTitanEmbedRequest> {
+  const impl = (
+    ai as unknown as {
+      aiImpl: {
+        createEmbedReq: (req: {
+          texts: string[];
+          embedModel: AxAIBedrockEmbedModel;
+        }) => Promise<[unknown, BedrockTitanEmbedRequest]>;
+      };
+    }
+  ).aiImpl;
+  const [, embedRequest] = await impl.createEmbedReq({
+    texts: ['hello world'],
+    embedModel: AxAIBedrockEmbedModel.TitanEmbedV2,
+  });
+  return embedRequest;
+}
+
+describe('AxAIBedrock Titan embeddings dimensions', () => {
+  it('honors config.dimensions when set', async () => {
+    const ai = new AxAIBedrock({
+      config: {
+        model: AxAIBedrockModel.ClaudeSonnet4,
+        embedModel: AxAIBedrockEmbedModel.TitanEmbedV2,
+        dimensions: 1024,
+      },
+    });
+
+    const embedRequest = await buildEmbedReq(ai);
+    expect(embedRequest.dimensions).toBe(1024);
+  });
+
+  it('passes through a non-default supported dimension (256)', async () => {
+    const ai = new AxAIBedrock({
+      config: {
+        model: AxAIBedrockModel.ClaudeSonnet4,
+        embedModel: AxAIBedrockEmbedModel.TitanEmbedV2,
+        dimensions: 256,
+      },
+    });
+
+    const embedRequest = await buildEmbedReq(ai);
+    expect(embedRequest.dimensions).toBe(256);
+  });
+
+  it('omits dimensions when unset so Titan uses its default (1024)', async () => {
+    const ai = new AxAIBedrock({
+      config: {
+        model: AxAIBedrockModel.ClaudeSonnet4,
+        embedModel: AxAIBedrockEmbedModel.TitanEmbedV2,
+      },
+    });
+
+    const embedRequest = await buildEmbedReq(ai);
+    expect(embedRequest.dimensions).toBeUndefined();
+    // JSON.stringify drops undefined, so the wire payload carries no
+    // dimensions field and Titan v2 applies its 1024 default.
+    expect(JSON.parse(JSON.stringify(embedRequest))).not.toHaveProperty(
+      'dimensions'
+    );
+  });
+});

--- a/src/aws-bedrock/api.ts
+++ b/src/aws-bedrock/api.ts
@@ -406,7 +406,7 @@ class AxAIBedrockImpl
 
     const embedRequest: BedrockTitanEmbedRequest = {
       inputText: req.texts[0], // Take first text
-      dimensions: 512,
+      dimensions: this.config.dimensions,
       normalize: true,
     };
 

--- a/src/aws-bedrock/package.json
+++ b/src/aws-bedrock/package.json
@@ -26,6 +26,7 @@
     "clean": "rm -rf dist",
     "test": "run-s test:*",
     "test:type-check": "tsc --noEmit",
+    "test:unit": "vitest run",
     "test:lint": "biome lint .",
     "test:format": "biome format .",
     "fix": "run-s fix:*",

--- a/src/aws-bedrock/types.ts
+++ b/src/aws-bedrock/types.ts
@@ -26,6 +26,7 @@ export enum AxAIBedrockEmbedModel {
 export interface AxAIBedrockConfig extends AxModelConfig {
   model: AxAIBedrockModel;
   embedModel?: AxAIBedrockEmbedModel;
+  dimensions?: number;
   region?: string;
   fallbackRegions?: string[];
   gptRegion?: string;


### PR DESCRIPTION
Thanks for Ax and for maintaining the AWS Bedrock provider! This is a small fix wiring Titan embedding `dimensions` through config, matching the OpenAI provider.

Closes #549

- **What kind of change does this PR introduce?** Bug fix

- **What is the current behavior?**

  `src/aws-bedrock/api.ts` (`createEmbedReq`) hardcodes `dimensions: 512` for every Titan embeddings request, and `AxAIBedrockConfig` has no `dimensions` field. Titan Text Embeddings V2 (`amazon.titan-embed-text-v2:0`, the only model in `AxAIBedrockEmbedModel`) defaults to **1024** dims and also supports 512/256 ([AWS docs](https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters-titan-embed-text.html)). So users always get half-width 512-dim vectors with no way to opt into the model's native 1024 default. See #549.

- **What is the new behavior (if this is a feature change)?**

  Bedrock now reads the embedding dimension from config, exactly like the sibling OpenAI provider (`src/ax/ai/openai/api.ts`: `dimensions: this.config.dimensions`):

  - Add optional `dimensions?: number` to `AxAIBedrockConfig`.
  - Emit `dimensions: this.config.dimensions` instead of `512`. When unset, `JSON.stringify` drops the `undefined` field, so Titan v2 applies its native 1024 default.

  | Item | Before | After |
  |------|--------|-------|
  | `config.dimensions: 1024` | ❌ ignored → sends 512 | ✅ sends 1024 |
  | `config.dimensions: 256` | ❌ ignored → sends 512 | ✅ sends 256 |
  | `config.dimensions` unset | ⚠️ forces 512 | ✅ omitted → Titan v2 default (1024) |
  | Public API / constructor args | — | ✅ unchanged (new field optional) |
  | `normalize: true`, `inputText` behavior | — | ✅ unchanged |
  | Chat / GPT / Claude paths | — | ✅ untouched |

- **AxIR portable behavior check**: `axir-no-impact` — the change is confined to `src/aws-bedrock/` (the `@ax-llm/ax-ai-aws-bedrock` workspace), which is outside `src/ax/ai|dsp|agent|flow`. No portable AxIR behavior changes.

- **Other information**:

  Added a credential-free regression test (`src/aws-bedrock/api.test.ts`) that asserts the request body honors the configured dimension and omits it when unset. (This package had no `test:unit` script, so the test would not have run in CI; added `"test:unit": "vitest run"` to its `package.json`, matching the `src/ax` and `src/tools` workspaces.)

  Local gates (run in `src/aws-bedrock/`):

  ```text
  $ npx vitest run api.test.ts
   ✓ api.test.ts (3 tests) 3ms
   Test Files  1 passed (1)
        Tests  3 passed (3)

  $ npx tsc --noEmit        # ok
  $ npx biome lint .        # Checked 4 files. No fixes applied.
  $ npx biome format .      # Checked 4 files. No fixes applied.
  $ npx tsup                # ESM/CJS/DTS Build success
  ```

  Red/green check — reverting only the source fix (`dimensions: this.config.dimensions` → `512`) while keeping the new test makes it fail, proving it catches the bug:

  ```text
  AssertionError: expected 512 to be undefined
  - Expected: undefined
  + Received: 512
  ```

  Restoring the fix turns it green again.

  **Out of scope (follow-up):** `createEmbedReq` only uses `req.texts[0]` ("Take first text"), dropping the rest of a batch. That looks like a separate bug; I kept this PR minimal and am happy to address it in a follow-up.

---
This contribution was prepared with the help of an AI agent (Claude Code); a human reviewed the change, its rationale, the AWS docs, and the test results before submitting.
