### PR TITLE
fix(website): use topic-specific academy run samples

### DIFF
--- a/scripts/website-academy.mjs
+++ b/scripts/website-academy.mjs
@@ -109,6 +109,14 @@ export async function validateAcademyCourse(
       if (!Number.isFinite(topic.minutes) || topic.minutes <= 0) {
         failures.push(`topic ${topic.id} needs a positive minute estimate`);
       }
+      if (topic.examplePath) {
+        await validatePath(
+          topic.examplePath,
+          `${topic.id} example`,
+          repoRoot,
+          failures
+        );
+      }
       validateExercises(topic, exerciseIds, failures, { publicExports });
       for (const symbol of topic.apiSymbols ?? []) {
         if (publicExports && !publicExports.has(symbol)) {
@@ -747,6 +755,8 @@ function renderTopic(course, manifest, unit, topic) {
   const previous = index > 0 ? course.topicOrder[index - 1] : null;
   const next =
     index + 1 < course.topicOrder.length ? course.topicOrder[index + 1] : null;
+  const examplePath = topic.examplePath ?? unit.examplePaths[0];
+
   return academyShell(
     manifest,
     'topic',
@@ -774,7 +784,7 @@ function renderTopic(course, manifest, unit, topic) {
           </ol>`
               : ''
           }
-            <div class="academy-run-example"><span class="academy-label">Run it</span><strong>In your own project</strong>${codeBlock(`${course.install}\n\n${course.quickStart}`)}<p>Set <code>OPENAI_APIKEY</code> in your environment before running provider-backed code.</p><strong>In the ax repo</strong><p>From a clone of the ax repo:</p>${codeBlock(`npm run example -- ${course.language} ${unit.examplePaths[0]}`)}</div>
+            <div class="academy-run-example"><span class="academy-label">Run it</span><strong>In your own project</strong>${codeBlock(`${course.install}\n\n${course.quickStart}`)}<p>Set <code>OPENAI_APIKEY</code> in your environment before running provider-backed code.</p><strong>In the ax repo</strong><p>From a clone of the ax repo:</p>${codeBlock(`npm run example -- ${course.language} ${examplePath}`)}</div>
         </section>
         <section class="academy-practice" aria-labelledby="practice-title">
           <div class="academy-section-heading"><div><span class="academy-label">Active practice</span><h2 id="practice-title">Show that you can use it</h2></div><span data-academy-practice-count>Answer 2 in a row to learn this · attempt 1</span></div>
@@ -782,7 +792,7 @@ function renderTopic(course, manifest, unit, topic) {
         </section>
         <section class="academy-sources" aria-labelledby="sources-title">
           <span class="academy-label">Keep exploring</span><h2 id="sources-title">Source-backed follow-up</h2>
-          <ul>${unit.sourceRefs.map((source) => renderSourceLink(source, course.language)).join('')}${unit.examplePaths.length ? `<li><a href="${githubSource(unit.examplePaths[0])}">Source on GitHub</a></li>` : ''}</ul>
+          <ul>${unit.sourceRefs.map((source) => renderSourceLink(source, course.language)).join('')}${examplePath ? `<li><a href="${githubSource(examplePath)}">Source on GitHub</a></li>` : ''}</ul>
         </section>
         <nav class="academy-lesson-nav" aria-label="Course lessons">
           ${previous ? `<a href="${topicHref(previous, course.language)}">← Previous</a>` : '<span></span>'}

--- a/website/content-src/academy/helpers.mjs
+++ b/website/content-src/academy/helpers.mjs
@@ -22,6 +22,7 @@ export const topic = ({
   apiLabel,
   summary,
   example,
+  examplePath,
   exampleSteps,
   check,
   checks,
@@ -39,6 +40,7 @@ export const topic = ({
     apiLabel,
     summary,
     example,
+    examplePath,
     exampleSteps: exampleSteps ?? [],
     apiSymbols,
     exercises: [

--- a/website/content-src/academy/units/01-dspy.mjs
+++ b/website/content-src/academy/units/01-dspy.mjs
@@ -10,7 +10,7 @@ export const dspyUnit = {
     'website/content-src/templates/concept-dspy.md',
     'src/ax/skills/ax-signature.md',
   ],
-  examplePaths: ['src/examples/typescript/generation/axgen-openai.ts'],
+  examplePaths: ['src/examples/typescript/generation/structured.ts'],
   topics: [
     topic({
       id: 'programs-not-prompts',
@@ -56,6 +56,7 @@ export const dspyUnit = {
         'You pair realistic examples with a metric, then compare versions on the same evidence. This turns prompt tweaking into a repeatable improvement loop.',
       example:
         'const metric = ({ prediction, example }) => prediction.sentiment === example.sentiment ? 1 : 0;',
+      examplePath: 'src/examples/typescript/optimization/axgen-optimization.ts',
       exampleSteps: [
         {
           label: 'Keep a known answer',

--- a/website/content-src/academy/units/02-models-signatures.mjs
+++ b/website/content-src/academy/units/02-models-signatures.mjs
@@ -19,6 +19,7 @@ export const modelsSignaturesUnit = {
         'You configure the provider, current model, credentials, and runtime options in one place. Your program contract stays separate from that choice.',
       example:
         "const llm = ai({ name: 'openai', apiKey: process.env.OPENAI_APIKEY!, config: { model: 'gpt-5.4-mini' } });",
+      examplePath: 'src/examples/typescript/generation/axgen-openai.ts',
       exampleSteps: [
         {
           label: 'Choose the provider',
@@ -112,6 +113,7 @@ export const modelsSignaturesUnit = {
         'You keep a field’s meaning stable as it moves through generators, tools, flows, agents, and events. That makes composed systems easier to validate and evaluate.',
       example:
         "const lookup = fn('lookup').arg('ticketId', f.string()).returns(f.json()).handler(loadTicket).build();",
+      examplePath: 'src/examples/typescript/short-agents/tools-agent.ts',
       exampleSteps: [
         {
           label: 'Name the capability',


### PR DESCRIPTION
- **What kind of change does this PR introduce?** docs update to the academy

- **What is the current behavior?** https://axllm.dev/typescript/academy/topics/fluent-fields-validation/ and other topics in unit 1,2 all reuse the same example as unit1, topic 1 instead of their intended examples showing what the topic covers.

- **What is the new behavior (if this is a feature change)?** use the correct per topic example

- **Other information**:
