### PR TITLE
feat(anthropic): add Claude Sonnet 5 support

### DIFF
--- a/docs/AXIR_BACKLOG.md
+++ b/docs/AXIR_BACKLOG.md
@@ -14,7 +14,13 @@ This ledger tracks portable TypeScript behavior that should be migrated into AxI
 
 ## Open
 
-No entries.
+- `axir-2026-06-30-port-claude-sonnet-5-adaptive-thinking-request-mapping` [axai] Port Claude Sonnet 5 adaptive-thinking request mapping
+  - Status: open
+  - Source PR: #558
+  - Source commit: `e53ca54bee275d3627035e4d99dcd97c261d7c13`
+  - TS paths: `src/ax/ai/anthropic/api.ts`, `src/ax/ai/anthropic/api.test.ts`, `src/ax/ai/anthropic/info.ts`, `src/ax/ai/anthropic/types.ts`
+  - Impact: TS routes claude-sonnet-5 (direct + Vertex) through the adaptive thinking surface: thinking { type: 'adaptive' } + output_config.effort, with no budget_tokens (the legacy thinking.type.enabled / budget_tokens shape is rejected with 400 by the model). Generated Python/Java/C++/Go/Rust packages still emit budget_tokens for Sonnet 5 (or lack the model entirely), so they build requests the model rejects and never map thinkingTokenBudget -> effort for it.
+  - Suggested AxIR work: Add or update the TS-derived conformance fixture.; Update AxIR/Core or descriptor data to match the portable TS behavior.; Run npm run axir:conformance:check and npm run test:axir.
 
 ## Done
 

--- a/ir/axir-backlog.json
+++ b/ir/axir-backlog.json
@@ -8,7 +8,9 @@
       "createdAt": "2026-06-07",
       "sourcePR": null,
       "sourceCommit": "4e8da4ba",
