### PR TITLE
Make Go consumable via `go get` + real package-manager install docs

### DIFF
--- a/.github/workflows/package-publish.yml
+++ b/.github/workflows/package-publish.yml
@@ -63,3 +63,37 @@ jobs:
         with:
           packages-dir: packages/python/dist
           skip-existing: true
+
+  java-maven-central:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    env:
+      DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run && 'true' || 'false' }}
+    steps:
+      - uses: actions/checkout@v4
+      # Configures ~/.m2/settings.xml with the `central` server (Portal token) and
+      # imports the GPG signing key the `release` profile in packages/java/pom.xml uses.
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+          server-id: central
+          server-username: MAVEN_CENTRAL_USERNAME
+          server-password: MAVEN_CENTRAL_PASSWORD
+          gpg-private-key: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
+          gpg-passphrase: MAVEN_GPG_PASSPHRASE
+      # Dry run builds + GPG-signs the jars (verify) but stops before upload; a real
+      # release runs `deploy`, which the central-publishing plugin uploads and publishes.
+      - name: Publish dev.axllm:ax to Maven Central
+        working-directory: packages/java
+        env:
+          MAVEN_CENTRAL_USERNAME: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
+          MAVEN_CENTRAL_PASSWORD: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
+          MAVEN_GPG_PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
+        run: |
+          GOAL="deploy"
+          if [ "$DRY_RUN" = "true" ]; then
+            GOAL="verify"
+          fi
+          mvn -B -ntp -Prelease -DskipTests "$GOAL"

--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,8 @@ audio
 .env.*
 .data
 demos.json
+# Scratch consumer demos used to verify package-manager install flows (holds a local .env)
+/demo/
 site/dist
 website/.generated/
 website/public/

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ compiled into verified generated Python, Java, C++, Go, and Rust libraries.
 | Python | `axllm`<br>`from axllm import ai, ax, agent, flow` | Generated and verified in repo; prepared for PyPI |
 | Java | `dev.axllm:ax`<br>`import dev.axllm.ax.*` | Generated and verified in repo; prepared for Maven Central |
 | C++ | `axllm::axllm`<br>`#include <axllm/axllm.hpp>` | Generated and verified in repo; prepared for CMake/GitHub Release |
