### PR TITLE
fix(anthropic): retry and fail over on transient errors (overload, rate limits, server errors)

### DIFF
--- a/docs/AXIR_BACKLOG.md
+++ b/docs/AXIR_BACKLOG.md
@@ -6,7 +6,13 @@ This ledger tracks portable TypeScript behavior that should be migrated into AxI
 
 ## Open
 
-No entries.
+- `axir-2026-06-24-port-anthropic-transient-error-classification-streaming-retry-fa` [axai] Port Anthropic transient-error classification + streaming retry/failover
+  - Status: open
+  - Source PR: #556
+  - Source commit: `2d1a5f96f033640bf4e892e866fde99bc92e8268`
+  - TS paths: `src/ax/ai`
+  - Impact: Generated Python/Java/C++/Go/Rust packages still map Anthropic streaming error events (overloaded_error/api_error/rate_limit_error) to refusals instead of retryable status errors, and lack the balancer's 529 retryability, pre-content streaming-overload retry-with-backoff, and mid-stream failure recording — so transient Anthropic errors hard-fail there with no retry or failover.
+  - Suggested AxIR work: Add or update the TS-derived conformance fixture.; Update AxIR/Core or descriptor data to match the portable TS behavior.; Run npm run axir:conformance:check and npm run test:axir.
 
 ## Done
 

--- a/ir/axir-backlog.json
+++ b/ir/axir-backlog.json
@@ -8,7 +8,9 @@
       "createdAt": "2026-06-07",
       "sourcePR": null,
       "sourceCommit": "4e8da4ba",
-      "tsPaths": ["src/ax/mcp"],
+      "tsPaths": [
+        "src/ax/mcp"
+      ],
       "portableSurface": "axmcp",
       "impact": "Generated Python, Java, C++, Go, and Rust packages do not yet expose the modern MCP client, transports, OAuth discovery, or SSRF guard behavior.",
       "suggestedAxirWork": [
@@ -19,6 +21,27 @@
       "completedAt": "2026-06-07",
       "completedByCommit": "working-tree",
       "verification": "npm run test:axir"
+    },
+    {
+      "id": "axir-2026-06-24-port-anthropic-transient-error-classification-streaming-retry-fa",
+      "status": "open",
+      "title": "Port Anthropic transient-error classification + streaming retry/failover",
+      "createdAt": "2026-06-24",
+      "sourcePR": 556,
+      "sourceCommit": "2d1a5f96f033640bf4e892e866fde99bc92e8268",
+      "tsPaths": [
+        "src/ax/ai"
+      ],
+      "portableSurface": "axai",
+      "impact": "Generated Python/Java/C++/Go/Rust packages still map Anthropic streaming error events (overloaded_error/api_error/rate_limit_error) to refusals instead of retryable status errors, and lack the balancer's 529 retryability, pre-content streaming-overload retry-with-backoff, and mid-stream failure recording — so transient Anthropic errors hard-fail there with no retry or failover.",
+      "suggestedAxirWork": [
+        "Add or update the TS-derived conformance fixture.",
+        "Update AxIR/Core or descriptor data to match the portable TS behavior.",
+        "Run npm run axir:conformance:check and npm run test:axir."
+      ],
+      "completedAt": null,
+      "completedByCommit": null,
+      "verification": null
     }
   ]
 }

--- a/src/ax/ai/anthropic/api.test.ts
+++ b/src/ax/ai/anthropic/api.test.ts
@@ -940,7 +940,9 @@ describe('AxAIAnthropic error-event classification', () => {
         error: { type: 'overloaded_error', message: 'Overloaded' },
       },
     ]);
-    ai.setOptions({ fetch });
+    // Disable retries so this exercises the classification mapping in isolation; the
+    // retry-with-backoff behavior is covered by 'streaming transient-error retry'.
+    ai.setOptions({ fetch, retry: { maxRetries: 0 } });
 
     const stream = (await ai.chat(
       { chatPrompt: [{ role: 'user', content: 'hello' }] },
@@ -1013,6 +1015,113 @@ describe('AxAIAnthropic error-event classification', () => {
       expect((err as AxAIServiceStatusError).status).toBe(status);
     }
   );
+});
+
+describe('AxAIAnthropic streaming transient-error retry', () => {
+  const overloadChunk = {
+    type: 'error',
+    error: { type: 'overloaded_error', message: 'Overloaded' },
+  };
+  const goodChunks = [
+    {
+      type: 'message_start',
+      message: {
+        id: 'msg_ok',
+        type: 'message',
+        role: 'assistant',
+        content: [],
+        model: 'claude-opus-4-8',
+        stop_reason: null,
+        usage: { input_tokens: 1, output_tokens: 0 },
+      },
+    },
+    {
+      type: 'content_block_delta',
+      index: 0,
+      delta: { type: 'text_delta', text: 'recovered' },
+    },
+    {
+      type: 'message_delta',
+      delta: { stop_reason: 'end_turn' },
+      usage: { output_tokens: 2 },
+    },
+  ];
+
+  // Builds a streaming Response from chunks, choosing per fetch call so we can return an
+  // overload first and a healthy stream on retry.
+  const streamFetch = (chunksByCall: readonly (readonly unknown[])[]) => {
+    let call = 0;
+    return vi.fn().mockImplementation(async () => {
+      const chunks = chunksByCall[Math.min(call, chunksByCall.length - 1)];
+      call++;
+      const encoder = new TextEncoder();
+      const body = new ReadableStream<Uint8Array>({
+        start(controller) {
+          for (const chunk of chunks ?? []) {
+            controller.enqueue(
+              encoder.encode(`data: ${JSON.stringify(chunk)}\n\n`)
+            );
+          }
+          controller.close();
+        },
+      });
+      return new Response(body, {
+        status: 200,
+        headers: { 'Content-Type': 'text/event-stream' },
+      });
+    });
+  };
+
+  it('retries a pre-content overloaded_error then streams the recovered response', async () => {
+    const fetch = streamFetch([[overloadChunk], goodChunks]);
+    const ai = new AxAIAnthropic({
+      apiKey: 'key',
+      config: { model: AxAIAnthropicModel.Claude48Opus },
+    });
+    ai.setOptions({ fetch, retry: { initialDelayMs: 1, maxRetries: 2 } });
+
+    const stream = (await ai.chat(
+      { chatPrompt: [{ role: 'user', content: 'hello' }] },
+      { stream: true }
+    )) as ReadableStream<any>;
+
+    let text = '';
+    const reader = stream.getReader();
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      text += value.results?.[0]?.content ?? '';
+    }
+
+    expect(text).toBe('recovered');
+    expect(fetch).toHaveBeenCalledTimes(2); // initial overload + 1 retry that succeeded
+  });
+
+  it('surfaces a 529 after exhausting the streaming overload retry budget', async () => {
+    const fetch = streamFetch([[overloadChunk]]); // always overloaded
+    const ai = new AxAIAnthropic({
+      apiKey: 'key',
+      config: { model: AxAIAnthropicModel.Claude48Opus },
+    });
+    ai.setOptions({ fetch, retry: { initialDelayMs: 1, maxRetries: 2 } });
+
+    const stream = (await ai.chat(
+      { chatPrompt: [{ role: 'user', content: 'hello' }] },
+      { stream: true }
+    )) as ReadableStream<any>;
+
+    const err = await stream
+      .getReader()
+      .read()
+      .then(
+        () => undefined,
+        (e) => e
+      );
+
+    expect(err).toBeInstanceOf(AxAIServiceStatusError);
+    expect((err as AxAIServiceStatusError).status).toBe(529);
+    expect(fetch).toHaveBeenCalledTimes(3); // initial + maxRetries(2)
+  });
 });
 
 describe('AxAIAnthropic user message caching', () => {

--- a/src/ax/ai/anthropic/api.test.ts
+++ b/src/ax/ai/anthropic/api.test.ts
@@ -1,6 +1,10 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { AxAIRefusalError } from '../../util/apicall.js';
+import {
+  AxAIServiceAuthenticationError,
+  AxAIServiceStatusError,
+} from '../../util/apicall.js';
 import { AxAIAnthropic } from './api.js';
 import { AxAIAnthropicModel } from './types.js';
 
@@ -897,6 +901,118 @@ describe('AxAIAnthropic thinking configuration', () => {
       refusalMessage: 'Cyber safety policy refusal.',
     } satisfies Partial<AxAIRefusalError>);
   });
