### PR TITLE
release: bump non-TS package versions together with the TS release

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "website:dev": "npm run website:prepare && hugo server --source website",
     "website:check": "node scripts/check-website-links.mjs",
     "prepare": "lefthook install",
-    "release": "npm run release --workspaces --if-present && release-it --no-increment",
+    "release": "npm run release --workspaces --if-present && npm run axir:generate-packages && release-it --no-increment",
     "publish": "npm run publish --workspaces  --if-present -- --provenance --access public",
     "dependencies:rebuild": "rm -rf package-lock.json && rm -rf node_modules && rm -rf */*/node_modules && npm i --no-audit --no-fund",
     "tsx": "node --env-file=.env --import=tsx",


### PR DESCRIPTION
## Problem

`npm run release` bumps the **TS** version (workspace `release-it` bumpers write it into root
`package.json`), but the **non-TS** packages bake their version in *at generation time* and
nothing regenerated them during release. So a release to `22.0.4` would leave
`packages/{rust,java,python,cpp,go}` stamped at the old version:

- the **AxIR Package Freshness** gate goes red on the release commit, and
- `package-publish.yml` (triggered by the GitHub Release) publishes `axllm` at the **stale** version.

## Fix

One line — regenerate the packages between the workspace bump and the release-it commit:

```
"release": "npm run release --workspaces --if-present && npm run axir:generate-packages && release-it --no-increment"
```

The bump writes the new version into root `package.json`; `axir:generate-packages` reads it
(`generatedPackageVersion()`) and restamps every package; release-it then stages with
`git add . --update` and commits, so the regenerated `packages/` land in the release commit + tag.
Net: `npm run release` now bumps **all** languages together, freshness stays green, and the
non-TS registries publish the same version as npm.

## Verification

Simulated a `22.0.3 → 22.0.4` bump (`AX_PACKAGE_VERSION=22.0.4 npm run axir:generate-packages`)
then ran release-it's exact staging command:
- **71** `packages/` files restamped (`packages/rust/Cargo.toml` → `version = "22.0.4"`, CMake, pom, pyproject, SKILL.md/README refs)
- `git add . --update` staged all 71 → they would be in the release commit
- reverted cleanly; only `package.json` changes on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)