-| Go | `github.com/ax-llm/ax/go`<br>`import ax "github.com/ax-llm/ax/go"` | Generated in repo with conformance checks and opt-in `runtime/goja` JavaScript actor runtime |
+| Go | `github.com/ax-llm/ax/packages/go`<br>`import ax "github.com/ax-llm/ax/packages/go"` | Generated in repo with conformance checks and opt-in `runtime/goja` JavaScript actor runtime |
 | Rust | `axllm`<br>`use axllm::{ai, ax, agent, flow};` | Generated in repo with conformance checks, blocking HTTP/TLS transport, and protocol-first code runtime |
 
 ```mermaid
@@ -477,8 +477,10 @@ npm install @ax-llm/ax
 Generated Python, Java, C++, Go, and Rust libraries are checked in under `packages/`
 and verified in this repo, all Apache-2.0 licensed.
 
-- **Python**: `pip install axllm` (published to PyPI on each release)
-- **Rust**: `cargo add axllm` (published to crates.io on each release)
+- **Python**: `pip install "axllm @ git+https://github.com/ax-llm/ax#subdirectory=packages/python"`
+  (the clean `pip install axllm` lights up once it's published to PyPI)
+- **Rust**: `cargo add --git https://github.com/ax-llm/ax axllm`
+  (the clean `cargo add axllm` lights up once it's published to crates.io)
 - **Go**: `go get github.com/ax-llm/ax/packages/go`
 - **Java**: consume `packages/java` from the repo (Maven coordinates
   `dev.axllm:ax`; build with the included `pom.xml`, or use JitPack against

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -9,11 +9,14 @@
     "ignoreUnknown": false,
     // AxIR data blobs and embedded template sources must stay byte-identical
     // to their original embedded form; formatting them changes the generated
-    // packages.
+    // packages. The generated packages/ output itself must likewise match the
+    // emitter byte-for-byte (the AxIR Package Freshness gate regenerates and
+    // diffs it), so biome must not reformat it either.
     "includes": [
       "**",
       "!ir/axcore/data/**",
-      "!tools/axir/internal/axir/templates/**"
+      "!tools/axir/internal/axir/templates/**",
+      "!packages/**"
     ]
   },
   "formatter": {

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -182,7 +182,7 @@ source-to-source transpiler. The compiler emits:
 - Python package `axllm`
 - Java package `dev.axllm.ax`
 - C++ namespace `axllm` and CMake target `axllm::axllm`
-- Go module `github.com/ax-llm/ax/go` and package `axllm`
+- Go module `github.com/ax-llm/ax/packages/go` and package `axllm`
 - Rust crate `axllm`
 
 Generated libraries include package metadata, examples, capability manifests,

--- a/docs/COMPILER.md
+++ b/docs/COMPILER.md
@@ -113,7 +113,7 @@ AxIR emits libraries, not one-off programs:
 - C++: namespace `axllm`, C++17, `axllm/axllm.hpp` plus
   `axllm/axllm.cpp`, CMake target `axllm::axllm`, and optional QuickJS
   sources outside the default build.
-- Go: module `github.com/ax-llm/ax/go`, package `axllm`, Go 1.22+,
+- Go: module `github.com/ax-llm/ax/packages/go`, package `axllm`, Go 1.22+,
   `context.Context` on execution/client boundaries, standard `net/http`
   transport, and an opt-in generated `runtime/goja` package for built-in
   JavaScript actor execution.
@@ -184,7 +184,7 @@ AxAgent. Generated runtime profiles are portability proofs behind the same
   process/protocol boundary.
 - `javascript-goja`: Go-native JavaScript actor code runs through the generated
   `runtime/goja` package. The root Go package stays vendor-neutral; users opt
-  in by importing `github.com/ax-llm/ax/go/runtime/goja`.
+  in by importing `github.com/ax-llm/ax/packages/go/runtime/goja`.
 - Rust keeps the process JSONL runtime protocol through `ProcessCodeRuntime`.
   The embedded JavaScript profile is additive and feature-gated, so the base
   crate stays dependency-light while the public `AxCodeRuntime` /

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -14,7 +14,7 @@ it is not a package name. The generated package sources are checked in under
 - Python: PyPI distribution and import package `axllm`
 - Java: Maven coordinate `dev.axllm:ax`, Java package `dev.axllm.ax`
 - C++: CMake package `axllm`, target `axllm::axllm`, namespace `axllm`
-- Go: module `github.com/ax-llm/ax/go`, package `axllm`
+- Go: module `github.com/ax-llm/ax/packages/go`, package `axllm`
 - Rust: crate `axllm`
 
 Do not publish generated packages as `axir`, `ax-go`, or other compiler/backend

--- a/packages/cpp/README.md
+++ b/packages/cpp/README.md
@@ -4,11 +4,13 @@ Use Ax from C++ when you want structured LLM programs close to your runtime: sig
 
 ## Quick Start
 
-```bash
-cd packages/cpp
-cmake -S . -B build
-cmake --build build
-./build/signature_schema
+Add Ax to your CMake project with `FetchContent`:
+
+```cmake
+include(FetchContent)
+FetchContent_Declare(axllm GIT_REPOSITORY https://github.com/ax-llm/ax GIT_TAG main SOURCE_SUBDIR packages/cpp)
+FetchContent_MakeAvailable(axllm)
+target_link_libraries(your_app PRIVATE axllm::axllm)
 ```
 
 ```cpp

--- a/packages/go/API.md
+++ b/packages/go/API.md
@@ -5,7 +5,7 @@ This generated API reference is emitted by AxIR from compiler-owned metadata. Do
 ## Package
 
 - Target: `go`
-- Package: `github.com/ax-llm/ax/go`
+- Package: `github.com/ax-llm/ax/packages/go`
 - AxIR contract: `0.1`
 
 ## Signatures

--- a/packages/go/README.md
+++ b/packages/go/README.md
@@ -5,15 +5,13 @@ Write Ax programs in Go with the same contract used by the main Ax library: sign
 ## Quick Start
 
 ```bash
-cd packages/go
-go test ./...
-go run ./examples/signature_schema
+go get github.com/ax-llm/ax/packages/go
 ```
 
 ```go
 package main
 
-import ax "github.com/ax-llm/ax/go"
+import ax "github.com/ax-llm/ax/packages/go"
 
 func main() {
     sig := ax.NewSignature("question:string -> answer:string")
@@ -32,7 +30,7 @@ func main() {
 
 ## Package Shape
 
-- Module: `github.com/ax-llm/ax/go`
+- Module: `github.com/ax-llm/ax/packages/go`
 - Import alias used in examples: `ax`
 - Base package uses the Go standard library for HTTP/process boundaries
 - Optional JavaScript actor execution lives in `runtime/goja` and is opt-in by import
@@ -81,7 +79,7 @@ Optional runtime profiles are dependency-bearing and opt-in. Adapter policy owns
 ## Contract Snapshot
 
 - Compiler contract version: 0.1
-- Package: github.com/ax-llm/ax/go
+- Package: github.com/ax-llm/ax/packages/go
 - Supported conformance suites: signature, schema, validation, prompt, axgen, axai, axagent, axoptimize, axprogram, axflow, axmcp
 - Provider mode: provider-descriptor-registry-openai-compatible-openai-responses-google-gemini-anthropic
 - Scripted transport support: true

--- a/packages/go/axir-api.json
+++ b/packages/go/axir-api.json
@@ -41,7 +41,11 @@
           "kind": "type",
           "description": "Parsed signature with input/output fields, descriptions, and JSON schema helpers.",
           "form": "axllm.AxSignature",
-          "important_options": ["inputs", "outputs", "description"],
+          "important_options": [
+            "inputs",
+            "outputs",
+            "description"
+          ],
           "returns": "signature object"
         }
       ]
@@ -118,7 +122,12 @@
           "kind": "type",
           "description": "OpenAI-compatible chat, stream, embedding, audio, and realtime provider boundary.",
           "form": "axllm.NewOpenAICompatibleClient(options)",
-          "important_options": ["api key", "model", "base URL", "transport"],
+          "important_options": [
+            "api key",
+            "model",
+            "base URL",
+            "transport"
+          ],
           "returns": "provider client"
         },
         {
@@ -128,7 +137,12 @@
           "kind": "type",
           "description": "OpenAI Responses provider mapping using the same Core-owned request and response contract.",
           "form": "axllm.NewOpenAIResponsesClient(options)",
-          "important_options": ["api key", "model", "audio", "realtime"],
+          "important_options": [
+            "api key",
+            "model",
+            "audio",
+            "realtime"
+          ],
           "returns": "provider client"
         },
         {
@@ -138,7 +152,11 @@
           "kind": "type",
           "description": "Gemini provider mapping for chat, streaming, media, tools, embeddings, and usage normalization.",
           "form": "axllm.NewGoogleGeminiClient(options)",
-          "important_options": ["api key", "model", "embed model"],
+          "important_options": [
+            "api key",
+            "model",
+            "embed model"
+          ],
           "returns": "provider client"
         },
         {
@@ -177,7 +195,10 @@
           "kind": "type",
           "description": "Choose a service by capability or model routing policy.",
           "form": "axllm.MultiServiceRouter",
-          "important_options": ["services", "routing"],
+          "important_options": [
+            "services",
+            "routing"
+          ],
           "returns": "AI service"
         },
         {
@@ -187,7 +208,11 @@
           "kind": "type",
           "description": "Route provider requests to registered provider clients.",
           "form": "axllm.ProviderRouter",
-          "important_options": ["providers", "routing", "processing"],
+          "important_options": [
+            "providers",
+            "routing",
+            "processing"
+          ],
           "returns": "AI service"
         }
       ]
@@ -264,7 +289,12 @@
           "kind": "type",
           "description": "Workflow graph with Core-owned planning, cache keys, state merge, child aggregation, optimization, and returns projection.",
           "form": "axllm.NewFlow(options)",
-          "important_options": ["steps", "state", "parallel groups", "returns"],
+          "important_options": [
+            "steps",
+            "state",
+            "parallel groups",
+            "returns"
+          ],
           "returns": "flow program"
         }
       ]
@@ -298,7 +328,11 @@
           "kind": "type",
           "description": "Callable tool descriptor with JSON-schema-compatible parameters and a host handler.",
           "form": "axllm.Tool",
-          "important_options": ["parameters", "returns", "handler"],
+          "important_options": [
+            "parameters",
+            "returns",
+            "handler"
+          ],
           "returns": "tool descriptor"
         }
       ]
@@ -346,7 +380,11 @@
           "kind": "type",
           "description": "Stdio transport with JSON-RPC framing for local MCP servers.",
           "form": "axllm.NewAxMCPStdioTransport(command, options)",
-          "important_options": ["command", "args", "env"],
+          "important_options": [
+            "command",
+            "args",
+            "env"
+          ],
           "returns": "MCP transport"
         }
       ]
@@ -363,7 +401,12 @@
           "kind": "type",
           "description": "Process/JSONL runtime adapter for actor-code sessions and runtime protocol tests.",
           "form": "axllm.NewProcessCodeRuntime(command, env)",
-          "important_options": ["command", "env", "cwd", "timeout"],
+          "important_options": [
+            "command",
+            "env",
+            "cwd",
+            "timeout"
+          ],
           "returns": "AxCodeRuntime",
           "example": "runtime := axllm.NewProcessCodeRuntime([]string{\"node\", \"runtime-server.mjs\"}, nil)"
         },
@@ -390,7 +433,12 @@
           "kind": "type",
           "description": "Actor primitive envelope for final, clarification, discovery, recall, used, guidance, and runtime results.",
           "form": "runtime envelope map",
-          "important_options": ["type", "args", "result", "error"],
+          "important_options": [
+            "type",
+            "args",
+            "result",
+            "error"
+          ],
           "returns": "runtime envelope"
         },
         {
@@ -469,7 +517,10 @@
           "kind": "interface",
           "description": "Optimizer boundary consumed by AxGen, AxAgent, and AxFlow optimization helpers.",
           "form": "OptimizerEngine.Optimize(request, evaluator)",
-          "important_options": ["request", "evaluator"],
+          "important_options": [
+            "request",
+            "evaluator"
+          ],
           "returns": "optimized artifact"
         },
         {
@@ -479,7 +530,11 @@
           "kind": "interface",
           "description": "Evaluator callback boundary used by generated optimizers.",
           "form": "OptimizerEvaluator.Evaluate(request)",
-          "important_options": ["dataset rows", "candidate map", "evidence"],
+          "important_options": [
+            "dataset rows",
+            "candidate map",
+            "evidence"
+          ],
           "returns": "score/evidence result"
         }
       ]

--- a/packages/go/axir-api.json
+++ b/packages/go/axir-api.json
@@ -2,7 +2,7 @@
   "schema_version": "axir-api-v1",
   "axir_version": "0.1",
   "target": "go",
-  "package_name": "github.com/ax-llm/ax/go",
+  "package_name": "github.com/ax-llm/ax/packages/go",
   "sections": [
     {
       "id": "signatures",
@@ -41,11 +41,7 @@
           "kind": "type",
           "description": "Parsed signature with input/output fields, descriptions, and JSON schema helpers.",
           "form": "axllm.AxSignature",
-          "important_options": [
-            "inputs",
-            "outputs",
-            "description"
-          ],
+          "important_options": ["inputs", "outputs", "description"],
           "returns": "signature object"
         }
       ]
@@ -122,12 +118,7 @@
           "kind": "type",
           "description": "OpenAI-compatible chat, stream, embedding, audio, and realtime provider boundary.",
           "form": "axllm.NewOpenAICompatibleClient(options)",
-          "important_options": [
-            "api key",
-            "model",
-            "base URL",
-            "transport"
-          ],
+          "important_options": ["api key", "model", "base URL", "transport"],
           "returns": "provider client"
         },
         {
@@ -137,12 +128,7 @@
           "kind": "type",
           "description": "OpenAI Responses provider mapping using the same Core-owned request and response contract.",
           "form": "axllm.NewOpenAIResponsesClient(options)",
-          "important_options": [
-            "api key",
-            "model",
-            "audio",
-            "realtime"
-          ],
+          "important_options": ["api key", "model", "audio", "realtime"],
           "returns": "provider client"
         },
         {
@@ -152,11 +138,7 @@
           "kind": "type",
           "description": "Gemini provider mapping for chat, streaming, media, tools, embeddings, and usage normalization.",
           "form": "axllm.NewGoogleGeminiClient(options)",
-          "important_options": [
-            "api key",
-            "model",
-            "embed model"
-          ],
+          "important_options": ["api key", "model", "embed model"],
           "returns": "provider client"
         },
         {
@@ -195,10 +177,7 @@
           "kind": "type",
           "description": "Choose a service by capability or model routing policy.",
           "form": "axllm.MultiServiceRouter",
-          "important_options": [
-            "services",
-            "routing"
-          ],
+          "important_options": ["services", "routing"],
           "returns": "AI service"
         },
         {
@@ -208,11 +187,7 @@
           "kind": "type",
           "description": "Route provider requests to registered provider clients.",
           "form": "axllm.ProviderRouter",
-          "important_options": [
-            "providers",
-            "routing",
-            "processing"
-          ],
+          "important_options": ["providers", "routing", "processing"],
           "returns": "AI service"
         }
       ]
@@ -289,12 +264,7 @@
           "kind": "type",
           "description": "Workflow graph with Core-owned planning, cache keys, state merge, child aggregation, optimization, and returns projection.",
           "form": "axllm.NewFlow(options)",
-          "important_options": [
-            "steps",
-            "state",
-            "parallel groups",
-            "returns"
-          ],
+          "important_options": ["steps", "state", "parallel groups", "returns"],
           "returns": "flow program"
         }
       ]
@@ -328,11 +298,7 @@
           "kind": "type",
           "description": "Callable tool descriptor with JSON-schema-compatible parameters and a host handler.",
           "form": "axllm.Tool",
-          "important_options": [
-            "parameters",
-            "returns",
-            "handler"
-          ],
+          "important_options": ["parameters", "returns", "handler"],
           "returns": "tool descriptor"
         }
       ]
@@ -380,11 +346,7 @@
           "kind": "type",
           "description": "Stdio transport with JSON-RPC framing for local MCP servers.",
           "form": "axllm.NewAxMCPStdioTransport(command, options)",
-          "important_options": [
-            "command",
-            "args",
-            "env"
-          ],
+          "important_options": ["command", "args", "env"],
           "returns": "MCP transport"
         }
       ]
@@ -401,12 +363,7 @@
           "kind": "type",
           "description": "Process/JSONL runtime adapter for actor-code sessions and runtime protocol tests.",
           "form": "axllm.NewProcessCodeRuntime(command, env)",
-          "important_options": [
-            "command",
-            "env",
-            "cwd",
-            "timeout"
-          ],
+          "important_options": ["command", "env", "cwd", "timeout"],
           "returns": "AxCodeRuntime",
           "example": "runtime := axllm.NewProcessCodeRuntime([]string{\"node\", \"runtime-server.mjs\"}, nil)"
         },
@@ -433,12 +390,7 @@
           "kind": "type",
           "description": "Actor primitive envelope for final, clarification, discovery, recall, used, guidance, and runtime results.",
           "form": "runtime envelope map",
-          "important_options": [
-            "type",
-            "args",
-            "result",
-            "error"
-          ],
+          "important_options": ["type", "args", "result", "error"],
           "returns": "runtime envelope"
         },
         {
@@ -517,10 +469,7 @@
           "kind": "interface",
           "description": "Optimizer boundary consumed by AxGen, AxAgent, and AxFlow optimization helpers.",
           "form": "OptimizerEngine.Optimize(request, evaluator)",
-          "important_options": [
-            "request",
-            "evaluator"
-          ],
+          "important_options": ["request", "evaluator"],
           "returns": "optimized artifact"
         },
         {
@@ -530,11 +479,7 @@
           "kind": "interface",
           "description": "Evaluator callback boundary used by generated optimizers.",
           "form": "OptimizerEvaluator.Evaluate(request)",
-          "important_options": [
-            "dataset rows",
-            "candidate map",
-            "evidence"
-          ],
+          "important_options": ["dataset rows", "candidate map", "evidence"],
           "returns": "score/evidence result"
         }
       ]

--- a/packages/go/axir-capabilities.json
+++ b/packages/go/axir-capabilities.json
@@ -1,7 +1,7 @@
 {
   "axir_version": "0.1",
   "target": "go",
-  "package_name": "github.com/ax-llm/ax/go",
+  "package_name": "github.com/ax-llm/ax/packages/go",
   "supported_suites": [
     "signature",
     "schema",

--- a/packages/go/conformance-coverage.json
+++ b/packages/go/conformance-coverage.json
@@ -1,7 +1,7 @@
 {
   "axir_version": "0.1",
   "target": "go",
-  "package_name": "github.com/ax-llm/ax/go",
+  "package_name": "github.com/ax-llm/ax/packages/go",
   "suites": {
     "axagent": [
       {

--- a/packages/go/conformance/main.go
+++ b/packages/go/conformance/main.go
@@ -6,8 +6,8 @@ import (
 	"path/filepath"
 	"strings"
 
-	ax "github.com/ax-llm/ax/go"
-	axgoja "github.com/ax-llm/ax/go/runtime/goja"
+	ax "github.com/ax-llm/ax/packages/go"
+	axgoja "github.com/ax-llm/ax/packages/go/runtime/goja"
 )
 
 func main() {

--- a/packages/go/examples/audio_responses_mapping/main.go
+++ b/packages/go/examples/audio_responses_mapping/main.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	ax "github.com/ax-llm/ax/go"
+	ax "github.com/ax-llm/ax/packages/go"
 )
 
 func main() {

--- a/packages/go/examples/axflow_program_graph/main.go
+++ b/packages/go/examples/axflow_program_graph/main.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	ax "github.com/ax-llm/ax/go"
+	ax "github.com/ax-llm/ax/packages/go"
 )
 
 type scriptedFlowClient struct{}

--- a/packages/go/examples/axgen_openai_api/main.go
+++ b/packages/go/examples/axgen_openai_api/main.go
@@ -7,7 +7,7 @@ import (
 	"os"
 	"time"
 
-	ax "github.com/ax-llm/ax/go"
+	ax "github.com/ax-llm/ax/packages/go"
 )
 
 func main() {

--- a/packages/go/examples/axgen_scripted_client_tool/main.go
+++ b/packages/go/examples/axgen_scripted_client_tool/main.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	ax "github.com/ax-llm/ax/go"
+	ax "github.com/ax-llm/ax/packages/go"
 )
 
 type scriptedClient struct {

--- a/packages/go/examples/flow_openai_api/main.go
+++ b/packages/go/examples/flow_openai_api/main.go
@@ -7,7 +7,7 @@ import (
 	"os"
 	"time"
 
-	ax "github.com/ax-llm/ax/go"
+	ax "github.com/ax-llm/ax/packages/go"
 )
 
 func main() {

--- a/packages/go/examples/gepa_local_optimizer/main.go
+++ b/packages/go/examples/gepa_local_optimizer/main.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"strings"
 
-	ax "github.com/ax-llm/ax/go"
+	ax "github.com/ax-llm/ax/packages/go"
 )
 
 type localEvaluator struct{}

--- a/packages/go/examples/mcp_scripted_tools/main.go
+++ b/packages/go/examples/mcp_scripted_tools/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"fmt"
 
-	ax "github.com/ax-llm/ax/go"
+	ax "github.com/ax-llm/ax/packages/go"
 )
 
 func main() {

--- a/packages/go/examples/optimizer_artifact/main.go
+++ b/packages/go/examples/optimizer_artifact/main.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"strings"
 
-	ax "github.com/ax-llm/ax/go"
+	ax "github.com/ax-llm/ax/packages/go"
 )
 
 type localEvaluator struct{}

--- a/packages/go/examples/provider_mapping_no_key/main.go
+++ b/packages/go/examples/provider_mapping_no_key/main.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	ax "github.com/ax-llm/ax/go"
+	ax "github.com/ax-llm/ax/packages/go"
 )
 
 func main() {

--- a/packages/go/examples/provider_stream_no_key/main.go
+++ b/packages/go/examples/provider_stream_no_key/main.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	ax "github.com/ax-llm/ax/go"
+	ax "github.com/ax-llm/ax/packages/go"
 )
 
 func main() {

--- a/packages/go/examples/realtime_audio_events/main.go
+++ b/packages/go/examples/realtime_audio_events/main.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	ax "github.com/ax-llm/ax/go"
+	ax "github.com/ax-llm/ax/packages/go"
 )
 
 func main() {

--- a/packages/go/examples/runtime_profiles/javascript_goja/main.go
+++ b/packages/go/examples/runtime_profiles/javascript_goja/main.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"strings"
 
-	ax "github.com/ax-llm/ax/go"
-	axgoja "github.com/ax-llm/ax/go/runtime/goja"
+	ax "github.com/ax-llm/ax/packages/go"
+	axgoja "github.com/ax-llm/ax/packages/go/runtime/goja"
 )
 
 func asMap(value ax.Value) map[string]ax.Value {

--- a/packages/go/examples/runtime_protocol/main.go
+++ b/packages/go/examples/runtime_protocol/main.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"os"
 
-	ax "github.com/ax-llm/ax/go"
+	ax "github.com/ax-llm/ax/packages/go"
 )
 
 func main() {

--- a/packages/go/examples/signature_schema/main.go
+++ b/packages/go/examples/signature_schema/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"fmt"
 
-	ax "github.com/ax-llm/ax/go"
+	ax "github.com/ax-llm/ax/packages/go"
 )
 
 func main() {

--- a/packages/go/go.mod
+++ b/packages/go/go.mod
@@ -1,4 +1,4 @@
-module github.com/ax-llm/ax/go
+module github.com/ax-llm/ax/packages/go
 
 go 1.22
 

--- a/packages/go/runtime/goja/goja.go
+++ b/packages/go/runtime/goja/goja.go
@@ -8,7 +8,7 @@ import (
 	"sync"
 	"time"
 
-	ax "github.com/ax-llm/ax/go"
+	ax "github.com/ax-llm/ax/packages/go"
 	gojavm "github.com/dop251/goja"
 )
 

--- a/packages/go/skills/ax-go-agent-memory-skills/SKILL.md
+++ b/packages/go/skills/ax-go-agent-memory-skills/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: "ax-go-agent-memory-skills"
-description: "Use when writing Go code with `github.com/ax-llm/ax/go` for agent memory, recall callbacks, dynamic skill discovery, loaded-skill state, and used-skill tracking."
+description: "Use when writing Go code with `github.com/ax-llm/ax/packages/go` for agent memory, recall callbacks, dynamic skill discovery, loaded-skill state, and used-skill tracking."
 version: "22.0.3"
 ---
 # AxAgent Memory And Skills For Go
 
-This skill helps an agent write Go code with the generated Ax package `github.com/ax-llm/ax/go`. Use the generated package API, examples, and manifests; do not import TypeScript-only APIs unless you are editing the TypeScript package.
+This skill helps an agent write Go code with the generated Ax package `github.com/ax-llm/ax/packages/go`. Use the generated package API, examples, and manifests; do not import TypeScript-only APIs unless you are editing the TypeScript package.
 
 ## When To Use
 
@@ -16,7 +16,7 @@ This skill helps an agent write Go code with the generated Ax package `github.co
 ## Package Facts
 
 - Language: Go.
-- Package: `github.com/ax-llm/ax/go`.
+- Package: `github.com/ax-llm/ax/packages/go`.
 - Package API docs: `API.md` and `axir-api.json`.
 - Capability manifest: `axir-capabilities.json`.
 - Runnable examples: `examples/`.

--- a/packages/go/skills/ax-go-agent-observability/SKILL.md
+++ b/packages/go/skills/ax-go-agent-observability/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: "ax-go-agent-observability"
-description: "Use when writing Go code with `github.com/ax-llm/ax/go` for agent tracing, usage accounting, action logs, runtime diagnostics, replay, and production debugging."
+description: "Use when writing Go code with `github.com/ax-llm/ax/packages/go` for agent tracing, usage accounting, action logs, runtime diagnostics, replay, and production debugging."
 version: "22.0.3"
 ---
 # AxAgent Observability For Go
 
-This skill helps an agent write Go code with the generated Ax package `github.com/ax-llm/ax/go`. Use the generated package API, examples, and manifests; do not import TypeScript-only APIs unless you are editing the TypeScript package.
+This skill helps an agent write Go code with the generated Ax package `github.com/ax-llm/ax/packages/go`. Use the generated package API, examples, and manifests; do not import TypeScript-only APIs unless you are editing the TypeScript package.
 
 ## When To Use
 
@@ -16,7 +16,7 @@ This skill helps an agent write Go code with the generated Ax package `github.co
 ## Package Facts
 
 - Language: Go.
-- Package: `github.com/ax-llm/ax/go`.
+- Package: `github.com/ax-llm/ax/packages/go`.
 - Package API docs: `API.md` and `axir-api.json`.
 - Capability manifest: `axir-capabilities.json`.
 - Runnable examples: `examples/`.

--- a/packages/go/skills/ax-go-agent-optimize/SKILL.md
+++ b/packages/go/skills/ax-go-agent-optimize/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: "ax-go-agent-optimize"
-description: "Use when writing Go code with `github.com/ax-llm/ax/go` for agent optimization, evaluators, judges, optimizer artifacts, BootstrapFewShot, and GEPA."
+description: "Use when writing Go code with `github.com/ax-llm/ax/packages/go` for agent optimization, evaluators, judges, optimizer artifacts, BootstrapFewShot, and GEPA."
 version: "22.0.3"
 ---
 # AxAgent Optimize For Go
 
-This skill helps an agent write Go code with the generated Ax package `github.com/ax-llm/ax/go`. Use the generated package API, examples, and manifests; do not import TypeScript-only APIs unless you are editing the TypeScript package.
+This skill helps an agent write Go code with the generated Ax package `github.com/ax-llm/ax/packages/go`. Use the generated package API, examples, and manifests; do not import TypeScript-only APIs unless you are editing the TypeScript package.
 
 ## When To Use
 
@@ -16,7 +16,7 @@ This skill helps an agent write Go code with the generated Ax package `github.co
 ## Package Facts
 
 - Language: Go.
-- Package: `github.com/ax-llm/ax/go`.
+- Package: `github.com/ax-llm/ax/packages/go`.
 - Package API docs: `API.md` and `axir-api.json`.
 - Capability manifest: `axir-capabilities.json`.
 - Runnable examples: `examples/`.

--- a/packages/go/skills/ax-go-agent-rlm/SKILL.md
+++ b/packages/go/skills/ax-go-agent-rlm/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: "ax-go-agent-rlm"
-description: "Use when writing Go code with `github.com/ax-llm/ax/go` for RLM executor loops, AxCodeRuntime sessions, runtime envelopes, process runtimes, and optional runtime profiles."
+description: "Use when writing Go code with `github.com/ax-llm/ax/packages/go` for RLM executor loops, AxCodeRuntime sessions, runtime envelopes, process runtimes, and optional runtime profiles."
 version: "22.0.3"
 ---
 # AxAgent RLM Runtime For Go
 
-This skill helps an agent write Go code with the generated Ax package `github.com/ax-llm/ax/go`. Use the generated package API, examples, and manifests; do not import TypeScript-only APIs unless you are editing the TypeScript package.
+This skill helps an agent write Go code with the generated Ax package `github.com/ax-llm/ax/packages/go`. Use the generated package API, examples, and manifests; do not import TypeScript-only APIs unless you are editing the TypeScript package.
 
 ## When To Use
 
@@ -16,7 +16,7 @@ This skill helps an agent write Go code with the generated Ax package `github.co
 ## Package Facts
 
 - Language: Go.
-- Package: `github.com/ax-llm/ax/go`.
+- Package: `github.com/ax-llm/ax/packages/go`.
 - Package API docs: `API.md` and `axir-api.json`.
 - Capability manifest: `axir-capabilities.json`.
 - Runnable examples: `examples/`.

--- a/packages/go/skills/ax-go-agent/SKILL.md
+++ b/packages/go/skills/ax-go-agent/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: "ax-go-agent"
-description: "Use when writing Go code with `github.com/ax-llm/ax/go` for agents, child delegation, tools, MCP, clarification, runtime state, and final typed responses."
+description: "Use when writing Go code with `github.com/ax-llm/ax/packages/go` for agents, child delegation, tools, MCP, clarification, runtime state, and final typed responses."
 version: "22.0.3"
 ---
 # AxAgent For Go
 
-This skill helps an agent write Go code with the generated Ax package `github.com/ax-llm/ax/go`. Use the generated package API, examples, and manifests; do not import TypeScript-only APIs unless you are editing the TypeScript package.
+This skill helps an agent write Go code with the generated Ax package `github.com/ax-llm/ax/packages/go`. Use the generated package API, examples, and manifests; do not import TypeScript-only APIs unless you are editing the TypeScript package.
 
 ## When To Use
 
@@ -16,7 +16,7 @@ This skill helps an agent write Go code with the generated Ax package `github.co
 ## Package Facts
 
 - Language: Go.
-- Package: `github.com/ax-llm/ax/go`.
+- Package: `github.com/ax-llm/ax/packages/go`.
 - Package API docs: `API.md` and `axir-api.json`.
 - Capability manifest: `axir-capabilities.json`.
 - Runnable examples: `examples/`.

--- a/packages/go/skills/ax-go-ai/SKILL.md
+++ b/packages/go/skills/ax-go-ai/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: "ax-go-ai"
-description: "Use when writing Go code with `github.com/ax-llm/ax/go` for provider clients, model selection, OpenAI-compatible calls, Responses, Gemini, Anthropic, routers, and balancers."
+description: "Use when writing Go code with `github.com/ax-llm/ax/packages/go` for provider clients, model selection, OpenAI-compatible calls, Responses, Gemini, Anthropic, routers, and balancers."
 version: "22.0.3"
 ---
 # AxAI Providers For Go
 
-This skill helps an agent write Go code with the generated Ax package `github.com/ax-llm/ax/go`. Use the generated package API, examples, and manifests; do not import TypeScript-only APIs unless you are editing the TypeScript package.
+This skill helps an agent write Go code with the generated Ax package `github.com/ax-llm/ax/packages/go`. Use the generated package API, examples, and manifests; do not import TypeScript-only APIs unless you are editing the TypeScript package.
 
 ## When To Use
 
@@ -16,7 +16,7 @@ This skill helps an agent write Go code with the generated Ax package `github.co
 ## Package Facts
 
 - Language: Go.
-- Package: `github.com/ax-llm/ax/go`.
+- Package: `github.com/ax-llm/ax/packages/go`.
 - Package API docs: `API.md` and `axir-api.json`.
 - Capability manifest: `axir-capabilities.json`.
 - Runnable examples: `examples/`.
@@ -27,7 +27,7 @@ This skill helps an agent write Go code with the generated Ax package `github.co
 ## Core Pattern
 
 ```go
-import ax "github.com/ax-llm/ax/go"
+import ax "github.com/ax-llm/ax/packages/go"
 
 llm := ax.NewAI("openai", map[string]ax.Value{"apiKey": os.Getenv("OPENAI_API_KEY")})
 ```

--- a/packages/go/skills/ax-go-audio/SKILL.md
+++ b/packages/go/skills/ax-go-audio/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: "ax-go-audio"
-description: "Use when writing Go code with `github.com/ax-llm/ax/go` for audio input/output, OpenAI Responses audio mapping, realtime event folding, and generated package audio examples."
+description: "Use when writing Go code with `github.com/ax-llm/ax/packages/go` for audio input/output, OpenAI Responses audio mapping, realtime event folding, and generated package audio examples."
 version: "22.0.3"
 ---
 # Ax Audio And Realtime For Go
 
-This skill helps an agent write Go code with the generated Ax package `github.com/ax-llm/ax/go`. Use the generated package API, examples, and manifests; do not import TypeScript-only APIs unless you are editing the TypeScript package.
+This skill helps an agent write Go code with the generated Ax package `github.com/ax-llm/ax/packages/go`. Use the generated package API, examples, and manifests; do not import TypeScript-only APIs unless you are editing the TypeScript package.
 
 ## When To Use
 
@@ -16,7 +16,7 @@ This skill helps an agent write Go code with the generated Ax package `github.co
 ## Package Facts
 
 - Language: Go.
-- Package: `github.com/ax-llm/ax/go`.
+- Package: `github.com/ax-llm/ax/packages/go`.
 - Package API docs: `API.md` and `axir-api.json`.
 - Capability manifest: `axir-capabilities.json`.
 - Runnable examples: `examples/`.
@@ -27,7 +27,7 @@ This skill helps an agent write Go code with the generated Ax package `github.co
 ## Core Pattern
 
 ```go
-import ax "github.com/ax-llm/ax/go"
+import ax "github.com/ax-llm/ax/packages/go"
 
 llm := ax.NewAI("openai", map[string]ax.Value{"apiKey": os.Getenv("OPENAI_API_KEY")})
 ```

--- a/packages/go/skills/ax-go-flow/SKILL.md
+++ b/packages/go/skills/ax-go-flow/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: "ax-go-flow"
-description: "Use when writing Go code with `github.com/ax-llm/ax/go` for flows, nodes, program graphs, nested programs, dynamic options, caching, and optimizer components."
+description: "Use when writing Go code with `github.com/ax-llm/ax/packages/go` for flows, nodes, program graphs, nested programs, dynamic options, caching, and optimizer components."
 version: "22.0.3"
 ---
 # AxFlow For Go
 
-This skill helps an agent write Go code with the generated Ax package `github.com/ax-llm/ax/go`. Use the generated package API, examples, and manifests; do not import TypeScript-only APIs unless you are editing the TypeScript package.
+This skill helps an agent write Go code with the generated Ax package `github.com/ax-llm/ax/packages/go`. Use the generated package API, examples, and manifests; do not import TypeScript-only APIs unless you are editing the TypeScript package.
 
 ## When To Use
 
@@ -16,7 +16,7 @@ This skill helps an agent write Go code with the generated Ax package `github.co
 ## Package Facts
 
 - Language: Go.
-- Package: `github.com/ax-llm/ax/go`.
+- Package: `github.com/ax-llm/ax/packages/go`.
 - Package API docs: `API.md` and `axir-api.json`.
 - Capability manifest: `axir-capabilities.json`.
 - Runnable examples: `examples/`.

--- a/packages/go/skills/ax-go-gen/SKILL.md
+++ b/packages/go/skills/ax-go-gen/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: "ax-go-gen"
-description: "Use when writing Go code with `github.com/ax-llm/ax/go` for AxGen programs, forward calls, streaming, tools, assertions, traces, usage, and output parsing."
+description: "Use when writing Go code with `github.com/ax-llm/ax/packages/go` for AxGen programs, forward calls, streaming, tools, assertions, traces, usage, and output parsing."
 version: "22.0.3"
 ---
 # AxGen Structured Generation For Go
 
-This skill helps an agent write Go code with the generated Ax package `github.com/ax-llm/ax/go`. Use the generated package API, examples, and manifests; do not import TypeScript-only APIs unless you are editing the TypeScript package.
+This skill helps an agent write Go code with the generated Ax package `github.com/ax-llm/ax/packages/go`. Use the generated package API, examples, and manifests; do not import TypeScript-only APIs unless you are editing the TypeScript package.
 
 ## When To Use
 
@@ -16,7 +16,7 @@ This skill helps an agent write Go code with the generated Ax package `github.co
 ## Package Facts
 
 - Language: Go.
-- Package: `github.com/ax-llm/ax/go`.
+- Package: `github.com/ax-llm/ax/packages/go`.
 - Package API docs: `API.md` and `axir-api.json`.
 - Capability manifest: `axir-capabilities.json`.
 - Runnable examples: `examples/`.

--- a/packages/go/skills/ax-go-gepa/SKILL.md
+++ b/packages/go/skills/ax-go-gepa/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: "ax-go-gepa"
-description: "Use when writing Go code with `github.com/ax-llm/ax/go` for GEPA, Pareto tradeoffs, reflection clients, metric budgets, optimizer state, and artifacts."
+description: "Use when writing Go code with `github.com/ax-llm/ax/packages/go` for GEPA, Pareto tradeoffs, reflection clients, metric budgets, optimizer state, and artifacts."
 version: "22.0.3"
 ---
 # Ax GEPA For Go
 
-This skill helps an agent write Go code with the generated Ax package `github.com/ax-llm/ax/go`. Use the generated package API, examples, and manifests; do not import TypeScript-only APIs unless you are editing the TypeScript package.
+This skill helps an agent write Go code with the generated Ax package `github.com/ax-llm/ax/packages/go`. Use the generated package API, examples, and manifests; do not import TypeScript-only APIs unless you are editing the TypeScript package.
 
 ## When To Use
 
@@ -16,7 +16,7 @@ This skill helps an agent write Go code with the generated Ax package `github.co
 ## Package Facts
 
 - Language: Go.
-- Package: `github.com/ax-llm/ax/go`.
+- Package: `github.com/ax-llm/ax/packages/go`.
 - Package API docs: `API.md` and `axir-api.json`.
 - Capability manifest: `axir-capabilities.json`.
 - Runnable examples: `examples/`.

--- a/packages/go/skills/ax-go-llm/SKILL.md
+++ b/packages/go/skills/ax-go-llm/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: "ax-go-llm"
-description: "Use when writing Go code with `github.com/ax-llm/ax/go` for using the generated Ax package, factory functions, package docs, examples, and API reference."
+description: "Use when writing Go code with `github.com/ax-llm/ax/packages/go` for using the generated Ax package, factory functions, package docs, examples, and API reference."
 version: "22.0.3"
 ---
 # Ax LLM Quick Reference For Go
 
-This skill helps an agent write Go code with the generated Ax package `github.com/ax-llm/ax/go`. Use the generated package API, examples, and manifests; do not import TypeScript-only APIs unless you are editing the TypeScript package.
+This skill helps an agent write Go code with the generated Ax package `github.com/ax-llm/ax/packages/go`. Use the generated package API, examples, and manifests; do not import TypeScript-only APIs unless you are editing the TypeScript package.
 
 ## When To Use
 
@@ -16,7 +16,7 @@ This skill helps an agent write Go code with the generated Ax package `github.co
 ## Package Facts
 
 - Language: Go.
-- Package: `github.com/ax-llm/ax/go`.
+- Package: `github.com/ax-llm/ax/packages/go`.
 - Package API docs: `API.md` and `axir-api.json`.
 - Capability manifest: `axir-capabilities.json`.
 - Runnable examples: `examples/`.
@@ -27,7 +27,7 @@ This skill helps an agent write Go code with the generated Ax package `github.co
 ## Core Pattern
 
 ```go
-import ax "github.com/ax-llm/ax/go"
+import ax "github.com/ax-llm/ax/packages/go"
 
 llm := ax.NewAI("openai", map[string]ax.Value{"apiKey": os.Getenv("OPENAI_API_KEY")})
 ```

--- a/packages/go/skills/ax-go-refine/SKILL.md
+++ b/packages/go/skills/ax-go-refine/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: "ax-go-refine"
-description: "Use when writing Go code with `github.com/ax-llm/ax/go` for reward-scored generation, iterative candidate improvement, evaluator feedback, and optimizer-backed refinement patterns."
+description: "Use when writing Go code with `github.com/ax-llm/ax/packages/go` for reward-scored generation, iterative candidate improvement, evaluator feedback, and optimizer-backed refinement patterns."
 version: "22.0.3"
 ---
 # Ax Refinement Patterns For Go
 
-This skill helps an agent write Go code with the generated Ax package `github.com/ax-llm/ax/go`. Use the generated package API, examples, and manifests; do not import TypeScript-only APIs unless you are editing the TypeScript package.
+This skill helps an agent write Go code with the generated Ax package `github.com/ax-llm/ax/packages/go`. Use the generated package API, examples, and manifests; do not import TypeScript-only APIs unless you are editing the TypeScript package.
 
 ## When To Use
 
@@ -16,7 +16,7 @@ This skill helps an agent write Go code with the generated Ax package `github.co
 ## Package Facts
 
 - Language: Go.
-- Package: `github.com/ax-llm/ax/go`.
+- Package: `github.com/ax-llm/ax/packages/go`.
 - Package API docs: `API.md` and `axir-api.json`.
 - Capability manifest: `axir-capabilities.json`.
 - Runnable examples: `examples/`.

--- a/packages/go/skills/ax-go-signature/SKILL.md
+++ b/packages/go/skills/ax-go-signature/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: "ax-go-signature"
-description: "Use when writing Go code with `github.com/ax-llm/ax/go` for string signatures, field descriptors, JSON schema output, validation, and typed tool argument shapes."
+description: "Use when writing Go code with `github.com/ax-llm/ax/packages/go` for string signatures, field descriptors, JSON schema output, validation, and typed tool argument shapes."
 version: "22.0.3"
 ---
 # Ax Signatures For Go
 
-This skill helps an agent write Go code with the generated Ax package `github.com/ax-llm/ax/go`. Use the generated package API, examples, and manifests; do not import TypeScript-only APIs unless you are editing the TypeScript package.
+This skill helps an agent write Go code with the generated Ax package `github.com/ax-llm/ax/packages/go`. Use the generated package API, examples, and manifests; do not import TypeScript-only APIs unless you are editing the TypeScript package.
 
 ## When To Use
 
@@ -16,7 +16,7 @@ This skill helps an agent write Go code with the generated Ax package `github.co
 ## Package Facts
 
 - Language: Go.
-- Package: `github.com/ax-llm/ax/go`.
+- Package: `github.com/ax-llm/ax/packages/go`.
 - Package API docs: `API.md` and `axir-api.json`.
 - Capability manifest: `axir-capabilities.json`.
 - Runnable examples: `examples/`.
@@ -27,7 +27,7 @@ This skill helps an agent write Go code with the generated Ax package `github.co
 ## Core Pattern
 
 ```go
-import ax "github.com/ax-llm/ax/go"
+import ax "github.com/ax-llm/ax/packages/go"
 
 sig := ax.NewSignature("question:string -> answer:string")
 schema := sig.ToJSONSchema(nil)

--- a/packages/java/README.md
+++ b/packages/java/README.md
@@ -4,11 +4,15 @@ Bring Ax into Java services and JVM applications with a small native API: signat
 
 ## Quick Start
 
+Maven and Gradle cannot depend on a git repository directly, so build and
+install the package to your local Maven repository until it is published to
+Maven Central:
+
 ```bash
-cd packages/java
-javac -cp . dev/axllm/ax/*.java examples/SignatureSchemaExample.java
-java -cp .:examples SignatureSchemaExample
+git clone https://github.com/ax-llm/ax && (cd ax/packages/java && mvn -q install)
 ```
+
+Then add the dependency `dev.axllm:ax:22.0.3` to your `pom.xml` or `build.gradle`.
 
 ```java
 import dev.axllm.ax.*;

--- a/packages/java/pom.xml
+++ b/packages/java/pom.xml
@@ -16,8 +16,17 @@
   <scm>
     <url>https://github.com/ax-llm/ax</url>
     <connection>scm:git:https://github.com/ax-llm/ax.git</connection>
+    <developerConnection>scm:git:https://github.com/ax-llm/ax.git</developerConnection>
   </scm>
   <description>Generated Ax runtime library.</description>
+
+  <developers>
+    <developer>
+      <id>ax-llm</id>
+      <name>Ax</name>
+      <url>https://github.com/ax-llm/ax</url>
+    </developer>
+  </developers>
 
   <properties>
     <maven.compiler.release>17</maven.compiler.release>
@@ -53,4 +62,94 @@
       </plugin>
     </plugins>
   </build>
+
+  <!--
+    `release` profile: builds the sources + javadoc jars, GPG-signs every
+    artifact, and publishes to the Maven Central Portal. Kept out of the default
+    build so a plain `mvn install` (repo runner / local consumer) needs no GPG key.
+    CI activates it with `mvn -Prelease deploy` (see .github/workflows/package-publish.yml).
+  -->
+  <profiles>
+    <profile>
+      <id>release</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-source-plugin</artifactId>
+            <version>3.3.1</version>
+            <executions>
+              <execution>
+                <id>attach-sources</id>
+                <goals>
+                  <goal>jar-no-fork</goal>
+                </goals>
+              </execution>
+            </executions>
+            <configuration>
+              <includes>
+                <include>dev/axllm/ax/**</include>
+              </includes>
+              <excludes>
+                <exclude>dev/axllm/ax/runtime/quickjs/**</exclude>
+              </excludes>
+            </configuration>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-javadoc-plugin</artifactId>
+            <version>3.6.3</version>
+            <executions>
+              <execution>
+                <id>attach-javadocs</id>
+                <goals>
+                  <goal>jar</goal>
+                </goals>
+              </execution>
+            </executions>
+            <configuration>
+              <quiet>true</quiet>
+              <doclint>none</doclint>
+              <failOnError>false</failOnError>
+              <sourcepath>${project.basedir}</sourcepath>
+              <sourceFileIncludes>
+                <include>dev/axllm/ax/*.java</include>
+              </sourceFileIncludes>
+            </configuration>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-gpg-plugin</artifactId>
+            <version>3.2.4</version>
+            <executions>
+              <execution>
+                <id>sign-artifacts</id>
+                <phase>verify</phase>
+                <goals>
+                  <goal>sign</goal>
+                </goals>
+              </execution>
+            </executions>
+            <configuration>
+              <gpgArguments>
+                <arg>--pinentry-mode</arg>
+                <arg>loopback</arg>
+              </gpgArguments>
+            </configuration>
+          </plugin>
+          <plugin>
+            <groupId>org.sonatype.central</groupId>
+            <artifactId>central-publishing-maven-plugin</artifactId>
+            <version>0.7.0</version>
+            <extensions>true</extensions>
+            <configuration>
+              <publishingServerId>central</publishingServerId>
+              <autoPublish>true</autoPublish>
+              <waitUntil>published</waitUntil>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 </project>

--- a/packages/python/README.md
+++ b/packages/python/README.md
@@ -5,9 +5,7 @@ Build Ax programs from Python without giving up the Ax model: typed signatures, 
 ## Quick Start
 
 ```bash
-cd packages/python
-python -m pip install -e .
-PYTHONPATH=. python examples/signature_schema.py
+pip install "axllm @ git+https://github.com/ax-llm/ax#subdirectory=packages/python"
 ```
 
 ```python

--- a/packages/rust/README.md
+++ b/packages/rust/README.md
@@ -5,9 +5,13 @@ Write Ax programs in Rust with native Result-based errors, serde_json dynamic va
 ## Quick Start
 
 ```bash
-cd packages/rust
-cargo test --all-targets
-cargo run --example signature_schema
+cargo add --git https://github.com/ax-llm/ax axllm
+```
+
+Or add to your `Cargo.toml`:
+
+```toml
+axllm = { git = "https://github.com/ax-llm/ax" }
 ```
 
 ```rust

--- a/scripts/check-skills.mjs
+++ b/scripts/check-skills.mjs
@@ -51,7 +51,7 @@ const packageNames = {
   python: 'axllm',
   java: 'dev.axllm:ax',
   cpp: 'axllm',
-  go: 'github.com/ax-llm/ax/go',
+  go: 'github.com/ax-llm/ax/packages/go',
   rust: 'axllm',
 };
 const packageJson = await readJson(path.join(repoRoot, 'package.json'));

--- a/scripts/run-example.mjs
+++ b/scripts/run-example.mjs
@@ -387,9 +387,9 @@ async function runGo(examplePath, rest) {
 
 go 1.22
 
-require github.com/ax-llm/ax/go v0.0.0
+require github.com/ax-llm/ax/packages/go v0.0.0
 
-replace github.com/ax-llm/ax/go => ${escapeGoModPath(outDir)}
+replace github.com/ax-llm/ax/packages/go => ${escapeGoModPath(outDir)}
 `
   );
   await writeFile(

--- a/scripts/website-prepare.mjs
+++ b/scripts/website-prepare.mjs
@@ -1802,7 +1802,7 @@ function generatedPackageSnippets(languageId) {
     },
     go: {
       default: [
-        'import ax "github.com/ax-llm/ax/go"',
+        'import ax "github.com/ax-llm/ax/packages/go"',
         '',
         'program := ax.NewAx("question:string -> answer:string", nil)',
       ],

--- a/src/examples/go/audio/pipeline_audio.go
+++ b/src/examples/go/audio/pipeline_audio.go
@@ -18,7 +18,7 @@ import (
 	"time"
 	"io/ioutil"
 
-	ax "github.com/ax-llm/ax/go"
+	ax "github.com/ax-llm/ax/packages/go"
 )
 
 

--- a/src/examples/go/audio/speech_audio.go
+++ b/src/examples/go/audio/speech_audio.go
@@ -19,7 +19,7 @@ import (
 	"time"
 	"io/ioutil"
 
-	ax "github.com/ax-llm/ax/go"
+	ax "github.com/ax-llm/ax/packages/go"
 )
 
 

--- a/src/examples/go/audio/transcribe_audio.go
+++ b/src/examples/go/audio/transcribe_audio.go
@@ -18,7 +18,7 @@ import (
 	"time"
 	"io/ioutil"
 
-	ax "github.com/ax-llm/ax/go"
+	ax "github.com/ax-llm/ax/packages/go"
 )
 
 

--- a/src/examples/go/flows/branch_flow.go
+++ b/src/examples/go/flows/branch_flow.go
@@ -16,7 +16,7 @@ import (
 	"os"
 	"time"
 
-	ax "github.com/ax-llm/ax/go"
+	ax "github.com/ax-llm/ax/packages/go"
 )
 
 

--- a/src/examples/go/flows/composed_flow.go
+++ b/src/examples/go/flows/composed_flow.go
@@ -16,7 +16,7 @@ import (
 	"os"
 	"time"
 
-	ax "github.com/ax-llm/ax/go"
+	ax "github.com/ax-llm/ax/packages/go"
 )
 
 

--- a/src/examples/go/flows/sequential_flow.go
+++ b/src/examples/go/flows/sequential_flow.go
@@ -17,7 +17,7 @@ import (
 	"os"
 	"time"
 
-	ax "github.com/ax-llm/ax/go"
+	ax "github.com/ax-llm/ax/packages/go"
 )
 
 

--- a/src/examples/go/generation/basic_generation.go
+++ b/src/examples/go/generation/basic_generation.go
@@ -17,7 +17,7 @@ import (
 	"os"
 	"time"
 
-	ax "github.com/ax-llm/ax/go"
+	ax "github.com/ax-llm/ax/packages/go"
 )
 
 

--- a/src/examples/go/generation/context_generation.go
+++ b/src/examples/go/generation/context_generation.go
@@ -16,7 +16,7 @@ import (
 	"os"
 	"time"
 
-	ax "github.com/ax-llm/ax/go"
+	ax "github.com/ax-llm/ax/packages/go"
 )
 
 

--- a/src/examples/go/generation/structured_generation.go
+++ b/src/examples/go/generation/structured_generation.go
@@ -16,7 +16,7 @@ import (
 	"os"
 	"time"
 
-	ax "github.com/ax-llm/ax/go"
+	ax "github.com/ax-llm/ax/packages/go"
 )
 
 

--- a/src/examples/go/long-agents/codebase_peek_map.go
+++ b/src/examples/go/long-agents/codebase_peek_map.go
@@ -16,8 +16,8 @@ import (
 	"strings"
 	"time"
 
-	ax "github.com/ax-llm/ax/go"
-	axgoja "github.com/ax-llm/ax/go/runtime/goja"
+	ax "github.com/ax-llm/ax/packages/go"
+	axgoja "github.com/ax-llm/ax/packages/go/runtime/goja"
 )
 
 func geminiClient() *ax.GoogleGeminiClient {

--- a/src/examples/go/long-agents/data_analyst_with_tools.go
+++ b/src/examples/go/long-agents/data_analyst_with_tools.go
@@ -18,8 +18,8 @@ import (
 	"strings"
 	"time"
 
-	ax "github.com/ax-llm/ax/go"
-	axgoja "github.com/ax-llm/ax/go/runtime/goja"
+	ax "github.com/ax-llm/ax/packages/go"
+	axgoja "github.com/ax-llm/ax/packages/go/runtime/goja"
 )
 
 func geminiClient() *ax.GoogleGeminiClient {

--- a/src/examples/go/long-agents/incident_log_forensics.go
+++ b/src/examples/go/long-agents/incident_log_forensics.go
@@ -16,8 +16,8 @@ import (
 	"os"
 	"time"
 
-	ax "github.com/ax-llm/ax/go"
-	axgoja "github.com/ax-llm/ax/go/runtime/goja"
+	ax "github.com/ax-llm/ax/packages/go"
+	axgoja "github.com/ax-llm/ax/packages/go/runtime/goja"
 )
 
 func geminiClient() *ax.GoogleGeminiClient {

--- a/src/examples/go/long-agents/self_improving_lab.go
+++ b/src/examples/go/long-agents/self_improving_lab.go
@@ -19,8 +19,8 @@ import (
 	"strings"
 	"time"
 
-	ax "github.com/ax-llm/ax/go"
-	axgoja "github.com/ax-llm/ax/go/runtime/goja"
+	ax "github.com/ax-llm/ax/packages/go"
+	axgoja "github.com/ax-llm/ax/packages/go/runtime/goja"
 )
 
 func openAIClient() *ax.OpenAICompatibleClient {

--- a/src/examples/go/long-agents/skills_and_memory_assistant.go
+++ b/src/examples/go/long-agents/skills_and_memory_assistant.go
@@ -17,8 +17,8 @@ import (
 	"strings"
 	"time"
 
-	ax "github.com/ax-llm/ax/go"
-	axgoja "github.com/ax-llm/ax/go/runtime/goja"
+	ax "github.com/ax-llm/ax/packages/go"
+	axgoja "github.com/ax-llm/ax/packages/go/runtime/goja"
 )
 
 func openAIClient() *ax.OpenAICompatibleClient {

--- a/src/examples/go/optimization/artifact_optimization.go
+++ b/src/examples/go/optimization/artifact_optimization.go
@@ -16,7 +16,7 @@ import (
 	"os"
 	"time"
 
-	ax "github.com/ax-llm/ax/go"
+	ax "github.com/ax-llm/ax/packages/go"
 )
 
 func openAIClient() *ax.OpenAICompatibleClient {

--- a/src/examples/go/optimization/axgen_optimization.go
+++ b/src/examples/go/optimization/axgen_optimization.go
@@ -17,7 +17,7 @@ import (
 	"os"
 	"time"
 
-	ax "github.com/ax-llm/ax/go"
+	ax "github.com/ax-llm/ax/packages/go"
 )
 
 func openAIClient() *ax.OpenAICompatibleClient {

--- a/src/examples/go/optimization/gepa_optimization.go
+++ b/src/examples/go/optimization/gepa_optimization.go
@@ -16,7 +16,7 @@ import (
 	"os"
 	"time"
 
-	ax "github.com/ax-llm/ax/go"
+	ax "github.com/ax-llm/ax/packages/go"
 )
 
 type localEvaluator struct{}

--- a/src/examples/go/short-agents/basic_agent.go
+++ b/src/examples/go/short-agents/basic_agent.go
@@ -18,8 +18,8 @@ import (
 	"strings"
 	"time"
 
-	ax "github.com/ax-llm/ax/go"
-	axgoja "github.com/ax-llm/ax/go/runtime/goja"
+	ax "github.com/ax-llm/ax/packages/go"
+	axgoja "github.com/ax-llm/ax/packages/go/runtime/goja"
 )
 
 func openAIClient() *ax.OpenAICompatibleClient {

--- a/src/examples/go/short-agents/handoff_agent.go
+++ b/src/examples/go/short-agents/handoff_agent.go
@@ -17,8 +17,8 @@ import (
 	"strings"
 	"time"
 
-	ax "github.com/ax-llm/ax/go"
-	axgoja "github.com/ax-llm/ax/go/runtime/goja"
+	ax "github.com/ax-llm/ax/packages/go"
+	axgoja "github.com/ax-llm/ax/packages/go/runtime/goja"
 )
 
 func openAIClient() *ax.OpenAICompatibleClient {

--- a/src/examples/go/short-agents/model_panel.go
+++ b/src/examples/go/short-agents/model_panel.go
@@ -16,7 +16,7 @@ import (
 	"os"
 	"time"
 
-	ax "github.com/ax-llm/ax/go"
+	ax "github.com/ax-llm/ax/packages/go"
 )
 
 func printJSON(value ax.Value) {

--- a/src/examples/go/short-agents/tools_agent.go
+++ b/src/examples/go/short-agents/tools_agent.go
@@ -17,8 +17,8 @@ import (
 	"strings"
 	"time"
 
-	ax "github.com/ax-llm/ax/go"
-	axgoja "github.com/ax-llm/ax/go/runtime/goja"
+	ax "github.com/ax-llm/ax/packages/go"
+	axgoja "github.com/ax-llm/ax/packages/go/runtime/goja"
 )
 
 func openAIClient() *ax.OpenAICompatibleClient {

--- a/tools/axir/internal/axir/axir_test.go
+++ b/tools/axir/internal/axir/axir_test.go
@@ -959,7 +959,7 @@ func TestCapabilityManifestsAndGeneratedPackageShape(t *testing.T) {
 					t.Fatalf("%s manifest should not claim runtime profile %q: %#v", tc.target, profileID, manifest.RuntimeProfiles)
 				}
 			}
-			wantPackage := map[string]string{"python": "axllm", "java": "dev.axllm:ax", "cpp": "axllm", "go": "github.com/ax-llm/ax/go", "rust": "axllm"}[tc.target]
+			wantPackage := map[string]string{"python": "axllm", "java": "dev.axllm:ax", "cpp": "axllm", "go": "github.com/ax-llm/ax/packages/go", "rust": "axllm"}[tc.target]
 			if manifest.PackageName != wantPackage {
 				t.Fatalf("bad package name for %s: got %q want %q", tc.target, manifest.PackageName, wantPackage)
 			}
@@ -1071,7 +1071,7 @@ func TestCapabilityManifestsAndGeneratedPackageShape(t *testing.T) {
 				checkGeneratedFileContains(t, dir, "axllm/axllm.cpp", "HttpTransport::call", "curl_easy_perform")
 				checkGeneratedFileContains(t, dir, "cmake/axllmConfig.cmake.in", "find_dependency(OpenSSL)", "axllmTargets.cmake")
 			case "go":
-				checkGeneratedFileContains(t, dir, "go.mod", "module github.com/ax-llm/ax/go", "go 1.22", "github.com/dop251/goja")
+				checkGeneratedFileContains(t, dir, "go.mod", "module github.com/ax-llm/ax/packages/go", "go 1.22", "github.com/dop251/goja")
 				checkGeneratedFileContains(t, dir, "axllm.go", "package axllm", "type Value = any", "func NewSignature", "type HTTPTransport struct")
 				checkGeneratedFileContains(t, dir, "runtime/goja/goja.go", "package goja", "func NewRuntime(options ...Option) *Runtime", "func (r *Runtime) RegisterCallable", "gojavm.New")
 				checkGeneratedFileContains(t, dir, "examples/runtime_profiles/javascript_goja/main.go", "go-javascript-goja-profile-ok", "ax.NewAgent", "agent.Test(runtime", "while (true) {}")
@@ -1240,7 +1240,7 @@ func TestDocsCoverCompilerAndArchitecture(t *testing.T) {
 		t.Fatal(err)
 	}
 	release := readRepoFile(t, root, "docs", "RELEASE.md")
-	for _, want := range []string{"@ax-llm/ax", "axllm", "dev.axllm:ax", "axllm::axllm", "github.com/ax-llm/ax/go", "javascript-goja", "runtime/goja", "crates.io"} {
+	for _, want := range []string{"@ax-llm/ax", "axllm", "dev.axllm:ax", "axllm::axllm", "github.com/ax-llm/ax/packages/go", "javascript-goja", "runtime/goja", "crates.io"} {
 		if !strings.Contains(release, want) {
 			t.Fatalf("docs/RELEASE.md missing %q", want)
 		}

--- a/tools/axir/internal/axir/codegen.go
+++ b/tools/axir/internal/axir/codegen.go
@@ -1817,7 +1817,7 @@ func packageNameForTarget(target string) string {
 	case "cpp":
 		return "axllm"
 	case "go":
-		return "github.com/ax-llm/ax/go"
+		return "github.com/ax-llm/ax/packages/go"
 	case "rust":
 		return "axllm"
 	default:
@@ -1917,9 +1917,7 @@ func packageReadmeConfigForTarget(target string, network string) packageReadmeCo
 			Intro:    "Build Ax programs from Python without giving up the Ax model: typed signatures, structured generation, provider routing, RLM agents, flows, and optimizer artifacts all come from the same shared compiler contract. The package feels like Python, but the behavior stays aligned with the main Ax implementation.",
 			Install: readmeLines(
 				"```bash",
-				"cd packages/python",
-				"python -m pip install -e .",
-				"PYTHONPATH=. python examples/signature_schema.py",
+				"pip install \"axllm @ git+https://github.com/ax-llm/ax#subdirectory=packages/python\"",
 				"```",
 			),
 			QuickStart: readmeLines(
@@ -1970,11 +1968,15 @@ func packageReadmeConfigForTarget(target string, network string) packageReadmeCo
 			Language: "Java",
 			Intro:    "Bring Ax into Java services and JVM applications with a small native API: signatures, structured generation, providers, RLM agents, flows, and optimizer artifacts are generated from the shared Ax compiler contract and exposed as ordinary Java classes.",
 			Install: readmeLines(
+				"Maven and Gradle cannot depend on a git repository directly, so build and",
+				"install the package to your local Maven repository until it is published to",
+				"Maven Central:",
+				"",
 				"```bash",
-				"cd packages/java",
-				"javac -cp . dev/axllm/ax/*.java examples/SignatureSchemaExample.java",
-				"java -cp .:examples SignatureSchemaExample",
+				"git clone https://github.com/ax-llm/ax && (cd ax/packages/java && mvn -q install)",
 				"```",
+				"",
+				"Then add the dependency `dev.axllm:ax:22.0.3` to your `pom.xml` or `build.gradle`.",
 			),
 			QuickStart: readmeLines(
 				"```java",
@@ -2026,11 +2028,13 @@ func packageReadmeConfigForTarget(target string, network string) packageReadmeCo
 			Language: "C++",
 			Intro:    "Use Ax from C++ when you want structured LLM programs close to your runtime: signatures, typed dynamic values, provider transports, RLM agents, flows, and optimizer artifacts are generated into a compact C++17 library.",
 			Install: readmeLines(
-				"```bash",
-				"cd packages/cpp",
-				"cmake -S . -B build",
-				"cmake --build build",
-				"./build/signature_schema",
+				"Add Ax to your CMake project with `FetchContent`:",
+				"",
+				"```cmake",
+				"include(FetchContent)",
+				"FetchContent_Declare(axllm GIT_REPOSITORY https://github.com/ax-llm/ax GIT_TAG main SOURCE_SUBDIR packages/cpp)",
+				"FetchContent_MakeAvailable(axllm)",
+				"target_link_libraries(your_app PRIVATE axllm::axllm)",
 				"```",
 			),
 			QuickStart: readmeLines(
@@ -2082,16 +2086,14 @@ func packageReadmeConfigForTarget(target string, network string) packageReadmeCo
 			Intro:    "Write Ax programs in Go with the same contract used by the main Ax library: signatures, structured generation, provider clients, RLM agents, flows, and optimizer artifacts compiled into a native Go module.",
 			Install: readmeLines(
 				"```bash",
-				"cd packages/go",
-				"go test ./...",
-				"go run ./examples/signature_schema",
+				"go get github.com/ax-llm/ax/packages/go",
 				"```",
 			),
 			QuickStart: readmeLines(
 				"```go",
 				"package main",
 				"",
-				"import ax \"github.com/ax-llm/ax/go\"",
+				"import ax \"github.com/ax-llm/ax/packages/go\"",
 				"",
 				"func main() {",
 				"    sig := ax.NewSignature(\"question:string -> answer:string\")",
@@ -2100,7 +2102,7 @@ func packageReadmeConfigForTarget(target string, network string) packageReadmeCo
 				"```",
 			),
 			PackageFacts: readmeLines(
-				"- Module: `github.com/ax-llm/ax/go`",
+				"- Module: `github.com/ax-llm/ax/packages/go`",
 				"- Import alias used in examples: `ax`",
 				"- Base package uses the Go standard library for HTTP/process boundaries",
 				"- Optional JavaScript actor execution lives in `runtime/goja` and is opt-in by import",
@@ -2139,9 +2141,13 @@ func packageReadmeConfigForTarget(target string, network string) packageReadmeCo
 			Intro:    "Write Ax programs in Rust with native Result-based errors, serde_json dynamic values at Ax boundaries, blocking provider transport, protocol-first RLM runtime sessions, and shared Ax semantics generated from the compiler contract.",
 			Install: readmeLines(
 				"```bash",
-				"cd packages/rust",
-				"cargo test --all-targets",
-				"cargo run --example signature_schema",
+				"cargo add --git https://github.com/ax-llm/ax axllm",
+				"```",
+				"",
+				"Or add to your `Cargo.toml`:",
+				"",
+				"```toml",
+				"axllm = { git = \"https://github.com/ax-llm/ax\" }",
 				"```",
 			),
 			QuickStart: readmeLines(

--- a/tools/axir/internal/axir/templates/go/goAudioResponsesMappingExample.go.txt
+++ b/tools/axir/internal/axir/templates/go/goAudioResponsesMappingExample.go.txt
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	ax "github.com/ax-llm/ax/go"
+	ax "github.com/ax-llm/ax/packages/go"
 )
 
 func main() {

--- a/tools/axir/internal/axir/templates/go/goAxFlowOpenAIExample.go.txt
+++ b/tools/axir/internal/axir/templates/go/goAxFlowOpenAIExample.go.txt
@@ -7,7 +7,7 @@ import (
 	"os"
 	"time"
 
-	ax "github.com/ax-llm/ax/go"
+	ax "github.com/ax-llm/ax/packages/go"
 )
 
 func main() {

--- a/tools/axir/internal/axir/templates/go/goAxFlowProgramGraphExample.go.txt
+++ b/tools/axir/internal/axir/templates/go/goAxFlowProgramGraphExample.go.txt
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	ax "github.com/ax-llm/ax/go"
+	ax "github.com/ax-llm/ax/packages/go"
 )
 
 type scriptedFlowClient struct{}

--- a/tools/axir/internal/axir/templates/go/goAxGenOpenAIExample.go.txt
+++ b/tools/axir/internal/axir/templates/go/goAxGenOpenAIExample.go.txt
@@ -7,7 +7,7 @@ import (
 	"os"
 	"time"
 
-	ax "github.com/ax-llm/ax/go"
+	ax "github.com/ax-llm/ax/packages/go"
 )
 
 func main() {

--- a/tools/axir/internal/axir/templates/go/goAxGenScriptedClientToolExample.go.txt
+++ b/tools/axir/internal/axir/templates/go/goAxGenScriptedClientToolExample.go.txt
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	ax "github.com/ax-llm/ax/go"
+	ax "github.com/ax-llm/ax/packages/go"
 )
 
 type scriptedClient struct {

--- a/tools/axir/internal/axir/templates/go/goConformance.go.txt
+++ b/tools/axir/internal/axir/templates/go/goConformance.go.txt
@@ -6,8 +6,8 @@ import (
 	"path/filepath"
 	"strings"
 
-	ax "github.com/ax-llm/ax/go"
-	axgoja "github.com/ax-llm/ax/go/runtime/goja"
+	ax "github.com/ax-llm/ax/packages/go"
+	axgoja "github.com/ax-llm/ax/packages/go/runtime/goja"
 )
 
 func main() {

--- a/tools/axir/internal/axir/templates/go/goMod.mod
+++ b/tools/axir/internal/axir/templates/go/goMod.mod
@@ -1,4 +1,4 @@
-module github.com/ax-llm/ax/go
+module github.com/ax-llm/ax/packages/go
 
 go 1.22
 

--- a/tools/axir/internal/axir/templates/go/goOptimizerArtifactExample.go.txt
+++ b/tools/axir/internal/axir/templates/go/goOptimizerArtifactExample.go.txt
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"strings"
 
-	ax "github.com/ax-llm/ax/go"
+	ax "github.com/ax-llm/ax/packages/go"
 )
 
 type localEvaluator struct{}

--- a/tools/axir/internal/axir/templates/go/goProviderMappingNoKeyExample.go.txt
+++ b/tools/axir/internal/axir/templates/go/goProviderMappingNoKeyExample.go.txt
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	ax "github.com/ax-llm/ax/go"
+	ax "github.com/ax-llm/ax/packages/go"
 )
 
 func main() {

--- a/tools/axir/internal/axir/templates/go/goProviderStreamNoKeyExample.go.txt
+++ b/tools/axir/internal/axir/templates/go/goProviderStreamNoKeyExample.go.txt
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	ax "github.com/ax-llm/ax/go"
+	ax "github.com/ax-llm/ax/packages/go"
 )
 
 func main() {

--- a/tools/axir/internal/axir/templates/go/goRealtimeAudioEventsExample.go.txt
+++ b/tools/axir/internal/axir/templates/go/goRealtimeAudioEventsExample.go.txt
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	ax "github.com/ax-llm/ax/go"
+	ax "github.com/ax-llm/ax/packages/go"
 )
 
 func main() {

--- a/tools/axir/internal/axir/templates/go/goRuntimeProtocolExample.go.txt
+++ b/tools/axir/internal/axir/templates/go/goRuntimeProtocolExample.go.txt
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"os"
 
-	ax "github.com/ax-llm/ax/go"
+	ax "github.com/ax-llm/ax/packages/go"
 )
 
 func main() {

--- a/tools/axir/internal/axir/templates/go/goSignatureSchemaExample.go.txt
+++ b/tools/axir/internal/axir/templates/go/goSignatureSchemaExample.go.txt
@@ -3,7 +3,7 @@ package main
 import (
 	"fmt"
 
-	ax "github.com/ax-llm/ax/go"
+	ax "github.com/ax-llm/ax/packages/go"
 )
 
 func main() {

--- a/tools/axir/internal/axir/templates/goja/goGojaRuntime.go.txt
+++ b/tools/axir/internal/axir/templates/goja/goGojaRuntime.go.txt
@@ -8,7 +8,7 @@ import (
 	"sync"
 	"time"
 
-	ax "github.com/ax-llm/ax/go"
+	ax "github.com/ax-llm/ax/packages/go"
 	gojavm "github.com/dop251/goja"
 )
 

--- a/tools/axir/internal/axir/templates/goja/goJavaScriptGojaProfileExample.go.txt
+++ b/tools/axir/internal/axir/templates/goja/goJavaScriptGojaProfileExample.go.txt
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"strings"
 
-	ax "github.com/ax-llm/ax/go"
-	axgoja "github.com/ax-llm/ax/go/runtime/goja"
+	ax "github.com/ax-llm/ax/packages/go"
+	axgoja "github.com/ax-llm/ax/packages/go/runtime/goja"
 )
 
 func asMap(value ax.Value) map[string]ax.Value {

--- a/tools/axir/internal/axir/templates/mcp/goMCPScriptedToolsExample.go.txt
+++ b/tools/axir/internal/axir/templates/mcp/goMCPScriptedToolsExample.go.txt
@@ -3,7 +3,7 @@ package main
 import (
 	"fmt"
 
-	ax "github.com/ax-llm/ax/go"
+	ax "github.com/ax-llm/ax/packages/go"
 )
 
 func main() {

--- a/tools/axir/internal/axir/templates/package/javaPomXML.xml
+++ b/tools/axir/internal/axir/templates/package/javaPomXML.xml
@@ -16,8 +16,17 @@
   <scm>
     <url>https://github.com/ax-llm/ax</url>
     <connection>scm:git:https://github.com/ax-llm/ax.git</connection>
+    <developerConnection>scm:git:https://github.com/ax-llm/ax.git</developerConnection>
   </scm>
   <description>Generated Ax runtime library.</description>
+
+  <developers>
+    <developer>
+      <id>ax-llm</id>
+      <name>Ax</name>
+      <url>https://github.com/ax-llm/ax</url>
+    </developer>
+  </developers>
 
   <properties>
     <maven.compiler.release>17</maven.compiler.release>
@@ -53,4 +62,94 @@
       </plugin>
     </plugins>
   </build>
+
+  <!--
+    `release` profile: builds the sources + javadoc jars, GPG-signs every
+    artifact, and publishes to the Maven Central Portal. Kept out of the default
+    build so a plain `mvn install` (repo runner / local consumer) needs no GPG key.
+    CI activates it with `mvn -Prelease deploy` (see .github/workflows/package-publish.yml).
+  -->
+  <profiles>
+    <profile>
+      <id>release</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-source-plugin</artifactId>
+            <version>3.3.1</version>
+            <executions>
+              <execution>
+                <id>attach-sources</id>
+                <goals>
+                  <goal>jar-no-fork</goal>
+                </goals>
+              </execution>
+            </executions>
+            <configuration>
+              <includes>
+                <include>dev/axllm/ax/**</include>
+              </includes>
+              <excludes>
+                <exclude>dev/axllm/ax/runtime/quickjs/**</exclude>
+              </excludes>
+            </configuration>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-javadoc-plugin</artifactId>
+            <version>3.6.3</version>
+            <executions>
+              <execution>
+                <id>attach-javadocs</id>
+                <goals>
+                  <goal>jar</goal>
+                </goals>
+              </execution>
+            </executions>
+            <configuration>
+              <quiet>true</quiet>
+              <doclint>none</doclint>
+              <failOnError>false</failOnError>
+              <sourcepath>${project.basedir}</sourcepath>
+              <sourceFileIncludes>
+                <include>dev/axllm/ax/*.java</include>
+              </sourceFileIncludes>
+            </configuration>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-gpg-plugin</artifactId>
+            <version>3.2.4</version>
+            <executions>
+              <execution>
+                <id>sign-artifacts</id>
+                <phase>verify</phase>
+                <goals>
+                  <goal>sign</goal>
+                </goals>
+              </execution>
+            </executions>
+            <configuration>
+              <gpgArguments>
+                <arg>--pinentry-mode</arg>
+                <arg>loopback</arg>
+              </gpgArguments>
+            </configuration>
+          </plugin>
+          <plugin>
+            <groupId>org.sonatype.central</groupId>
+            <artifactId>central-publishing-maven-plugin</artifactId>
+            <version>0.7.0</version>
+            <extensions>true</extensions>
+            <configuration>
+              <publishingServerId>central</publishingServerId>
+              <autoPublish>true</autoPublish>
+              <waitUntil>published</waitUntil>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 </project>

--- a/tools/axir/internal/axir/templates_skills.go
+++ b/tools/axir/internal/axir/templates_skills.go
@@ -359,7 +359,7 @@ func skillSignatureSnippet(target string) string {
 	case "cpp":
 		return readmeLines("#include \"axllm/axllm.hpp\"", "", "auto sig = axllm::s(\"question:string -> answer:string\");", "auto schema = axllm::to_json_schema(axllm::Core::get(sig, \"outputs\"));")
 	case "go":
-		return readmeLines("import ax \"github.com/ax-llm/ax/go\"", "", "sig := ax.NewSignature(\"question:string -> answer:string\")", "schema := sig.ToJSONSchema(nil)")
+		return readmeLines("import ax \"github.com/ax-llm/ax/packages/go\"", "", "sig := ax.NewSignature(\"question:string -> answer:string\")", "schema := sig.ToJSONSchema(nil)")
 	case "rust":
 		return readmeLines("use axllm::s;", "", "let sig = s(\"question:string -> answer:string\")?;", "let schema = sig.to_json_schema(\"outputs\");")
 	default:
@@ -376,7 +376,7 @@ func skillAISnippet(target string) string {
 	case "cpp":
 		return readmeLines("#include \"axllm/axllm.hpp\"", "", "auto llm = axllm::ai(\"openai\", { {\"apiKey\", std::getenv(\"OPENAI_API_KEY\")} });")
 	case "go":
-		return readmeLines("import ax \"github.com/ax-llm/ax/go\"", "", "llm := ax.NewAI(\"openai\", map[string]ax.Value{\"apiKey\": os.Getenv(\"OPENAI_API_KEY\")})")
+		return readmeLines("import ax \"github.com/ax-llm/ax/packages/go\"", "", "llm := ax.NewAI(\"openai\", map[string]ax.Value{\"apiKey\": os.Getenv(\"OPENAI_API_KEY\")})")
 	case "rust":
 		return readmeLines("use axllm::ai;", "", "let llm = ai(\"openai\", options)?;")
 	default:

--- a/tools/axir/internal/axir/verify.go
+++ b/tools/axir/internal/axir/verify.go
@@ -489,9 +489,9 @@ func verifyGoPackageSmoke(report *VerifyTargetReport, goTool string) error {
 
 go 1.22
 
-require github.com/ax-llm/ax/go v0.0.0
+require github.com/ax-llm/ax/packages/go v0.0.0
 
-replace github.com/ax-llm/ax/go => ..
+replace github.com/ax-llm/ax/packages/go => ..
 `), 0o644); err != nil {
 		return err
 	}
@@ -500,7 +500,7 @@ replace github.com/ax-llm/ax/go => ..
 import (
 	"fmt"
 
-	ax "github.com/ax-llm/ax/go"
+	ax "github.com/ax-llm/ax/packages/go"
 )
 
 func main() {

--- a/website/content-src/languages/cpp.json
+++ b/website/content-src/languages/cpp.json
@@ -5,9 +5,10 @@
   "fence": "cpp",
   "packageName": "axllm",
   "install": [
-    "git clone https://github.com/ax-llm/ax && cmake -S ax/packages/cpp -B build",
-    "cmake --build build",
-    "./build/signature_schema"
+    "include(FetchContent)",
+    "FetchContent_Declare(axllm GIT_REPOSITORY https://github.com/ax-llm/ax GIT_TAG main SOURCE_SUBDIR packages/cpp)",
+    "FetchContent_MakeAvailable(axllm)",
+    "target_link_libraries(your_app PRIVATE axllm::axllm)"
   ],
   "exampleRoot": "packages/cpp/examples",
   "apiKind": "axir",

--- a/website/content-src/languages/go.json
+++ b/website/content-src/languages/go.json
@@ -3,11 +3,8 @@
   "label": "Go",
   "shortLabel": "Go",
   "fence": "go",
-  "packageName": "github.com/ax-llm/ax/go",
-  "install": [
-    "git clone https://github.com/ax-llm/ax && cd ax/packages/go",
-    "go run ./examples/signature_schema"
-  ],
+  "packageName": "github.com/ax-llm/ax/packages/go",
+  "install": ["go get github.com/ax-llm/ax/packages/go"],
   "exampleRoot": "packages/go/examples",
   "apiKind": "axir",
   "optimizeName": "AxGEPA",
@@ -22,7 +19,7 @@
   },
   "snippets": {
     "quickStart": [
-      "import axllm \"github.com/ax-llm/ax/go\"",
+      "import axllm \"github.com/ax-llm/ax/packages/go\"",
       "",
       "client := axllm.NewAI(\"openai\", map[string]axllm.Value{\"apiKey\": os.Getenv(\"OPENAI_API_KEY\")})",
       "classify := axllm.NewAx(\"review:string -> sentiment:class \\\"positive, negative, neutral\\\"\", nil)"

--- a/website/content-src/languages/java.json
+++ b/website/content-src/languages/java.json
@@ -5,9 +5,9 @@
   "fence": "java",
   "packageName": "dev.axllm:ax",
   "install": [
-    "git clone https://github.com/ax-llm/ax && cd ax/packages/java",
-    "javac -cp . dev/axllm/ax/*.java examples/SignatureSchemaExample.java",
-    "java -cp .:examples SignatureSchemaExample"
+    "# build + install to your local Maven repo (until published):",
+    "git clone https://github.com/ax-llm/ax && (cd ax/packages/java && mvn -q install)",
+    "# then add dev.axllm:ax:22.0.3 to your pom.xml dependencies"
   ],
   "exampleRoot": "packages/java/examples",
   "apiKind": "axir",

--- a/website/content-src/languages/rust.json
+++ b/website/content-src/languages/rust.json
@@ -4,10 +4,7 @@
   "shortLabel": "Rust",
   "fence": "rust",
   "packageName": "axllm",
-  "install": [
-    "git clone https://github.com/ax-llm/ax && cd ax/packages/rust",
-    "cargo run --example signature_schema"
-  ],
+  "install": ["cargo add --git https://github.com/ax-llm/ax axllm"],
   "exampleRoot": "packages/rust/examples",
   "apiKind": "axir",
   "optimizeName": "AxGEPA",

--- a/website/data/homepage_languages.yaml
+++ b/website/data/homepage_languages.yaml
@@ -472,7 +472,7 @@ languages:
           "sentiment": "positive"
         }
       code: |
-        import ax "github.com/ax-llm/ax/go"
+        import ax "github.com/ax-llm/ax/packages/go"
 
         llm := ax.NewAI("openai", nil)
         classify := ax.NewAx(
@@ -487,7 +487,7 @@ languages:
       filename: audio.go
       runtimeLabel: speech:audio
       code: |
-        import ax "github.com/ax-llm/ax/go"
+        import ax "github.com/ax-llm/ax/packages/go"
 
         llm := ax.NewAI("openai", nil)
         narrator := ax.NewAx(
@@ -526,7 +526,7 @@ languages:
       filename: researcher.go
       runtimeLabel: Go host session
       code: |
-        import ax "github.com/ax-llm/ax/go"
+        import ax "github.com/ax-llm/ax/packages/go"
 
         llm := ax.NewAI("openai", nil)
         research := ax.NewAgent(

--- a/website/layouts/_default/baseof.html
+++ b/website/layouts/_default/baseof.html
@@ -89,7 +89,7 @@
       (dict "id" "python" "label" "Python" "package" "axllm")
       (dict "id" "java" "label" "Java" "package" "dev.axllm:ax")
       (dict "id" "cpp" "label" "C++" "package" "axllm::axllm")
-      (dict "id" "go" "label" "Go" "package" "github.com/ax-llm/ax/go")
+      (dict "id" "go" "label" "Go" "package" "github.com/ax-llm/ax/packages/go")
       (dict "id" "rust" "label" "Rust" "package" "axllm")
     }}
     {{ $currentLanguage := index $languages 0 }}

--- a/website/layouts/shortcodes/backend-badges.html
+++ b/website/layouts/shortcodes/backend-badges.html
@@ -4,7 +4,7 @@
     (dict "id" "python" "label" "Python" "package" "axllm" "status" "in repo · PyPI soon" "href" "/python/quick-start/")
     (dict "id" "java" "label" "Java" "package" "dev.axllm:ax" "status" "in repo · Maven Central soon" "href" "/java/quick-start/")
     (dict "id" "cpp" "label" "C++" "package" "axllm::axllm" "status" "in repo · source build" "href" "/cpp/quick-start/")
-    (dict "id" "go" "label" "Go" "package" "github.com/ax-llm/ax/go" "status" "in repo · go get soon" "href" "/go/quick-start/")
+    (dict "id" "go" "label" "Go" "package" "github.com/ax-llm/ax/packages/go" "status" "in repo · go get soon" "href" "/go/quick-start/")
     (dict "id" "rust" "label" "Rust" "package" "axllm" "status" "in repo · crates.io soon" "href" "/rust/quick-start/")
   }}
   {{ range $languages }}

--- a/website/static/go/.well-known/agent-skills/ax-go-agent-memory-skills/SKILL.md
+++ b/website/static/go/.well-known/agent-skills/ax-go-agent-memory-skills/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: "ax-go-agent-memory-skills"
-description: "Use when writing Go code with `github.com/ax-llm/ax/go` for agent memory, recall callbacks, dynamic skill discovery, loaded-skill state, and used-skill tracking."
+description: "Use when writing Go code with `github.com/ax-llm/ax/packages/go` for agent memory, recall callbacks, dynamic skill discovery, loaded-skill state, and used-skill tracking."
 version: "22.0.3"
 ---
 # AxAgent Memory And Skills For Go
 
-This skill helps an agent write Go code with the generated Ax package `github.com/ax-llm/ax/go`. Use the generated package API, examples, and manifests; do not import TypeScript-only APIs unless you are editing the TypeScript package.
+This skill helps an agent write Go code with the generated Ax package `github.com/ax-llm/ax/packages/go`. Use the generated package API, examples, and manifests; do not import TypeScript-only APIs unless you are editing the TypeScript package.
 
 ## When To Use
 
@@ -16,7 +16,7 @@ This skill helps an agent write Go code with the generated Ax package `github.co
 ## Package Facts
 
 - Language: Go.
-- Package: `github.com/ax-llm/ax/go`.
+- Package: `github.com/ax-llm/ax/packages/go`.
 - Package API docs: `API.md` and `axir-api.json`.
 - Capability manifest: `axir-capabilities.json`.
 - Runnable examples: `examples/`.

--- a/website/static/go/.well-known/agent-skills/ax-go-agent-observability/SKILL.md
+++ b/website/static/go/.well-known/agent-skills/ax-go-agent-observability/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: "ax-go-agent-observability"
-description: "Use when writing Go code with `github.com/ax-llm/ax/go` for agent tracing, usage accounting, action logs, runtime diagnostics, replay, and production debugging."
+description: "Use when writing Go code with `github.com/ax-llm/ax/packages/go` for agent tracing, usage accounting, action logs, runtime diagnostics, replay, and production debugging."
 version: "22.0.3"
 ---
 # AxAgent Observability For Go
 
-This skill helps an agent write Go code with the generated Ax package `github.com/ax-llm/ax/go`. Use the generated package API, examples, and manifests; do not import TypeScript-only APIs unless you are editing the TypeScript package.
+This skill helps an agent write Go code with the generated Ax package `github.com/ax-llm/ax/packages/go`. Use the generated package API, examples, and manifests; do not import TypeScript-only APIs unless you are editing the TypeScript package.
 
 ## When To Use
 
@@ -16,7 +16,7 @@ This skill helps an agent write Go code with the generated Ax package `github.co
 ## Package Facts
 
 - Language: Go.
-- Package: `github.com/ax-llm/ax/go`.
+- Package: `github.com/ax-llm/ax/packages/go`.
 - Package API docs: `API.md` and `axir-api.json`.
 - Capability manifest: `axir-capabilities.json`.
 - Runnable examples: `examples/`.

--- a/website/static/go/.well-known/agent-skills/ax-go-agent-optimize/SKILL.md
+++ b/website/static/go/.well-known/agent-skills/ax-go-agent-optimize/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: "ax-go-agent-optimize"
-description: "Use when writing Go code with `github.com/ax-llm/ax/go` for agent optimization, evaluators, judges, optimizer artifacts, BootstrapFewShot, and GEPA."
+description: "Use when writing Go code with `github.com/ax-llm/ax/packages/go` for agent optimization, evaluators, judges, optimizer artifacts, BootstrapFewShot, and GEPA."
 version: "22.0.3"
 ---
 # AxAgent Optimize For Go
 
-This skill helps an agent write Go code with the generated Ax package `github.com/ax-llm/ax/go`. Use the generated package API, examples, and manifests; do not import TypeScript-only APIs unless you are editing the TypeScript package.
+This skill helps an agent write Go code with the generated Ax package `github.com/ax-llm/ax/packages/go`. Use the generated package API, examples, and manifests; do not import TypeScript-only APIs unless you are editing the TypeScript package.
 
 ## When To Use
 
@@ -16,7 +16,7 @@ This skill helps an agent write Go code with the generated Ax package `github.co
 ## Package Facts
 
 - Language: Go.
-- Package: `github.com/ax-llm/ax/go`.
+- Package: `github.com/ax-llm/ax/packages/go`.
 - Package API docs: `API.md` and `axir-api.json`.
 - Capability manifest: `axir-capabilities.json`.
 - Runnable examples: `examples/`.

--- a/website/static/go/.well-known/agent-skills/ax-go-agent-rlm/SKILL.md
+++ b/website/static/go/.well-known/agent-skills/ax-go-agent-rlm/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: "ax-go-agent-rlm"
-description: "Use when writing Go code with `github.com/ax-llm/ax/go` for RLM executor loops, AxCodeRuntime sessions, runtime envelopes, process runtimes, and optional runtime profiles."
+description: "Use when writing Go code with `github.com/ax-llm/ax/packages/go` for RLM executor loops, AxCodeRuntime sessions, runtime envelopes, process runtimes, and optional runtime profiles."
 version: "22.0.3"
 ---
 # AxAgent RLM Runtime For Go
 
-This skill helps an agent write Go code with the generated Ax package `github.com/ax-llm/ax/go`. Use the generated package API, examples, and manifests; do not import TypeScript-only APIs unless you are editing the TypeScript package.
+This skill helps an agent write Go code with the generated Ax package `github.com/ax-llm/ax/packages/go`. Use the generated package API, examples, and manifests; do not import TypeScript-only APIs unless you are editing the TypeScript package.
 
 ## When To Use
 
@@ -16,7 +16,7 @@ This skill helps an agent write Go code with the generated Ax package `github.co
 ## Package Facts
 
 - Language: Go.
-- Package: `github.com/ax-llm/ax/go`.
+- Package: `github.com/ax-llm/ax/packages/go`.
 - Package API docs: `API.md` and `axir-api.json`.
 - Capability manifest: `axir-capabilities.json`.
 - Runnable examples: `examples/`.

--- a/website/static/go/.well-known/agent-skills/ax-go-agent/SKILL.md
+++ b/website/static/go/.well-known/agent-skills/ax-go-agent/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: "ax-go-agent"
-description: "Use when writing Go code with `github.com/ax-llm/ax/go` for agents, child delegation, tools, MCP, clarification, runtime state, and final typed responses."
+description: "Use when writing Go code with `github.com/ax-llm/ax/packages/go` for agents, child delegation, tools, MCP, clarification, runtime state, and final typed responses."
 version: "22.0.3"
 ---
 # AxAgent For Go
 
-This skill helps an agent write Go code with the generated Ax package `github.com/ax-llm/ax/go`. Use the generated package API, examples, and manifests; do not import TypeScript-only APIs unless you are editing the TypeScript package.
+This skill helps an agent write Go code with the generated Ax package `github.com/ax-llm/ax/packages/go`. Use the generated package API, examples, and manifests; do not import TypeScript-only APIs unless you are editing the TypeScript package.
 
 ## When To Use
 
@@ -16,7 +16,7 @@ This skill helps an agent write Go code with the generated Ax package `github.co
 ## Package Facts
 
 - Language: Go.
-- Package: `github.com/ax-llm/ax/go`.
+- Package: `github.com/ax-llm/ax/packages/go`.
 - Package API docs: `API.md` and `axir-api.json`.
 - Capability manifest: `axir-capabilities.json`.
 - Runnable examples: `examples/`.

--- a/website/static/go/.well-known/agent-skills/ax-go-ai/SKILL.md
+++ b/website/static/go/.well-known/agent-skills/ax-go-ai/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: "ax-go-ai"
-description: "Use when writing Go code with `github.com/ax-llm/ax/go` for provider clients, model selection, OpenAI-compatible calls, Responses, Gemini, Anthropic, routers, and balancers."
+description: "Use when writing Go code with `github.com/ax-llm/ax/packages/go` for provider clients, model selection, OpenAI-compatible calls, Responses, Gemini, Anthropic, routers, and balancers."
 version: "22.0.3"
 ---
 # AxAI Providers For Go
 
-This skill helps an agent write Go code with the generated Ax package `github.com/ax-llm/ax/go`. Use the generated package API, examples, and manifests; do not import TypeScript-only APIs unless you are editing the TypeScript package.
+This skill helps an agent write Go code with the generated Ax package `github.com/ax-llm/ax/packages/go`. Use the generated package API, examples, and manifests; do not import TypeScript-only APIs unless you are editing the TypeScript package.
 
 ## When To Use
 
@@ -16,7 +16,7 @@ This skill helps an agent write Go code with the generated Ax package `github.co
 ## Package Facts
 
 - Language: Go.
-- Package: `github.com/ax-llm/ax/go`.
+- Package: `github.com/ax-llm/ax/packages/go`.
 - Package API docs: `API.md` and `axir-api.json`.
 - Capability manifest: `axir-capabilities.json`.
 - Runnable examples: `examples/`.
@@ -27,7 +27,7 @@ This skill helps an agent write Go code with the generated Ax package `github.co
 ## Core Pattern
 
 ```go
-import ax "github.com/ax-llm/ax/go"
+import ax "github.com/ax-llm/ax/packages/go"
 
 llm := ax.NewAI("openai", map[string]ax.Value{"apiKey": os.Getenv("OPENAI_API_KEY")})
 ```

--- a/website/static/go/.well-known/agent-skills/ax-go-audio/SKILL.md
+++ b/website/static/go/.well-known/agent-skills/ax-go-audio/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: "ax-go-audio"
-description: "Use when writing Go code with `github.com/ax-llm/ax/go` for audio input/output, OpenAI Responses audio mapping, realtime event folding, and generated package audio examples."
+description: "Use when writing Go code with `github.com/ax-llm/ax/packages/go` for audio input/output, OpenAI Responses audio mapping, realtime event folding, and generated package audio examples."
 version: "22.0.3"
 ---
 # Ax Audio And Realtime For Go
 
-This skill helps an agent write Go code with the generated Ax package `github.com/ax-llm/ax/go`. Use the generated package API, examples, and manifests; do not import TypeScript-only APIs unless you are editing the TypeScript package.
+This skill helps an agent write Go code with the generated Ax package `github.com/ax-llm/ax/packages/go`. Use the generated package API, examples, and manifests; do not import TypeScript-only APIs unless you are editing the TypeScript package.
 
 ## When To Use
 
@@ -16,7 +16,7 @@ This skill helps an agent write Go code with the generated Ax package `github.co
 ## Package Facts
 
 - Language: Go.
-- Package: `github.com/ax-llm/ax/go`.
+- Package: `github.com/ax-llm/ax/packages/go`.
 - Package API docs: `API.md` and `axir-api.json`.
 - Capability manifest: `axir-capabilities.json`.
 - Runnable examples: `examples/`.
@@ -27,7 +27,7 @@ This skill helps an agent write Go code with the generated Ax package `github.co
 ## Core Pattern
 
 ```go
-import ax "github.com/ax-llm/ax/go"
+import ax "github.com/ax-llm/ax/packages/go"
 
 llm := ax.NewAI("openai", map[string]ax.Value{"apiKey": os.Getenv("OPENAI_API_KEY")})
 ```

--- a/website/static/go/.well-known/agent-skills/ax-go-flow/SKILL.md
+++ b/website/static/go/.well-known/agent-skills/ax-go-flow/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: "ax-go-flow"
-description: "Use when writing Go code with `github.com/ax-llm/ax/go` for flows, nodes, program graphs, nested programs, dynamic options, caching, and optimizer components."
+description: "Use when writing Go code with `github.com/ax-llm/ax/packages/go` for flows, nodes, program graphs, nested programs, dynamic options, caching, and optimizer components."
 version: "22.0.3"
 ---
 # AxFlow For Go
 
-This skill helps an agent write Go code with the generated Ax package `github.com/ax-llm/ax/go`. Use the generated package API, examples, and manifests; do not import TypeScript-only APIs unless you are editing the TypeScript package.
+This skill helps an agent write Go code with the generated Ax package `github.com/ax-llm/ax/packages/go`. Use the generated package API, examples, and manifests; do not import TypeScript-only APIs unless you are editing the TypeScript package.
 
 ## When To Use
 
@@ -16,7 +16,7 @@ This skill helps an agent write Go code with the generated Ax package `github.co
 ## Package Facts
 
 - Language: Go.
-- Package: `github.com/ax-llm/ax/go`.
+- Package: `github.com/ax-llm/ax/packages/go`.
 - Package API docs: `API.md` and `axir-api.json`.
 - Capability manifest: `axir-capabilities.json`.
 - Runnable examples: `examples/`.

--- a/website/static/go/.well-known/agent-skills/ax-go-gen/SKILL.md
+++ b/website/static/go/.well-known/agent-skills/ax-go-gen/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: "ax-go-gen"
-description: "Use when writing Go code with `github.com/ax-llm/ax/go` for AxGen programs, forward calls, streaming, tools, assertions, traces, usage, and output parsing."
+description: "Use when writing Go code with `github.com/ax-llm/ax/packages/go` for AxGen programs, forward calls, streaming, tools, assertions, traces, usage, and output parsing."
 version: "22.0.3"
 ---
 # AxGen Structured Generation For Go
 
-This skill helps an agent write Go code with the generated Ax package `github.com/ax-llm/ax/go`. Use the generated package API, examples, and manifests; do not import TypeScript-only APIs unless you are editing the TypeScript package.
+This skill helps an agent write Go code with the generated Ax package `github.com/ax-llm/ax/packages/go`. Use the generated package API, examples, and manifests; do not import TypeScript-only APIs unless you are editing the TypeScript package.
 
 ## When To Use
 
@@ -16,7 +16,7 @@ This skill helps an agent write Go code with the generated Ax package `github.co
 ## Package Facts
 
 - Language: Go.
-- Package: `github.com/ax-llm/ax/go`.
+- Package: `github.com/ax-llm/ax/packages/go`.
 - Package API docs: `API.md` and `axir-api.json`.
 - Capability manifest: `axir-capabilities.json`.
 - Runnable examples: `examples/`.

--- a/website/static/go/.well-known/agent-skills/ax-go-gepa/SKILL.md
+++ b/website/static/go/.well-known/agent-skills/ax-go-gepa/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: "ax-go-gepa"
-description: "Use when writing Go code with `github.com/ax-llm/ax/go` for GEPA, Pareto tradeoffs, reflection clients, metric budgets, optimizer state, and artifacts."
+description: "Use when writing Go code with `github.com/ax-llm/ax/packages/go` for GEPA, Pareto tradeoffs, reflection clients, metric budgets, optimizer state, and artifacts."
 version: "22.0.3"
 ---
 # Ax GEPA For Go
 
-This skill helps an agent write Go code with the generated Ax package `github.com/ax-llm/ax/go`. Use the generated package API, examples, and manifests; do not import TypeScript-only APIs unless you are editing the TypeScript package.
+This skill helps an agent write Go code with the generated Ax package `github.com/ax-llm/ax/packages/go`. Use the generated package API, examples, and manifests; do not import TypeScript-only APIs unless you are editing the TypeScript package.
 
 ## When To Use
 
@@ -16,7 +16,7 @@ This skill helps an agent write Go code with the generated Ax package `github.co
 ## Package Facts
 
 - Language: Go.
-- Package: `github.com/ax-llm/ax/go`.
+- Package: `github.com/ax-llm/ax/packages/go`.
 - Package API docs: `API.md` and `axir-api.json`.
 - Capability manifest: `axir-capabilities.json`.
 - Runnable examples: `examples/`.

--- a/website/static/go/.well-known/agent-skills/ax-go-llm/SKILL.md
+++ b/website/static/go/.well-known/agent-skills/ax-go-llm/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: "ax-go-llm"
-description: "Use when writing Go code with `github.com/ax-llm/ax/go` for using the generated Ax package, factory functions, package docs, examples, and API reference."
+description: "Use when writing Go code with `github.com/ax-llm/ax/packages/go` for using the generated Ax package, factory functions, package docs, examples, and API reference."
 version: "22.0.3"
 ---
 # Ax LLM Quick Reference For Go
 
-This skill helps an agent write Go code with the generated Ax package `github.com/ax-llm/ax/go`. Use the generated package API, examples, and manifests; do not import TypeScript-only APIs unless you are editing the TypeScript package.
+This skill helps an agent write Go code with the generated Ax package `github.com/ax-llm/ax/packages/go`. Use the generated package API, examples, and manifests; do not import TypeScript-only APIs unless you are editing the TypeScript package.
 
 ## When To Use
 
@@ -16,7 +16,7 @@ This skill helps an agent write Go code with the generated Ax package `github.co
 ## Package Facts
 
 - Language: Go.
-- Package: `github.com/ax-llm/ax/go`.
+- Package: `github.com/ax-llm/ax/packages/go`.
 - Package API docs: `API.md` and `axir-api.json`.
 - Capability manifest: `axir-capabilities.json`.
 - Runnable examples: `examples/`.
@@ -27,7 +27,7 @@ This skill helps an agent write Go code with the generated Ax package `github.co
 ## Core Pattern
 
 ```go
-import ax "github.com/ax-llm/ax/go"
+import ax "github.com/ax-llm/ax/packages/go"
 
 llm := ax.NewAI("openai", map[string]ax.Value{"apiKey": os.Getenv("OPENAI_API_KEY")})
 ```

--- a/website/static/go/.well-known/agent-skills/ax-go-refine/SKILL.md
+++ b/website/static/go/.well-known/agent-skills/ax-go-refine/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: "ax-go-refine"
-description: "Use when writing Go code with `github.com/ax-llm/ax/go` for reward-scored generation, iterative candidate improvement, evaluator feedback, and optimizer-backed refinement patterns."
+description: "Use when writing Go code with `github.com/ax-llm/ax/packages/go` for reward-scored generation, iterative candidate improvement, evaluator feedback, and optimizer-backed refinement patterns."
 version: "22.0.3"
 ---
 # Ax Refinement Patterns For Go
 
-This skill helps an agent write Go code with the generated Ax package `github.com/ax-llm/ax/go`. Use the generated package API, examples, and manifests; do not import TypeScript-only APIs unless you are editing the TypeScript package.
+This skill helps an agent write Go code with the generated Ax package `github.com/ax-llm/ax/packages/go`. Use the generated package API, examples, and manifests; do not import TypeScript-only APIs unless you are editing the TypeScript package.
 
 ## When To Use
 
@@ -16,7 +16,7 @@ This skill helps an agent write Go code with the generated Ax package `github.co
 ## Package Facts
 
 - Language: Go.
-- Package: `github.com/ax-llm/ax/go`.
+- Package: `github.com/ax-llm/ax/packages/go`.
 - Package API docs: `API.md` and `axir-api.json`.
 - Capability manifest: `axir-capabilities.json`.
 - Runnable examples: `examples/`.

--- a/website/static/go/.well-known/agent-skills/ax-go-signature/SKILL.md
+++ b/website/static/go/.well-known/agent-skills/ax-go-signature/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: "ax-go-signature"
-description: "Use when writing Go code with `github.com/ax-llm/ax/go` for string signatures, field descriptors, JSON schema output, validation, and typed tool argument shapes."
+description: "Use when writing Go code with `github.com/ax-llm/ax/packages/go` for string signatures, field descriptors, JSON schema output, validation, and typed tool argument shapes."
 version: "22.0.3"
 ---
 # Ax Signatures For Go
 
-This skill helps an agent write Go code with the generated Ax package `github.com/ax-llm/ax/go`. Use the generated package API, examples, and manifests; do not import TypeScript-only APIs unless you are editing the TypeScript package.
+This skill helps an agent write Go code with the generated Ax package `github.com/ax-llm/ax/packages/go`. Use the generated package API, examples, and manifests; do not import TypeScript-only APIs unless you are editing the TypeScript package.
 
 ## When To Use
 
@@ -16,7 +16,7 @@ This skill helps an agent write Go code with the generated Ax package `github.co
 ## Package Facts
 
 - Language: Go.
-- Package: `github.com/ax-llm/ax/go`.
+- Package: `github.com/ax-llm/ax/packages/go`.
 - Package API docs: `API.md` and `axir-api.json`.
 - Capability manifest: `axir-capabilities.json`.
 - Runnable examples: `examples/`.
@@ -27,7 +27,7 @@ This skill helps an agent write Go code with the generated Ax package `github.co
 ## Core Pattern
 
 ```go
-import ax "github.com/ax-llm/ax/go"
+import ax "github.com/ax-llm/ax/packages/go"
 
 sig := ax.NewSignature("question:string -> answer:string")
 schema := sig.ToJSONSchema(nil)

--- a/website/static/go/.well-known/agent-skills/index.json
+++ b/website/static/go/.well-known/agent-skills/index.json
@@ -4,93 +4,93 @@
     {
       "name": "ax-go-llm",
       "type": "skill-md",
-      "description": "Use when writing Go code with `github.com/ax-llm/ax/go` for using the generated Ax package, factory functions, package docs, examples, and API reference.",
+      "description": "Use when writing Go code with `github.com/ax-llm/ax/packages/go` for using the generated Ax package, factory functions, package docs, examples, and API reference.",
       "url": "ax-go-llm/SKILL.md",
-      "digest": "sha256:57303a2096e5db6f0a7c0655f50c5f66315c2a84f06643dd5d7f5fd605200327"
+      "digest": "sha256:93b907da22405857db82d6ad83cfc21dbafbf000a0db43fde3dcf1501b1e2f10"
     },
     {
       "name": "ax-go-ai",
       "type": "skill-md",
-      "description": "Use when writing Go code with `github.com/ax-llm/ax/go` for provider clients, model selection, OpenAI-compatible calls, Responses, Gemini, Anthropic, routers, and balancers.",
+      "description": "Use when writing Go code with `github.com/ax-llm/ax/packages/go` for provider clients, model selection, OpenAI-compatible calls, Responses, Gemini, Anthropic, routers, and balancers.",
       "url": "ax-go-ai/SKILL.md",
-      "digest": "sha256:dfc69a30edc89e848a7ae194dff671aa3a2a222081cb3a76b0206e986f8acd7b"
+      "digest": "sha256:371ff8503182c7c921e144e3281cf6343bef16db852b6b017ee45082bf27b6e9"
     },
     {
       "name": "ax-go-audio",
       "type": "skill-md",
-      "description": "Use when writing Go code with `github.com/ax-llm/ax/go` for audio input/output, OpenAI Responses audio mapping, realtime event folding, and generated package audio examples.",
+      "description": "Use when writing Go code with `github.com/ax-llm/ax/packages/go` for audio input/output, OpenAI Responses audio mapping, realtime event folding, and generated package audio examples.",
       "url": "ax-go-audio/SKILL.md",
-      "digest": "sha256:2ba836d6a918fa9845ee128ee5997d479ada44e481d14b71059f30346a46a7d1"
+      "digest": "sha256:7e3509dedcb46f77f4bcdeed60aa8a2c06d198782d67450f0ff5aa7a251e0772"
     },
     {
       "name": "ax-go-signature",
       "type": "skill-md",
-      "description": "Use when writing Go code with `github.com/ax-llm/ax/go` for string signatures, field descriptors, JSON schema output, validation, and typed tool argument shapes.",
+      "description": "Use when writing Go code with `github.com/ax-llm/ax/packages/go` for string signatures, field descriptors, JSON schema output, validation, and typed tool argument shapes.",
       "url": "ax-go-signature/SKILL.md",
-      "digest": "sha256:8b66eb677672e7c954ed9dd2aea8e78153c062741343a312c92105a85a783240"
+      "digest": "sha256:05245c00265138a8c2247919a679b6a9267b08967b0c5177e16b11f90c2efd98"
     },
     {
       "name": "ax-go-gen",
       "type": "skill-md",
-      "description": "Use when writing Go code with `github.com/ax-llm/ax/go` for AxGen programs, forward calls, streaming, tools, assertions, traces, usage, and output parsing.",
+      "description": "Use when writing Go code with `github.com/ax-llm/ax/packages/go` for AxGen programs, forward calls, streaming, tools, assertions, traces, usage, and output parsing.",
       "url": "ax-go-gen/SKILL.md",
-      "digest": "sha256:3ec85730a6f52442380c3c34792bd11c47bcecd56d5c3fa100d54293afbc7c93"
+      "digest": "sha256:4966c00b07833341330ade733b7e28a6448769167d8f3df40459a1ca89e003e2"
     },
     {
       "name": "ax-go-flow",
       "type": "skill-md",
-      "description": "Use when writing Go code with `github.com/ax-llm/ax/go` for flows, nodes, program graphs, nested programs, dynamic options, caching, and optimizer components.",
+      "description": "Use when writing Go code with `github.com/ax-llm/ax/packages/go` for flows, nodes, program graphs, nested programs, dynamic options, caching, and optimizer components.",
       "url": "ax-go-flow/SKILL.md",
-      "digest": "sha256:a2a119eb9d57067bd205adaa476c85ad4e14bf97d3f7d3bb0ac76c3d2d51bac7"
+      "digest": "sha256:3b94af349cec9cadc5aad6f4b909bf8ad54a0e399616bcc2629e38db02fca3cf"
     },
     {
       "name": "ax-go-agent",
       "type": "skill-md",
-      "description": "Use when writing Go code with `github.com/ax-llm/ax/go` for agents, child delegation, tools, MCP, clarification, runtime state, and final typed responses.",
+      "description": "Use when writing Go code with `github.com/ax-llm/ax/packages/go` for agents, child delegation, tools, MCP, clarification, runtime state, and final typed responses.",
       "url": "ax-go-agent/SKILL.md",
-      "digest": "sha256:6479d7c9ff0fea2930e96e8ca9ddfc0c739954bad89c26c3516c4accecce1d78"
+      "digest": "sha256:3cf9fa1df5c126c7be615b4ab0fa7ac71f1f107ffee65150fd45a917a59043d9"
     },
     {
       "name": "ax-go-agent-rlm",
       "type": "skill-md",
-      "description": "Use when writing Go code with `github.com/ax-llm/ax/go` for RLM executor loops, AxCodeRuntime sessions, runtime envelopes, process runtimes, and optional runtime profiles.",
+      "description": "Use when writing Go code with `github.com/ax-llm/ax/packages/go` for RLM executor loops, AxCodeRuntime sessions, runtime envelopes, process runtimes, and optional runtime profiles.",
       "url": "ax-go-agent-rlm/SKILL.md",
-      "digest": "sha256:a50d8f8f277146d0fd04d2c09ece8dcea1a2fb1e0f13a050c0b4aa13a42599a3"
+      "digest": "sha256:ff2d91e9a6882f077794a41751f927e1990b7f979c5e5c2b4c2a8b4debabcc78"
     },
     {
       "name": "ax-go-agent-memory-skills",
       "type": "skill-md",
-      "description": "Use when writing Go code with `github.com/ax-llm/ax/go` for agent memory, recall callbacks, dynamic skill discovery, loaded-skill state, and used-skill tracking.",
+      "description": "Use when writing Go code with `github.com/ax-llm/ax/packages/go` for agent memory, recall callbacks, dynamic skill discovery, loaded-skill state, and used-skill tracking.",
       "url": "ax-go-agent-memory-skills/SKILL.md",
-      "digest": "sha256:9b279985ff98ad042fa7d98bf9537a2aeb3ff811b7002d317cbe9e10f8dc3724"
+      "digest": "sha256:42d0a62027f80e224ddbf4e48108dae90d48b6c5b83485be287adade168e907f"
     },
     {
       "name": "ax-go-agent-observability",
       "type": "skill-md",
-      "description": "Use when writing Go code with `github.com/ax-llm/ax/go` for agent tracing, usage accounting, action logs, runtime diagnostics, replay, and production debugging.",
+      "description": "Use when writing Go code with `github.com/ax-llm/ax/packages/go` for agent tracing, usage accounting, action logs, runtime diagnostics, replay, and production debugging.",
       "url": "ax-go-agent-observability/SKILL.md",
-      "digest": "sha256:e5fdc6e3fae76e1b73f177d6c8c8aceff722e74c3ff349fd16db70333efa4379"
+      "digest": "sha256:d01dd95319ecd500627c44ca070b19da036d008c05f840c6c17ba758eeb55b5d"
     },
     {
       "name": "ax-go-agent-optimize",
       "type": "skill-md",
-      "description": "Use when writing Go code with `github.com/ax-llm/ax/go` for agent optimization, evaluators, judges, optimizer artifacts, BootstrapFewShot, and GEPA.",
+      "description": "Use when writing Go code with `github.com/ax-llm/ax/packages/go` for agent optimization, evaluators, judges, optimizer artifacts, BootstrapFewShot, and GEPA.",
       "url": "ax-go-agent-optimize/SKILL.md",
-      "digest": "sha256:b022086043acd032f579b74e192ec3191ac3e2f08009e86331f04af409a6a5ca"
+      "digest": "sha256:a96f7461916643be99c0022322b403c1913843318f5e21e1e446bc61bb92f0bd"
     },
     {
       "name": "ax-go-gepa",
       "type": "skill-md",
-      "description": "Use when writing Go code with `github.com/ax-llm/ax/go` for GEPA, Pareto tradeoffs, reflection clients, metric budgets, optimizer state, and artifacts.",
+      "description": "Use when writing Go code with `github.com/ax-llm/ax/packages/go` for GEPA, Pareto tradeoffs, reflection clients, metric budgets, optimizer state, and artifacts.",
       "url": "ax-go-gepa/SKILL.md",
-      "digest": "sha256:bc853bf4d53338d90773814d61ca69af98718a084afe65ada5f443148e921a46"
+      "digest": "sha256:ab7348693f50afd5e010204e85c71e28b4e72ed4214e8eeb6f66ba6d83f8dfbf"
     },
     {
       "name": "ax-go-refine",
       "type": "skill-md",
-      "description": "Use when writing Go code with `github.com/ax-llm/ax/go` for reward-scored generation, iterative candidate improvement, evaluator feedback, and optimizer-backed refinement patterns.",
+      "description": "Use when writing Go code with `github.com/ax-llm/ax/packages/go` for reward-scored generation, iterative candidate improvement, evaluator feedback, and optimizer-backed refinement patterns.",
       "url": "ax-go-refine/SKILL.md",
-      "digest": "sha256:556827dd1012b2159dd0484dc270e2fa4aaabf59936c816ca0648f7ee11eea59"
+      "digest": "sha256:fe66b30957233bc40064e1aae1c00186b298a2d886ae4ec370bafcdf66762c19"
     }
   ]
 }


### PR DESCRIPTION
## What

Make every non-TypeScript package **genuinely consumable via its package manager**, and
fix the docs that pointed at commands which don't work.

Two problems this fixes:
1. **Go didn't `go get` at all.** The module path was `github.com/ax-llm/ax/go` but the
   package lives at `packages/go/` — Go requires the path to match the repo subdir, so
   `go get` failed outright. Renamed to `github.com/ax-llm/ax/packages/go` (canonical
   constant in `tools/axir/internal/axir/codegen.go`, propagated through templates,
   hand-written examples, scripts, docs, website layouts, and the regenerated
   `packages/go` + website skills).
2. **Install docs were "git clone + cd"** (building the package in place) or claimed
   published one-liners (`pip install axllm`, `cargo add axllm`) that don't resolve
   because nothing is on the registries yet.

## Install commands now documented (all verified end-to-end from an external consumer)

| Lang | Command |
|------|---------|
| Python | `pip install "axllm @ git+https://github.com/ax-llm/ax#subdirectory=packages/python"` |
| Rust | `cargo add --git https://github.com/ax-llm/ax axllm` |
| Go | `go get github.com/ax-llm/ax/packages/go` |
| Java | `git clone … && (cd ax/packages/java && mvn -q install)` → depend on `dev.axllm:ax` |
| C++ | CMake `FetchContent` (`SOURCE_SUBDIR packages/cpp`) → link `axllm::axllm` |

Each is reflected in `website/content-src/languages/*.json`, the regenerated
`packages/*/README.md`, and the main `README.md`. The clean published one-liners
(`pip install axllm` / `cargo add axllm`) are noted as lighting up once the registries
are enabled.

Verification: a throwaway consumer project per language (kept out of the repo; `demo/`
is now gitignored) added each package **as a dependency** via the documented command and
ran a minimal `ax("question:string -> answer:string")` generation against `gpt-4o-mini`,
printing a grounded answer.

## Still needs registry-account access (cannot be done from a PR)
Publishing `axllm` to PyPI + crates.io and `dev.axllm:ax` to Maven Central so the clean
one-liners work. The publish workflow already exists (`package-publish.yml`); claiming the
names + registering OIDC trusted publishers is a manual account-owner step.

## Gates
`axir:check-packages`, `skills:check`, `go build ./...`, `go test -C tools/axir ./...` — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