+});
+
+describe('AxAIAnthropic error-event classification', () => {
+  it('maps a non-streaming overloaded_error event to a 529 status error', async () => {
+    const ai = new AxAIAnthropic({
+      apiKey: 'key',
+      config: { model: AxAIAnthropicModel.Claude48Opus },
+    });
+    const fetch = createMockFetch({
+      type: 'error',
+      error: { type: 'overloaded_error', message: 'Overloaded' },
+    });
+    ai.setOptions({ fetch });
+
+    const err = await ai
+      .chat(
+        { chatPrompt: [{ role: 'user', content: 'hello' }] },
+        { stream: false }
+      )
+      .then(
+        () => undefined,
+        (e) => e
+      );
+
+    expect(err).toBeInstanceOf(AxAIServiceStatusError);
+    expect((err as AxAIServiceStatusError).status).toBe(529);
+  });
+
+  it('maps a streaming overloaded_error event to a 529 status error', async () => {
+    const ai = new AxAIAnthropic({
+      apiKey: 'key',
+      config: { model: AxAIAnthropicModel.Claude48Opus },
+    });
+    const fetch = createMockStreamFetch([
+      {
+        type: 'error',
+        error: { type: 'overloaded_error', message: 'Overloaded' },
+      },
+    ]);
+    ai.setOptions({ fetch });
+
+    const stream = (await ai.chat(
+      { chatPrompt: [{ role: 'user', content: 'hello' }] },
+      { stream: true }
+    )) as ReadableStream<any>;
+    const reader = stream.getReader();
+
+    const err = await reader.read().then(
+      () => undefined,
+      (e) => e
+    );
+
+    expect(err).toBeInstanceOf(AxAIServiceStatusError);
+    expect((err as AxAIServiceStatusError).status).toBe(529);
+  });
+
+  it('maps an authentication_error event to an authentication error', async () => {
+    const ai = new AxAIAnthropic({
+      apiKey: 'key',
+      config: { model: AxAIAnthropicModel.Claude48Opus },
+    });
+    const fetch = createMockFetch({
+      type: 'error',
+      error: { type: 'authentication_error', message: 'invalid x-api-key' },
+    });
+    ai.setOptions({ fetch });
+
+    const err = await ai
+      .chat(
+        { chatPrompt: [{ role: 'user', content: 'hello' }] },
+        { stream: false }
+      )
+      .then(
+        () => undefined,
+        (e) => e
+      );
+
+    expect(err).toBeInstanceOf(AxAIServiceAuthenticationError);
+  });
+
+  it.each([
+    ['invalid_request_error', 400],
+    ['permission_error', 403],
+    ['not_found_error', 404],
+    ['request_too_large', 413],
+  ])(
+    'maps a %s event to a non-refusal %i status error',
+    async (type, status) => {
+      const ai = new AxAIAnthropic({
+        apiKey: 'key',
+        config: { model: AxAIAnthropicModel.Claude48Opus },
+      });
+      const fetch = createMockFetch({
+        type: 'error',
+        error: { type, message: type },
+      });
+      ai.setOptions({ fetch });
+
+      const err = await ai
+        .chat(
+          { chatPrompt: [{ role: 'user', content: 'hello' }] },
+          { stream: false }
+        )
+        .then(
+          () => undefined,
+          (e) => e
+        );
+
+      expect(err).toBeInstanceOf(AxAIServiceStatusError);
+      expect((err as AxAIServiceStatusError).status).toBe(status);
+    }
+  );
 });
 
 describe('AxAIAnthropic user message caching', () => {

--- a/src/ax/ai/anthropic/api.ts
+++ b/src/ax/ai/anthropic/api.ts
@@ -49,6 +49,32 @@ const buildAnthropicBetaHeader = (extraBetas: readonly string[] = []): string =>
   [...new Set([...ANTHROPIC_BASE_BETAS, ...extraBetas])].join(', ');
 
 /**
+ * The HTTP status an Anthropic `error.type` corresponds to, or undefined for types that
+ * aren't status errors (authentication, or unknown types treated as refusals). Shared by
+ * the error-event mapper and the streaming-error classifier so both agree on the mapping.
+ */
+function anthropicErrorTypeToStatus(type: string): number | undefined {
+  switch (type) {
+    case 'overloaded_error':
+      return 529;
+    case 'api_error':
+      return 500;
+    case 'rate_limit_error':
+      return 429;
+    case 'invalid_request_error':
+      return 400;
+    case 'permission_error':
+      return 403;
+    case 'not_found_error':
+      return 404;
+    case 'request_too_large':
+      return 413;
+    default:
+      return undefined;
+  }
+}
+
+/**
  * Maps an Anthropic `type: 'error'` event to the right Ax error class so the balancer can fail
  * over on transient errors instead of hard-failing. These callbacks only run on HTTP-200 error
  * envelopes (e.g. the streaming `overloaded_error` SSE event), so the status is derived from
@@ -58,26 +84,14 @@ function mapAnthropicErrorEvent(error: {
   type: string;
   message: string;
 }): AxAIServiceStatusError | AxAIServiceAuthenticationError | AxAIRefusalError {
-  switch (error.type) {
-    case 'overloaded_error':
-      return new AxAIServiceStatusError(529, error.type, '', undefined, error);
-    case 'api_error':
-      return new AxAIServiceStatusError(500, error.type, '', undefined, error);
-    case 'rate_limit_error':
-      return new AxAIServiceStatusError(429, error.type, '', undefined, error);
-    case 'invalid_request_error':
-      return new AxAIServiceStatusError(400, error.type, '', undefined, error);
-    case 'permission_error':
-      return new AxAIServiceStatusError(403, error.type, '', undefined, error);
-    case 'not_found_error':
-      return new AxAIServiceStatusError(404, error.type, '', undefined, error);
-    case 'request_too_large':
-      return new AxAIServiceStatusError(413, error.type, '', undefined, error);
-    case 'authentication_error':
-      return new AxAIServiceAuthenticationError('', undefined, error);
-    default:
-      return new AxAIRefusalError(error.message);
+  if (error.type === 'authentication_error') {
+    return new AxAIServiceAuthenticationError('', undefined, error);
   }
+  const status = anthropicErrorTypeToStatus(error.type);
+  if (status !== undefined) {
+    return new AxAIServiceStatusError(status, error.type, '', undefined, error);
+  }
+  return new AxAIRefusalError(error.message);
 }
 
 const isClaudeOpus47OrLater = (model: string): boolean =>
@@ -802,6 +816,15 @@ class AxAIAnthropicImpl
 
     return { results, remoteId: resp.id };
   };
+
+  // Classifies a streaming error event (delivered as an HTTP-200 SSE event) into its HTTP
+  // status so the base layer can retry transient overloads with backoff before failover.
+  classifyStreamErrorStatus = (
+    resp: Readonly<AxAIAnthropicChatResponseDelta>
+  ): number | undefined =>
+    resp.type === 'error'
+      ? anthropicErrorTypeToStatus(resp.error.type)
+      : undefined;
 
   createChatStreamResp = (
     resp: Readonly<AxAIAnthropicChatResponseDelta>,

--- a/src/ax/ai/anthropic/api.ts
+++ b/src/ax/ai/anthropic/api.ts
@@ -1,6 +1,10 @@
 import { getModelInfo } from '../../dsp/modelinfo.js';
 import type { AxAPI } from '../../util/apicall.js';
-import { AxAIRefusalError } from '../../util/apicall.js';
+import {
+  AxAIRefusalError,
+  AxAIServiceAuthenticationError,
+  AxAIServiceStatusError,
+} from '../../util/apicall.js';
 import { AxBaseAI, axBaseAIDefaultConfig } from '../base.js';
 import type {
   AxAIInputModelList,
@@ -43,6 +47,38 @@ const ANTHROPIC_TASK_BUDGET_BETA = 'task-budgets-2026-03-13';
 
 const buildAnthropicBetaHeader = (extraBetas: readonly string[] = []): string =>
   [...new Set([...ANTHROPIC_BASE_BETAS, ...extraBetas])].join(', ');
+
+/**
+ * Maps an Anthropic `type: 'error'` event to the right Ax error class so the balancer can fail
+ * over on transient errors instead of hard-failing. These callbacks only run on HTTP-200 error
+ * envelopes (e.g. the streaming `overloaded_error` SSE event), so the status is derived from
+ * `error.type`; url/body aren't in scope, and the balancer only reads `.status`.
+ */
+function mapAnthropicErrorEvent(error: {
+  type: string;
+  message: string;
+}): AxAIServiceStatusError | AxAIServiceAuthenticationError | AxAIRefusalError {
+  switch (error.type) {
+    case 'overloaded_error':
+      return new AxAIServiceStatusError(529, error.type, '', undefined, error);
+    case 'api_error':
+      return new AxAIServiceStatusError(500, error.type, '', undefined, error);
+    case 'rate_limit_error':
+      return new AxAIServiceStatusError(429, error.type, '', undefined, error);
+    case 'invalid_request_error':
+      return new AxAIServiceStatusError(400, error.type, '', undefined, error);
+    case 'permission_error':
+      return new AxAIServiceStatusError(403, error.type, '', undefined, error);
+    case 'not_found_error':
+      return new AxAIServiceStatusError(404, error.type, '', undefined, error);
+    case 'request_too_large':
+      return new AxAIServiceStatusError(413, error.type, '', undefined, error);
+    case 'authentication_error':
+      return new AxAIServiceAuthenticationError('', undefined, error);
+    default:
+      return new AxAIRefusalError(error.message);
+  }
+}
 
 const isClaudeOpus47OrLater = (model: string): boolean =>
   model.includes('claude-opus-4-7') || model.includes('claude-opus-4-8');
@@ -629,12 +665,7 @@ class AxAIAnthropicImpl
     resp: Readonly<AxAIAnthropicChatResponse | AxAIAnthropicChatError>
   ): AxChatResponse => {
     if (resp.type === 'error') {
-      // Use AxAIRefusalError for authentication and API errors that could be refusal-related
-      throw new AxAIRefusalError(
-        resp.error.message,
-        undefined, // model not specified in error response
-        undefined // requestId not specified in error response
-      );
+      throw mapAnthropicErrorEvent(resp.error);
     }
 
     if (resp.stop_reason === 'refusal') {
@@ -791,11 +822,7 @@ class AxAIAnthropicImpl
 
     if (resp.type === 'error') {
       const { error } = resp as unknown as AxAIAnthropicErrorEvent;
-      throw new AxAIRefusalError(
-        error.message,
-        undefined, // model not specified in error event
-        undefined // requestId not specified in error event
-      );
+      throw mapAnthropicErrorEvent(error);
     }
 
     const index = 0;

--- a/src/ax/ai/anthropic/types.ts
+++ b/src/ax/ai/anthropic/types.ts
@@ -285,7 +285,15 @@ export type AxAIAnthropicChatResponse = {
 export type AxAIAnthropicChatError = {
   type: 'error';
   error: {
-    type: 'authentication_error';
+    type:
+      | 'overloaded_error'
+      | 'api_error'
+      | 'rate_limit_error'
+      | 'invalid_request_error'
+      | 'authentication_error'
+      | 'permission_error'
+      | 'not_found_error'
+      | 'request_too_large';
     message: string;
   };
 };
@@ -410,7 +418,15 @@ export interface AxAIAnthropicPingEvent {
 export interface AxAIAnthropicErrorEvent {
   type: 'error';
   error: {
-    type: 'overloaded_error';
+    type:
+      | 'overloaded_error'
+      | 'api_error'
+      | 'rate_limit_error'
+      | 'invalid_request_error'
+      | 'authentication_error'
+      | 'permission_error'
+      | 'not_found_error'
+      | 'request_too_large';
     message: string;
   };
 }

--- a/src/ax/ai/balance.test.ts
+++ b/src/ax/ai/balance.test.ts
@@ -408,4 +408,170 @@ describe('AxBalancer', () => {
     expect(calledService).toBe(1);
     expect('results' in res && res.results[0]?.content).toBe('test response');
   });
+
+  test('fails over on a streaming 529 thrown while reading the stream', async () => {
+    let calledService: number | undefined;
+    const services: AxAIService[] = [
+      createMockService({
+        name: 'service-0',
+        // Resolves with a stream (HTTP-200), then errors on the first read — the shape of
+        // Anthropic's streaming overloaded_error. The balancer must peek this and fail over.
+        chatResponse: async () =>
+          new ReadableStream({
+            pull(controller) {
+              controller.error(
+                new AxAIServiceStatusError(
+                  529,
+                  'overloaded_error',
+                  'test-url',
+                  {},
+                  {}
+                )
+              );
+            },
+          }),
+      }),
+      createMockService({
+        name: 'service-1',
+        chatResponse: async () => {
+          calledService = 1;
+          return new ReadableStream({
+            start(controller) {
+              controller.enqueue({
+                results: [
+                  {
+                    index: 0,
+                    content: 'streamed fallback',
+                    finishReason: 'stop' as const,
+                  },
+                ],
+                modelUsage: {
+                  ai: 'test-ai',
+                  model: 'test-model',
+                  tokens: {
+                    promptTokens: 20,
+                    completionTokens: 10,
+                    totalTokens: 30,
+                  },
+                },
+              });
+              controller.close();
+            },
+          });
+        },
+      }),
+    ];
+
+    const balancer = new AxBalancer(services, {
+      comparator: AxBalancer.inputOrderComparator,
+      debug: false,
+    });
+
+    const res = await balancer.chat(
+      { chatPrompt: [{ role: 'user', content: 'test' }], model: 'mock' },
+      { stream: true }
+    );
+
+    let content = '';
+    const reader = (res as ReadableStream<any>).getReader();
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      content += value.results?.[0]?.content ?? '';
+    }
+
+    expect(calledService).toBe(1);
+    expect(content).toBe('streamed fallback');
+  });
+
+  test('records a mid-stream failure so the next call backs off the failed service', async () => {
+    let calledService1 = false;
+    const streamingChunk = {
+      results: [
+        { index: 0, content: 'partial', finishReason: 'stop' as const },
+      ],
+      modelUsage: {
+        ai: 'test-ai',
+        model: 'test-model',
+        tokens: { promptTokens: 20, completionTokens: 10, totalTokens: 30 },
+      },
+    };
+    const services: AxAIService[] = [
+      createMockService({
+        name: 'service-0',
+        // Emits one good chunk, then errors mid-stream — too late to fail over transparently
+        // (partial output is committed), but the failure must still be recorded for backoff.
+        chatResponse: async () =>
+          new ReadableStream({
+            start(controller) {
+              controller.enqueue(streamingChunk);
+            },
+            pull(controller) {
+              controller.error(
+                new AxAIServiceStatusError(
+                  529,
+                  'overloaded_error',
+                  'test-url',
+                  {},
+                  {}
+                )
+              );
+            },
+          }),
+      }),
+      createMockService({
+        name: 'service-1',
+        chatResponse: async () => {
+          calledService1 = true;
+          return new ReadableStream({
+            start(controller) {
+              controller.enqueue({ ...streamingChunk });
+              controller.close();
+            },
+          });
+        },
+      }),
+    ];
+
+    const balancer = new AxBalancer(services, {
+      comparator: AxBalancer.inputOrderComparator,
+      debug: false,
+    });
+
+    // First call: stream from service-0 delivers one chunk then throws mid-stream.
+    const res1 = (await balancer.chat(
+      { chatPrompt: [{ role: 'user', content: 'test' }], model: 'mock' },
+      { stream: true }
+    )) as ReadableStream<any>;
+    let firstContent = '';
+    let midStreamError: unknown;
+    const reader1 = res1.getReader();
+    try {
+      while (true) {
+        const { done, value } = await reader1.read();
+        if (done) break;
+        firstContent += value.results?.[0]?.content ?? '';
+      }
+    } catch (e) {
+      midStreamError = e;
+    }
+    expect(firstContent).toBe('partial');
+    expect(midStreamError).toBeInstanceOf(AxAIServiceStatusError);
+    expect(calledService1).toBe(false);
+
+    // Second call: service-0 is now in backoff, so the balancer must route to service-1.
+    const res2 = (await balancer.chat(
+      { chatPrompt: [{ role: 'user', content: 'test' }], model: 'mock' },
+      { stream: true }
+    )) as ReadableStream<any>;
+    let secondContent = '';
+    const reader2 = res2.getReader();
+    while (true) {
+      const { done, value } = await reader2.read();
+      if (done) break;
+      secondContent += value.results?.[0]?.content ?? '';
+    }
+    expect(calledService1).toBe(true);
+    expect(secondContent).toBe('partial');
+  });
 });

--- a/src/ax/ai/balance.test.ts
+++ b/src/ax/ai/balance.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, test } from 'vitest';
 
-import { AxAIServiceNetworkError } from '../util/apicall.js';
+import {
+  AxAIServiceNetworkError,
+  AxAIServiceStatusError,
+} from '../util/apicall.js';
 
 import { AxBalancer } from './balance.js';
 import { AxMockAIService, type AxMockAIServiceConfig } from './mock/api.js';
@@ -348,5 +351,61 @@ describe('AxBalancer', () => {
     });
 
     expect(calledService).toBe(1);
+  });
+
+  test('fails over to next service on a 529 overloaded status', async () => {
+    let calledService: number | undefined;
+    const services: AxAIService[] = [
+      createMockService({
+        name: 'service-0',
+        latencyMs: 200,
+        chatResponse: async () => {
+          throw new AxAIServiceStatusError(
+            529,
+            'overloaded_error',
+            'test-url',
+            {},
+            {}
+          );
+        },
+      }),
+      createMockService({
+        name: 'service-1',
+        chatResponse: async () => {
+          calledService = 1;
+          return {
+            results: [
+              {
+                index: 0,
+                content: 'test response',
+                finishReason: 'stop' as const,
+              },
+            ],
+            modelUsage: {
+              ai: 'test-ai',
+              model: 'test-model',
+              tokens: {
+                promptTokens: 20,
+                completionTokens: 10,
+                totalTokens: 30,
+              },
+            },
+          };
+        },
+      }),
+    ];
+
+    const balancer = new AxBalancer(services, {
+      comparator: AxBalancer.inputOrderComparator,
+      debug: false,
+    });
+
+    const res = await balancer.chat({
+      chatPrompt: [{ role: 'user', content: 'test' }],
+      model: 'mock',
+    });
+
+    expect(calledService).toBe(1);
+    expect('results' in res && res.results[0]?.content).toBe('test response');
   });
 });

