### PR TITLE
fix: make Claude skill install opt-in

### DIFF
--- a/scripts/postbuild.js
+++ b/scripts/postbuild.js
@@ -63,13 +63,7 @@ if (existsSync(cliSourcePath)) {
   };
 }
 
-// Conditionally add postinstall script (only if scripts/ directory exists)
 const scriptsSourcePath = path.join(packagePath, 'scripts');
-if (existsSync(scriptsSourcePath)) {
-  packageJson.scripts = {
-    postinstall: 'node ./scripts/postinstall.mjs',
-  };
-}
 
 // Write the modified package.json to the build folder
 await writeFile(

--- a/scripts/postbuild.test.js
+++ b/scripts/postbuild.test.js
@@ -1,4 +1,10 @@
-import { mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
@@ -108,5 +114,27 @@ describe('Postbuild Script', () => {
     expect(generatedPackageJson.exports['./index.global.js']).toBe(
       './index.global.js'
     );
+  });
+
+  it('should not add postinstall when package scripts are bundled', async () => {
+    const postbuildPath = path.join(__dirname, 'postbuild.js');
+    const { execSync } = await import('node:child_process');
+
+    mkdirSync(path.join(testDir, 'scripts'), { recursive: true });
+    writeFileSync(
+      path.join(testDir, 'scripts', 'postinstall.mjs'),
+      'console.log("installing skills");\n'
+    );
+
+    execSync(`node ${postbuildPath}`, { cwd: testDir });
+
+    const generatedPackageJson = JSON.parse(
+      readFileSync(path.join(testDir, 'dist', 'package.json'), 'utf8')
+    );
+
+    expect(generatedPackageJson.scripts).toBeUndefined();
+    expect(
+      existsSync(path.join(testDir, 'dist', 'scripts', 'postinstall.mjs'))
+    ).toBe(true);
   });
 });


### PR DESCRIPTION
Fixes #483

What changed:
- Stop adding `scripts.postinstall` to the published dist `package.json` when `src/ax/scripts` exists.
- Keep the explicit `ax` CLI entry, copied skills, and bundled `scripts/postinstall.mjs` available for opt-in use through `npx @ax-llm/ax setup-claude` and `npx @ax-llm/ax remove-claude`.
- Add a postbuild regression test for the case where package scripts are bundled.

Validation:
- `npm ci` completed.
- `npx vitest run scripts/postbuild.test.js` passed before the change with 3 tests.
- `npx vitest run scripts/postbuild.test.js` passed after the change with 4 tests.
- `npx biome format scripts/postbuild.js scripts/postbuild.test.js` reported no fixes.
- `git diff --check` passed.
- Manual postbuild inspection of `src/ax/dist/package.json`: `scripts` is absent, `bin.ax` still points to `./cli/index.mjs`, `dist/scripts/postinstall.mjs` is still copied, and 15 skill markdown files are still copied under `dist/skills`.

Not run:
- Full `npm run test`; this patch only changes postbuild package metadata and the matching regression test.
