### PR TITLE
fix(maven): bump central-publishing-maven-plugin to 0.11.0 (0.7.0 false-fails on publish)

### DIFF
--- a/packages/java/pom.xml
+++ b/packages/java/pom.xml
@@ -140,7 +140,7 @@
           <plugin>
             <groupId>org.sonatype.central</groupId>
             <artifactId>central-publishing-maven-plugin</artifactId>
-            <version>0.7.0</version>
+            <version>0.11.0</version>
             <extensions>true</extensions>
             <configuration>
               <publishingServerId>central</publishingServerId>

--- a/tools/axir/internal/axir/templates/package/javaPomXML.xml
+++ b/tools/axir/internal/axir/templates/package/javaPomXML.xml
@@ -140,7 +140,7 @@
           <plugin>
             <groupId>org.sonatype.central</groupId>
             <artifactId>central-publishing-maven-plugin</artifactId>
-            <version>0.7.0</version>
+            <version>0.11.0</version>
             <extensions>true</extensions>
             <configuration>
               <publishingServerId>central</publishingServerId>


### PR DESCRIPTION
## Problem

The `22.0.4` release's `java-maven-central` job reported **failure**, but the artifact **actually published** — [`dev.axllm:ax:22.0.4`](https://repo1.maven.org/maven2/dev/axllm/ax/22.0.4/) is live on Maven Central.

The bundle uploaded and auto-published fine; then `central-publishing-maven-plugin:0.7.0` crashed **parsing the Portal's status response**:
```
UnrecognizedPropertyException: Unrecognized field "warnings" (class DeploymentApiResponse)
```
The Central Portal API added a `warnings` field that `0.7.0`'s model doesn't tolerate — a known bug fixed in later releases.

## Fix

Bump the plugin `0.7.0 → 0.11.0` (latest) in the generated pom template so future releases report success correctly. No config change.

## Verification
- `0.11.0` resolves from Maven Central; `mvn -Prelease validate` → BUILD SUCCESS
- regenerated `packages/java/pom.xml`; AxIR Package Freshness stays green

🤖 Generated with [Claude Code](https://claude.com/claude-code)