--- a/src/ax/ai/balance.ts
+++ b/src/ax/ai/balance.ts
@@ -80,6 +80,12 @@ export class AxBalancer<
     { retries: number; lastFailureTime: number }
   > = new Map();
 
+  // Status codes worth retrying on a different service: 408 Request Timeout,
+  // 429 Too Many Requests, 5xx server errors, and 529 (Anthropic overloaded).
+  private static readonly RETRYABLE_STATUS_CODES = [
+    408, 429, 500, 502, 503, 504, 529,
+  ];
+
   constructor(services: TServices, options?: AxBalancerOptions<TModelKey>) {
     if (services.length === 0) {
       throw new Error('No AI services provided.');
@@ -390,6 +396,84 @@ export class AxBalancer<
     this.serviceFailures.delete(service.getId());
   }
 
+  /**
+   * Whether an error should route to another service rather than fail the request.
+   * Mirrors the decisions made in chat()'s catch block so the streaming peek path and
+   * the synchronous path agree on what "retryable" means.
+   */
+  private isRetryableServiceError(e: unknown): e is AxAIServiceError {
+    if (!(e instanceof AxAIServiceError)) return false;
+    switch (e.constructor) {
+      case AxAIServiceAuthenticationError:
+        return false;
+      case AxAIServiceStatusError:
+        return AxBalancer.RETRYABLE_STATUS_CODES.includes(
+          (e as AxAIServiceStatusError).status
+        );
+      case AxAIServiceNetworkError:
+      case AxAIServiceResponseError:
+      case AxAIServiceStreamTerminatedError:
+      case AxAIServiceTimeoutError:
+        return true;
+      default:
+        return false;
+    }
+  }
+
+  /**
+   * Wraps a streaming response to make it participate in failover. Two responsibilities:
+   *
+   * 1. Pre-content errors: eagerly reads the first chunk so a provider error thrown while
+   *    reading (e.g. Anthropic's HTTP-200 `overloaded_error` SSE) rejects here, where
+   *    {@link chat}'s try/catch can route it through the normal failover path. On success it
+   *    returns a new stream that re-emits the buffered first chunk then pumps the rest.
+   * 2. Mid-stream errors: a retryable error *after* the first chunk can't fail over
+   *    transparently (partial output is already committed), so it is surfaced via
+   *    `controller.error`. But we record the failure first (see {@link handleFailure}) —
+   *    otherwise the failed service stays out of backoff and an app-level retry via chat()
+   *    (which restarts at index 0 and doesn't reset()) would route straight back to it.
+   */
+  private async peekStreamForFailover(
+    stream: ReadableStream<AxChatResponse>,
+    service: AxAIService<unknown, unknown, TModelKey>
+  ): Promise<ReadableStream<AxChatResponse>> {
+    const reader = stream.getReader();
+    // May reject (provider error event) — propagated to chat()'s catch for failover.
+    const first = await reader.read();
+    let emittedFirst = false;
+    // Arrow captures `this`/`service`; the ReadableStream source's `this` is not the balancer.
+    const recordMidStreamFailure = (err: unknown): void => {
+      if (this.isRetryableServiceError(err)) this.handleFailure(service, err);
+    };
+    return new ReadableStream<AxChatResponse>({
+      async pull(controller) {
+        if (!emittedFirst) {
+          emittedFirst = true;
+          if (first.done) {
+            controller.close();
+            return;
+          }
+          controller.enqueue(first.value);
+          return;
+        }
+        try {
+          const { done, value } = await reader.read();
+          if (done) {
+            controller.close();
+            return;
+          }
+          controller.enqueue(value);
+        } catch (err) {
+          recordMidStreamFailure(err);
+          controller.error(err);
+        }
+      },
+      cancel(reason) {
+        return reader.cancel(reason);
+      },
+    });
+  }
+
   async chat(
     req: Readonly<AxChatRequest<TModelKey>>,
     options?: Readonly<AxAIServiceOptions>
@@ -458,6 +542,19 @@ export class AxBalancer<
 
       try {
         const response = await currentService.chat(req, options);
+        // For streaming responses the provider resolves with the stream as soon as the
+        // HTTP headers arrive; an error event (e.g. Anthropic's HTTP-200 `overloaded_error`
+        // SSE) is only thrown when the stream is read — which happens in the caller, after
+        // this try/catch has returned. Peek the first chunk here so a pre-content error
+        // surfaces inside this try/catch and can drive failover.
+        if (response instanceof ReadableStream) {
+          const peeked = await this.peekStreamForFailover(
+            response,
+            currentService
+          );
+          this.handleSuccess(currentService);
+          return peeked;
+        }
         this.handleSuccess(currentService);
         return response;
       } catch (e) {
@@ -471,11 +568,11 @@ export class AxBalancer<
             throw e;
 
           case AxAIServiceStatusError: {
-            // Only retry specific status codes that are retryable
-            // 408 = Request Timeout, 429 = Too Many Requests, 5xx = Server errors
-            const retryableStatuses = [408, 429, 500, 502, 503, 504, 529];
+            // Only retry specific status codes that are retryable.
             if (
-              !retryableStatuses.includes((e as AxAIServiceStatusError).status)
+              !AxBalancer.RETRYABLE_STATUS_CODES.includes(
+                (e as AxAIServiceStatusError).status
+              )
             ) {
               throw e;
             }
@@ -561,8 +658,7 @@ export class AxBalancer<
 
         // Don't retry non-retryable status codes (4xx except 408 and 429)
         if (e instanceof AxAIServiceStatusError) {
-          const retryableStatuses = [408, 429, 500, 502, 503, 504, 529];
-          if (!retryableStatuses.includes(e.status)) {
+          if (!AxBalancer.RETRYABLE_STATUS_CODES.includes(e.status)) {
             throw e;
           }
         }

--- a/src/ax/ai/balance.ts
+++ b/src/ax/ai/balance.ts
@@ -473,7 +473,7 @@ export class AxBalancer<
           case AxAIServiceStatusError: {
             // Only retry specific status codes that are retryable
             // 408 = Request Timeout, 429 = Too Many Requests, 5xx = Server errors
-            const retryableStatuses = [408, 429, 500, 502, 503, 504];
+            const retryableStatuses = [408, 429, 500, 502, 503, 504, 529];
             if (
               !retryableStatuses.includes((e as AxAIServiceStatusError).status)
             ) {
@@ -561,7 +561,7 @@ export class AxBalancer<
 
         // Don't retry non-retryable status codes (4xx except 408 and 429)
         if (e instanceof AxAIServiceStatusError) {
-          const retryableStatuses = [408, 429, 500, 502, 503, 504];
+          const retryableStatuses = [408, 429, 500, 502, 503, 504, 529];
           if (!retryableStatuses.includes(e.status)) {
             throw e;
           }

--- a/src/ax/ai/base.ts
+++ b/src/ax/ai/base.ts
@@ -9,7 +9,12 @@ import { defaultLogger } from '../dsp/loggers.js';
 import { getModelInfo } from '../dsp/modelinfo.js';
 import { axSpanAttributes, axSpanEvents } from '../trace/trace.js';
 import { mergeAbortSignals } from '../util/abort.js';
-import { AxMediaNotSupportedError, apiCall } from '../util/apicall.js';
+import type { RetryConfig } from '../util/apicall.js';
+import {
+  AxMediaNotSupportedError,
+  apiCall,
+  defaultRetryConfig,
+} from '../util/apicall.js';
 import { createHash, randomUUID } from '../util/crypto.js';
 import { RespTransformStream } from '../util/transform.js';
 import {
@@ -1718,6 +1723,88 @@ export class AxBaseAI<
     return cleanFn;
   }
 
+  /**
+   * Peeks the first raw streaming delta and, if the provider classifies it as a retryable
+   * transient error (e.g. an Anthropic `overloaded_error` SSE event), re-issues the request
+   * with exponential backoff — the same policy {@link apiCall} applies to an HTTP 529 status,
+   * so streaming and non-streaming overloads behave identically. The first delta is classified
+   * on the raw chunk (no stateful transform runs), so peeking has no side effects. After the
+   * retry budget is exhausted the original error delta is replayed so it surfaces normally
+   * (and the balancer can still fail over). A non-error first delta is replayed unchanged.
+   *
+   * Note: re-issuing cancels the previous stream's reader best-effort; the underlying fetch
+   * body of the abandoned overloaded request is released by GC rather than promptly aborted,
+   * since apiCall's streams don't propagate cancel. Acceptable for the transient-overload case.
+   */
+  private async retryTransientStreamStart(
+    stream: ReadableStream<TChatResponseDelta>,
+    reissue: () => Promise<unknown>,
+    retryOverride?: Partial<RetryConfig>
+  ): Promise<ReadableStream<TChatResponseDelta>> {
+    const cfg: RetryConfig = { ...defaultRetryConfig, ...retryOverride };
+    const classify = this.aiImpl.classifyStreamErrorStatus;
+    let current = stream;
+    let attempt = 0;
+
+    while (true) {
+      const reader = current.getReader();
+      const first = await reader.read();
+
+      if (!first.done) {
+        const status = classify?.(first.value);
+        if (
+          status !== undefined &&
+          cfg.retryableStatusCodes.includes(status) &&
+          attempt < cfg.maxRetries
+        ) {
+          await reader.cancel().catch(() => {});
+          attempt++;
+          const delay = Math.min(
+            cfg.initialDelayMs * cfg.backoffFactor ** (attempt - 1),
+            cfg.maxDelayMs
+          );
+          await new Promise((resolve) => setTimeout(resolve, delay));
+          const next = await reissue();
+          if (!(next instanceof ReadableStream)) {
+            return next as ReadableStream<TChatResponseDelta>;
+          }
+          current = next as ReadableStream<TChatResponseDelta>;
+          continue;
+        }
+      }
+
+      // Good first delta, or a non-retryable / retry-exhausted error: replay the buffered
+      // first delta and pump the rest, so the normal transform pipeline runs once.
+      let emittedFirst = false;
+      return new ReadableStream<TChatResponseDelta>({
+        async pull(controller) {
+          if (!emittedFirst) {
+            emittedFirst = true;
+            if (first.done) {
+              controller.close();
+              return;
+            }
+            controller.enqueue(first.value);
+            return;
+          }
+          try {
+            const { done, value } = await reader.read();
+            if (done) {
+              controller.close();
+              return;
+            }
+            controller.enqueue(value);
+          } catch (err) {
+            controller.error(err);
+          }
+        },
+        cancel(reason) {
+          return reader.cancel(reason);
+        },
+      });
+    }
+  }
+
   private async _chat2(
     model: TModel,
     modelConfig: Readonly<AxModelConfig>,
@@ -1879,9 +1966,30 @@ export class AxBaseAI<
     };
 
     const rt = options?.rateLimiter ?? this.rt;
+    const issueRequest = () =>
+      rt ? rt(fn, { modelUsage: this.modelUsage }) : fn();
     let rv: Awaited<ReturnType<typeof fn>>;
     try {
-      rv = rt ? await rt(fn, { modelUsage: this.modelUsage }) : await fn();
+      rv = await issueRequest();
+      // Pre-content streaming retry: if the stream's FIRST delta is a transient error event
+      // (e.g. Anthropic's HTTP-200 `overloaded_error` SSE, which precedes message_start),
+      // re-issue with backoff so a streaming overload gets the same retry policy as an HTTP 529
+      // status — before the balancer sees it. Scope is the first delta only: an error preceded
+      // by leading ping/message_start events isn't retried here, and an error after content
+      // can't be retried at all (output already committed) — both instead surface during
+      // consumption and fail over downstream. Only providers implementing
+      // classifyStreamErrorStatus participate; others are unaffected.
+      if (
+        modelConfig.stream &&
+        rv instanceof ReadableStream &&
+        this.aiImpl.classifyStreamErrorStatus
+      ) {
+        rv = (await this.retryTransientStreamStart(
+          rv as ReadableStream<TChatResponseDelta>,
+          issueRequest,
+          options?.retry ?? this.retry
+        )) as typeof rv;
+      }
     } catch (error) {
       recordSpanException(span, error);
       if (span?.isRecording()) {

--- a/src/ax/ai/types.ts
+++ b/src/ax/ai/types.ts
@@ -1107,6 +1107,17 @@ export interface AxAIServiceImpl<
     state: object
   ): AxChatResponse;
 
+  /**
+   * Optional: classify a raw streaming delta that carries a transient error into the
+   * HTTP status it corresponds to (e.g. Anthropic's HTTP-200 `overloaded_error` SSE event
+   * → 529). The base layer applies the same retryable-status policy used for real HTTP
+   * status errors, so a streaming overload is retried-with-backoff before any failover —
+   * matching the non-streaming path. Return undefined for normal deltas (the common case).
+   */
+  classifyStreamErrorStatus?(
+    resp: Readonly<TChatResponseDelta>
+  ): number | undefined;
+
   createEmbedReq?(
     req: Readonly<AxInternalEmbedRequest<TEmbedModel>>,
     config?: Readonly<AxAIServiceOptions>

--- a/src/ax/util/apicall.ts
+++ b/src/ax/util/apicall.ts
@@ -80,7 +80,7 @@ export const defaultRetryConfig: RetryConfig = {
   initialDelayMs: 1000,
   maxDelayMs: 60000,
   backoffFactor: 2,
-  retryableStatusCodes: [500, 408, 429, 502, 503, 504],
+  retryableStatusCodes: [500, 408, 429, 502, 503, 504, 529],
 };
 
 const textDecoderStream =


### PR DESCRIPTION
## The problem

Anthropic signals transient failures two ways: as an HTTP status (`429` rate limit, `529` overload, `500` server error), and as an HTTP-200 server-sent `error` event — the form a streaming overload always takes. Both response parsers (non-streaming and streaming) mapped *every* `type: "error"` event to `AxAIRefusalError`, which extends `Error` rather than `AxAIServiceError`, so the balancer treated a transient blip as a content refusal and rethrew it immediately — surfacing as `"Model refused to fulfill request: Overloaded"` and hard-failing with no failover, even when healthy fallback providers were configured.

This hit **streaming hardest: it had no resilience at all** — a streaming transient error only ever arrives as an SSE `error` event, so it always took the refusal path, with no retry and no failover. Non-streaming had partial cover (`apiCall` already retried `429`/`500` HTTP statuses before the body was parsed), but `529` was in no retry set and any HTTP-200 error envelope hit the same refusal path.

This PR makes those transient errors behave like the retryable, failover-able conditions they are — consistently across streaming and non-streaming, and across overloads (`529`), rate limits (`429`), and server errors (`500`).

## What's in it

**Problem: streaming error events were misclassified as content refusals.**
Classify Anthropic `error` events by `error.type` — transient errors (`overloaded_error`→529, `api_error`→500, `rate_limit_error`→429) become retryable status errors, `authentication_error` becomes an auth error, client errors map to their statuses (400/403/404/413), and only genuinely-unknown types keep the old refusal default. (`fix(anthropic)`)

**Problem: the balancer never saw streaming errors, so it couldn't fail over.**
A streaming provider returns the `ReadableStream` as soon as the HTTP headers arrive; the error only throws when the stream is *read* — after the balancer has already handed the stream back. The balancer now peeks the first chunk so a pre-content error drives normal failover. An error *after* content can't fail over transparently (bytes are already sent), so it's surfaced — but the failure is recorded so the provider backs off and the app's next call routes elsewhere. (`feat(balance)`)

**Problem: streaming overloads were never retried.**
`apiCall`'s retry keys off HTTP status, but a streaming overload arrives as an HTTP-200 SSE event it never inspects — so a streaming overload failed over immediately while a non-streaming `529` got retried-with-backoff first. The base layer now peeks the first delta and, if the provider classifies it as a retryable transient error, re-issues with the same backoff policy `apiCall` uses for a `529`, before any failover. Opt-in per provider via an optional classifier hook; other providers are unaffected. (`feat(base)`)

**Problem: `529` wasn't retryable anywhere.**
Added `529` to the balancer's retryable status set and to `apiCall`'s default retry config, so a clean HTTP `529` status now retries and fails over too.

## Design decisions (and review concerns we worked through)

- **Retry-then-failover, applied uniformly.** Pre-PR, `529` was in no retry set, so overload had *no resilience at all* — this PR is strictly additive, not a slowdown of a previously-fast failover. We retry-with-backoff on the same endpoint and *then* fail over, for both streaming and non-streaming. This matches Anthropic's documented guidance for 429/529 (retry with exponential backoff; their own SDKs do this by default) and gives a clean two-tier shape: the request layer absorbs short transient blips, the balancer handles sustained outages by moving to another provider. (Immediate-failover-without-retry stays a small product-level choice if a deployment prefers it.)

- **Non-retryable errors are classified but not failed over.** Auth (`401`) and client errors (`400`/`403`/`404`/`413`, including a `403` billing/credit-balance error) are now surfaced as proper status errors instead of refusals, but they're intentionally *not* retried or failed over — retrying a bad request, bad key, or exhausted credit won't help. (Failing a credit-exhausted `403` over to a *different* provider could help, but `403` is too ambiguous to auto-failover safely; that's a possible future enhancement, not this PR.)

- **Unknown error types still default to a refusal.** Conservative, and identical in the streaming and non-streaming paths. Strictly better than before — where *every* error type became a refusal — since only the known transient types were promoted to retryable.

- **Mid-stream (post-content) errors hard-fail and trigger failover — they just aren't retried.** Once tokens have been streamed to the caller you can't transparently re-issue. Before this PR such an error simply streamed through the balancer to the consumer, with no failover action taken (the balancer had already counted the request a success), so the next call would route right back to the same failing provider. Now the error is surfaced as a proper status error — the current call still fails, since you can't un-send bytes — *and* the failure is recorded, so the provider enters backoff and the balancer routes the app's next call to a healthy provider. The only thing they don't get is in-call retry. A pre-content error that isn't the very first event (e.g. preceded by a `ping`/`message_start`) is a rare edge that falls through to this same path. Inherent to streaming, not a regression.

- **Known limitation:** re-issuing on a streaming retry cancels the abandoned stream best-effort, but the low-level streams don't propagate cancel, so the old connection is released by GC rather than promptly aborted. Flagged for a follow-up.

## Testing

Adds coverage for error-event classification, streaming and non-streaming 529 failover, mid-stream failure → next-call backoff, and streaming overload retry-then-recover / retry-then-surface. Full AI test suite green (404 tests).