-      "tsPaths": ["src/ax/mcp"],
+      "tsPaths": [
+        "src/ax/mcp"
+      ],
       "portableSurface": "axmcp",
       "impact": "Generated Python, Java, C++, Go, and Rust packages do not yet expose the modern MCP client, transports, OAuth discovery, or SSRF guard behavior.",
       "suggestedAxirWork": [
@@ -49,7 +51,9 @@
       "createdAt": "2026-06-24",
       "sourcePR": 556,
       "sourceCommit": "2d1a5f96f033640bf4e892e866fde99bc92e8268",
-      "tsPaths": ["src/ax/ai"],
+      "tsPaths": [
+        "src/ax/ai"
+      ],
       "portableSurface": "axai",
       "impact": "Generated Python/Java/C++/Go/Rust packages still map Anthropic streaming error events (overloaded_error/api_error/rate_limit_error) to refusals instead of retryable status errors, and lack the balancer's 529 retryability, pre-content streaming-overload retry-with-backoff, and mid-stream failure recording — so transient Anthropic errors hard-fail there with no retry or failover.",
       "suggestedAxirWork": [
@@ -85,13 +89,40 @@
       "completedAt": "2026-06-28",
       "completedByCommit": "working-tree",
       "verification": "npm run test:axir; npm run axir:check-packages"
+    },
+    {
+      "id": "axir-2026-06-30-port-claude-sonnet-5-adaptive-thinking-request-mapping",
+      "status": "open",
+      "title": "Port Claude Sonnet 5 adaptive-thinking request mapping",
+      "createdAt": "2026-06-30",
+      "sourcePR": 558,
+      "sourceCommit": "e53ca54bee275d3627035e4d99dcd97c261d7c13",
+      "tsPaths": [
+        "src/ax/ai/anthropic/api.ts",
+        "src/ax/ai/anthropic/api.test.ts",
+        "src/ax/ai/anthropic/info.ts",
+        "src/ax/ai/anthropic/types.ts"
+      ],
+      "portableSurface": "axai",
+      "impact": "TS routes claude-sonnet-5 (direct + Vertex) through the adaptive thinking surface: thinking { type: 'adaptive' } + output_config.effort, with no budget_tokens (the legacy thinking.type.enabled / budget_tokens shape is rejected with 400 by the model). Generated Python/Java/C++/Go/Rust packages still emit budget_tokens for Sonnet 5 (or lack the model entirely), so they build requests the model rejects and never map thinkingTokenBudget -> effort for it.",
+      "suggestedAxirWork": [
+        "Add or update the TS-derived conformance fixture.",
+        "Update AxIR/Core or descriptor data to match the portable TS behavior.",
+        "Run npm run axir:conformance:check and npm run test:axir."
+      ],
+      "completedAt": null,
+      "completedByCommit": null,
+      "verification": null
     }
   ],
   "nonPortableExemptions": [
     {
       "id": "webllm-browser-only",
       "surface": "axai",
-      "paths": ["src/ax/ai/webllm", "src/examples/webllm-chat.html"],
+      "paths": [
+        "src/ax/ai/webllm",
+        "src/examples/webllm-chat.html"
+      ],
       "scopedFiles": [
         "src/ax/ai/wrap.ts",
         "src/ax/ai/catalog.ts",
@@ -99,7 +130,12 @@
         "src/ax/ai/wrap.test.ts",
         "src/ax/skills/ax-ai.md"
       ],
-      "tags": ["webllm", "browser-only", "webgpu", "host-engine"],
+      "tags": [
+        "webllm",
+        "browser-only",
+        "webgpu",
+        "host-engine"
+      ],
       "reason": "WebLLM is browser-specific integration code around a caller-supplied MLCEngine/WebGPU runtime. It is not a portable Ax semantic and should not create Python/Java/C++/Go/Rust AxIR backlog work.",
       "createdAt": "2026-06-26"
     }

--- a/src/ax/ai/anthropic/api.test.ts
+++ b/src/ax/ai/anthropic/api.test.ts
@@ -601,6 +601,68 @@ describe('AxAIAnthropic thinking configuration', () => {
     expect(body.output_config).toEqual({ effort: 'high' });
   });
 
+  it('Sonnet 5 with high produces adaptive thinking + effort high', async () => {
+    const ai = new AxAIAnthropic({
+      apiKey: 'key',
+      config: { model: AxAIAnthropicModel.Claude5Sonnet },
+    });
+
+    const { capture, fetch } = createCaptureFetch('claude-sonnet-5');
+    ai.setOptions({ fetch });
+
+    await ai.chat(
+      { chatPrompt: [{ role: 'user', content: 'hi' }] },
+      { stream: false, thinkingTokenBudget: 'high' }
+    );
+
+    expect(fetch).toHaveBeenCalled();
+    const body = capture.lastBody;
+    expect(body.model).toBe('claude-sonnet-5');
+    expect(body.thinking).toEqual({ type: 'adaptive' });
+    expect(body.output_config).toEqual({ effort: 'high' });
+    expect(body.thinking?.budget_tokens).toBeUndefined();
+  });
+
+  it('Sonnet 5 with highest produces adaptive + effort max', async () => {
+    const ai = new AxAIAnthropic({
+      apiKey: 'key',
+      config: { model: AxAIAnthropicModel.Claude5Sonnet },
+    });
+
+    const { capture, fetch } = createCaptureFetch('claude-sonnet-5');
+    ai.setOptions({ fetch });
+
+    await ai.chat(
+      { chatPrompt: [{ role: 'user', content: 'hi' }] },
+      { stream: false, thinkingTokenBudget: 'highest' }
+    );
+
+    expect(fetch).toHaveBeenCalled();
+    const body = capture.lastBody;
+    expect(body.thinking).toEqual({ type: 'adaptive' });
+    expect(body.output_config).toEqual({ effort: 'max' });
+    expect(body.thinking?.budget_tokens).toBeUndefined();
+  });
+
+  it('Sonnet 5 accepts direct xhigh effort', async () => {
+    const ai = new AxAIAnthropic({
+      apiKey: 'key',
+      config: { model: AxAIAnthropicModel.Claude5Sonnet, effort: 'xhigh' },
+    });
+
+    const { capture, fetch } = createCaptureFetch('claude-sonnet-5');
+    ai.setOptions({ fetch });
+
+    await ai.chat(
+      { chatPrompt: [{ role: 'user', content: 'hi' }] },
+      { stream: false }
+    );
+
+    expect(fetch).toHaveBeenCalled();
+    expect(capture.lastBody?.output_config).toEqual({ effort: 'xhigh' });
+    expect(capture.lastBody?.thinking).toBeUndefined();
+  });
+
   it('Opus 4.8 accepts direct xhigh effort and omits sampling params', async () => {
     const ai = new AxAIAnthropic({
       apiKey: 'key',

--- a/src/ax/ai/anthropic/api.ts
+++ b/src/ax/ai/anthropic/api.ts
@@ -100,6 +100,17 @@ const isClaudeOpus47OrLater = (model: string): boolean =>
 const isClaudeOpus48 = (model: string): boolean =>
   model.includes('claude-opus-4-8');
 
+const isClaude5 = (model: string): boolean => model.includes('claude-sonnet-5');
+
+/**
+ * Models that use adaptive thinking + output_config.effort and reject the legacy
+ * thinking.type.enabled / budget_tokens surface (Opus 4.6, Opus 4.7+, Sonnet 5).
+ */
+const isAdaptiveThinkingModel = (model: string): boolean =>
+  model.includes('claude-opus-4-6') ||
+  isClaudeOpus47OrLater(model) ||
+  isClaude5(model);
+
 const cleanSchemaForAnthropic = (schema: any): any => {
   if (!schema || typeof schema !== 'object') {
     return schema;
@@ -492,7 +503,6 @@ class AxAIAnthropicImpl
     }
 
     // Model detection helpers
-    const isOpus46 = (m: string) => m.includes('claude-opus-4-6');
     const isOpus45 = (m: string) => m.includes('claude-opus-4-5');
     const isOpus47Plus = isClaudeOpus47OrLater(modelStr);
     const samplingUnsupported = isOpus47Plus;
@@ -518,8 +528,8 @@ class AxAIAnthropicImpl
           | 'high'
           | 'highest';
 
-        if (isOpus47Plus || isOpus46(modelStr)) {
-          // Opus 4.7+ and Opus 4.6: use adaptive thinking + effort
+        if (isAdaptiveThinkingModel(modelStr)) {
+          // Opus 4.6+, Sonnet 5: adaptive thinking + effort
           thinkingWire = { type: 'adaptive' };
           const effort = effortMap?.[budgetLevel] ?? 'medium';
           outputConfig = { effort };

--- a/src/ax/ai/anthropic/info.ts
+++ b/src/ax/ai/anthropic/info.ts
@@ -3,6 +3,38 @@ import type { AxModelInfo } from '../types.js';
 import { AxAIAnthropicModel, AxAIAnthropicVertexModel } from './types.js';
 
 export const axModelInfoAnthropic: AxModelInfo[] = [
+  // 5 Sonnet (2026-06)
+  // Final pricing recorded below; intro pricing ($2/$10 per 1M in/out) runs through 2026-08-31.
+  {
+    name: AxAIAnthropicModel.Claude5Sonnet,
+    currency: 'usd',
+    promptTokenCostPer1M: 3.0,
+    completionTokenCostPer1M: 15.0,
+    cacheReadTokenCostPer1M: 0.3,
+    cacheWriteTokenCostPer1M: 3.75,
+    maxTokens: 128000,
+    contextWindow: 1_000_000,
+    supported: {
+      thinkingBudget: true,
+      showThoughts: true,
+      structuredOutputs: true,
+    },
+  },
+  {
+    name: AxAIAnthropicVertexModel.Claude5Sonnet,
+    currency: 'usd',
+    promptTokenCostPer1M: 3.0,
+    completionTokenCostPer1M: 15.0,
+    cacheReadTokenCostPer1M: 0.3,
+    cacheWriteTokenCostPer1M: 3.75,
+    maxTokens: 128000,
+    contextWindow: 1_000_000,
+    supported: {
+      thinkingBudget: true,
+      showThoughts: true,
+      structuredOutputs: true,
+    },
+  },
   // 4.8 Opus (2026-05)
   {
     name: AxAIAnthropicModel.Claude48Opus,

--- a/src/ax/ai/anthropic/types.ts
+++ b/src/ax/ai/anthropic/types.ts
@@ -1,6 +1,7 @@
 import type { AxModelConfig } from '../types.js';
 
 export enum AxAIAnthropicModel {
+  Claude5Sonnet = 'claude-sonnet-5',
   Claude48Opus = 'claude-opus-4-8',
   Claude47Opus = 'claude-opus-4-7',
   Claude46Opus = 'claude-opus-4-6',
@@ -25,6 +26,7 @@ export enum AxAIAnthropicModel {
 }
 
 export enum AxAIAnthropicVertexModel {
+  Claude5Sonnet = 'claude-sonnet-5',
   Claude48Opus = 'claude-opus-4-8',
   Claude47Opus = 'claude-opus-4-7',
   Claude46Opus = 'claude-opus-4-6',


### PR DESCRIPTION
## Summary

Adds `claude-sonnet-5` (direct + Vertex) to the Anthropic provider, including the request mapping needed for live calls to succeed.

## Scope

- **Model + pricing** (`types.ts`, `info.ts`): add `Claude5Sonnet` to both model enums; add model info — 1M context, 128k max output, `$3/$15` per 1M in/out (we ignore the intro `$2/$10` through 2026-08-31), cache pricing, and `supported: { thinkingBudget, showThoughts, structuredOutputs }`.
- **Thinking mapping** (`api.ts`): Sonnet 5 removed the legacy `thinking.type.enabled` / `budget_tokens` surface (returns 400). Widen the adaptive-thinking predicate (`isAdaptiveThinkingModel`) so Sonnet 5 reuses the existing Opus 4.7+ path — `thinking: { type: 'adaptive' }` + `output_config.effort`, no `budget_tokens`. `effortLevelMapping`, the `directEffort` path, and request assembly are all reused unchanged.
- **Tests** (`api.test.ts`): Sonnet 5 cases for `thinkingTokenBudget: high → effort high`, `highest → effort max`, direct `effort: 'xhigh'`, each asserting no `budget_tokens`.

## Verification

- `vitest run src/ax/ai/anthropic/api.test.ts` → all pass (incl. new cases).
- `tsc --noEmit` → clean.

## Notes / follow-ups (pre-existing, not addressed here)

- `thinkingTokenBudget: 'none'` is a no-op on adaptive-default models (Sonnet 5, Opus 4.7+): it omits the thinking field, but those models think adaptively by default. Truly disabling requires `thinking: { type: 'disabled' }`. Pre-existing for Opus; now also applies to Sonnet 5.
- `supported.thinkingBudget` only feeds capability reporting, not the request shape — kept `true` for Sonnet 5; the wire path is selected by model detection in `api.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)