### PR TITLE
fix(agent): reject multiple code blocks per turn

### DIFF
--- a/docs/AXIR_BACKLOG.md
+++ b/docs/AXIR_BACKLOG.md
@@ -14,7 +14,13 @@ This ledger tracks portable TypeScript behavior that should be migrated into AxI
 
 ## Open
 
-No entries.
+- `axir-2026-07-28-port-actor-multi-fence-rejection-before-execution` [axagent] Port actor multi-fence rejection before execution
+  - Status: open
+  - Source PR: #563
+  - Source commit: `eec609f8789e6fe22956e15006c260dbf634f86c`
+  - TS paths: `src/ax/agent/agent.test.ts`, `src/ax/agent/agentInternal/actorLoopTurn.ts`
+  - Impact: Generated Python, Java, C++, Go, and Rust agents may still normalize malformed multi-block actor responses to the first fenced block and execute a partial program.
+  - Suggested AxIR work: Add or update the TS-derived conformance fixture.; Update AxIR/Core or descriptor data to match the portable TS behavior.; Run npm run axir:conformance:check and npm run test:axir.
 
 ## Done
 

--- a/ir/axir-backlog.json
+++ b/ir/axir-backlog.json
@@ -2,6 +2,28 @@
   "schemaVersion": 2,
   "entries": [
     {
+      "id": "axir-2026-07-28-port-actor-multi-fence-rejection-before-execution",
+      "status": "open",
+      "title": "Port actor multi-fence rejection before execution",
+      "createdAt": "2026-07-28",
+      "sourcePR": 563,
+      "sourceCommit": "eec609f8789e6fe22956e15006c260dbf634f86c",
+      "tsPaths": [
+        "src/ax/agent/agent.test.ts",
+        "src/ax/agent/agentInternal/actorLoopTurn.ts"
+      ],
+      "portableSurface": "axagent",
+      "impact": "Generated Python, Java, C++, Go, and Rust agents may still normalize malformed multi-block actor responses to the first fenced block and execute a partial program.",
+      "suggestedAxirWork": [
+        "Add or update the TS-derived conformance fixture.",
+        "Update AxIR/Core or descriptor data to match the portable TS behavior.",
+        "Run npm run axir:conformance:check and npm run test:axir."
+      ],
+      "completedAt": null,
+      "completedByCommit": null,
+      "verification": null
+    },
+    {
       "id": "axir-2026-06-07-port-mcp-client-and-transports",
       "status": "done",
       "title": "Port MCP client and transports",

--- a/src/ax/agent/agent.test.ts
+++ b/src/ax/agent/agent.test.ts
@@ -8063,6 +8063,114 @@ console.log('Keys:', Object.keys(globalThis));`;
     );
   });
 
+  it('should reject multiple fenced actor code blocks without executing either block', async () => {
+    let actorCallCount = 0;
+    let secondTurnUserPrompt = '';
+    const executedCode: string[] = [];
+
+    const testMockAI = new AxMockAIService({
+      features: { functions: false, streaming: false },
+      chatResponse: async (req) => {
+        const systemPrompt = String(req.chatPrompt[0]?.content ?? '');
+        const userPrompt = String(req.chatPrompt[1]?.content ?? '');
+
+        if (systemPrompt.includes('You (`executor`)')) {
+          actorCallCount++;
+          if (actorCallCount === 2) {
+            secondTurnUserPrompt = userPrompt;
+          }
+          return {
+            results: [
+              {
+                index: 0,
+                content:
+                  actorCallCount === 1
+                    ? [
+                        'Javascript Code: First attempt:',
+                        '```javascript',
+                        'console.log("partial");',
+                        '```',
+                        'Final attempt:',
+                        '```javascript',
+                        'await final("premature", { partial: true });',
+                        '```',
+                      ].join('\n')
+                    : 'Javascript Code: await final("done", { data: "done" });',
+                finishReason: 'stop',
+              },
+            ],
+            modelUsage: makeModelUsage(),
+          };
+        }
+
+        if (systemPrompt.includes('Answer Synthesis Agent')) {
+          return {
+            results: [
+              { index: 0, content: 'Answer: done', finishReason: 'stop' },
+            ],
+            modelUsage: makeModelUsage(),
+          };
+        }
+
+        return {
+          results: [{ index: 0, content: 'fallback', finishReason: 'stop' }],
+          modelUsage: makeModelUsage(),
+        };
+      },
+    });
+
+    const runtime: AxCodeRuntime = {
+      ...runtimeWithConsoleMode,
+      createSession(globals) {
+        return {
+          execute: async (code: string) => {
+            if (code.startsWith(AX_HOST_SNIPPET_MARKER)) return 'host-snippet';
+            executedCode.push(code);
+            if (globals?.final && code.includes('final(')) {
+              (globals.final as (...args: unknown[]) => void)('done', {
+                data: 'done',
+              });
+            }
+            return 'ok';
+          },
+          patchGlobals: async (patch: Record<string, unknown>) => {
+            const { [AX_INPUTS_PATCH_GLOBAL]: staged, ...rest } = patch;
+            Object.assign(globals ?? {}, rest);
+            if (globals && staged && typeof staged === 'object') {
+              globals.inputs = Object.assign(
+                (globals.inputs as Record<string, unknown>) ?? {},
+                staged
+              );
+            }
+          },
+          close: () => {},
+        };
+      },
+    };
+
+    const testAgent = agent('query:string -> answer:string', {
+      ai: testMockAI,
+      contextFields: [],
+      runtime,
+      maxTurns: 3,
+      contextPolicy: { preset: 'full' },
+    });
+
+    const result = await testAgent.forward(testMockAI, { query: 'test' });
+
+    expect(result.answer).toBe('done');
+    expect(actorCallCount).toBe(2);
+    expect(getActorAuthoredCodes(executedCode)).toEqual([
+      'await final("done", { data: "done" });',
+    ]);
+    expect(secondTurnUserPrompt).toContain(
+      '[POLICY] Javascript Code must contain at most one fenced code block.'
+    );
+    expect(secondTurnUserPrompt).toContain(
+      'contained multiple fenced code blocks, so none of them were executed'
+    );
+  });
+
   it('should strip outer javascript fences before policy validation and replay', async () => {
     let actorCallCount = 0;
     let secondTurnUserPrompt = '';

--- a/src/ax/agent/agent.test.ts
+++ b/src/ax/agent/agent.test.ts
@@ -8063,113 +8063,197 @@ console.log('Keys:', Object.keys(globalThis));`;
     );
   });
 
-  it('should reject multiple fenced actor code blocks without executing either block', async () => {
-    let actorCallCount = 0;
-    let secondTurnUserPrompt = '';
-    const executedCode: string[] = [];
+  const multipleFenceCases: ReadonlyArray<{
+    name: string;
+    language?: string;
+    codeFieldTitle: string;
+    usageInstructions: string;
+    firstResponse: string;
+    correctedResponse: string;
+    correctedCode: string;
+    rejectedCodes: readonly string[];
+  }> = [
+    {
+      name: 'should reject multiple fenced actor code blocks without executing either block',
+      codeFieldTitle: 'Javascript Code',
+      usageInstructions: runtimeWithConsoleMode.getUsageInstructions(),
+      firstResponse: [
+        'Javascript Code: First attempt:',
+        '```javascript',
+        'console.log("partial");',
+        '```',
+        'Final attempt:',
+        '```javascript',
+        'await final("premature", { partial: true });',
+        '```',
+      ].join('\n'),
+      correctedResponse:
+        'Javascript Code: await final("done", { data: "done" });',
+      correctedCode: 'await final("done", { data: "done" });',
+      rejectedCodes: [
+        'console.log("partial");',
+        'await final("premature", { partial: true });',
+      ],
+    },
+    {
+      name: 'should reject an unterminated second fenced actor code block',
+      codeFieldTitle: 'Javascript Code',
+      usageInstructions: runtimeWithConsoleMode.getUsageInstructions(),
+      firstResponse: [
+        'Javascript Code: First attempt:',
+        '```javascript',
+        'console.log("partial");',
+        '```',
+        'Final attempt:',
+        '```javascript',
+        'await final("premature", { partial: true });',
+      ].join('\n'),
+      correctedResponse:
+        'Javascript Code: await final("done", { data: "done" });',
+      correctedCode: 'await final("done", { data: "done" });',
+      rejectedCodes: [
+        'console.log("partial");',
+        'await final("premature", { partial: true });',
+      ],
+    },
+    {
+      name: 'should reject multiple fenced actor code blocks for a non-JavaScript runtime',
+      language: 'Python',
+      codeFieldTitle: 'Python Code',
+      usageInstructions: '- Use Python syntax for runtime code.',
+      firstResponse: [
+        'Python Code: First attempt:',
+        '```python',
+        'print("partial")',
+        '```',
+        'Final attempt:',
+        '```python',
+        'final("premature", {"partial": True})',
+        '```',
+      ].join('\n'),
+      correctedResponse: 'Python Code: final("done", {"data": "done"})',
+      correctedCode: 'final("done", {"data": "done"})',
+      rejectedCodes: [
+        'print("partial")',
+        'final("premature", {"partial": True})',
+      ],
+    },
+  ];
 
-    const testMockAI = new AxMockAIService({
-      features: { functions: false, streaming: false },
-      chatResponse: async (req) => {
-        const systemPrompt = String(req.chatPrompt[0]?.content ?? '');
-        const userPrompt = String(req.chatPrompt[1]?.content ?? '');
+  it.each(multipleFenceCases)(
+    '$name',
+    async ({
+      language,
+      codeFieldTitle,
+      usageInstructions,
+      firstResponse,
+      correctedResponse,
+      correctedCode,
+      rejectedCodes,
+    }) => {
+      let actorCallCount = 0;
+      let secondTurnUserPrompt = '';
+      const executedCode: string[] = [];
 
-        if (systemPrompt.includes('You (`executor`)')) {
-          actorCallCount++;
-          if (actorCallCount === 2) {
-            secondTurnUserPrompt = userPrompt;
+      const testMockAI = new AxMockAIService({
+        features: { functions: false, streaming: false },
+        chatResponse: async (req) => {
+          const systemPrompt = String(req.chatPrompt[0]?.content ?? '');
+          const userPrompt = String(req.chatPrompt[1]?.content ?? '');
+
+          if (systemPrompt.includes('You (`executor`)')) {
+            actorCallCount++;
+            if (actorCallCount === 2) {
+              secondTurnUserPrompt = userPrompt;
+            }
+            return {
+              results: [
+                {
+                  index: 0,
+                  content:
+                    actorCallCount === 1 ? firstResponse : correctedResponse,
+                  finishReason: 'stop',
+                },
+              ],
+              modelUsage: makeModelUsage(),
+            };
           }
+
+          if (systemPrompt.includes('Answer Synthesis Agent')) {
+            return {
+              results: [
+                { index: 0, content: 'Answer: done', finishReason: 'stop' },
+              ],
+              modelUsage: makeModelUsage(),
+            };
+          }
+
           return {
-            results: [
-              {
-                index: 0,
-                content:
-                  actorCallCount === 1
-                    ? [
-                        'Javascript Code: First attempt:',
-                        '```javascript',
-                        'console.log("partial");',
-                        '```',
-                        'Final attempt:',
-                        '```javascript',
-                        'await final("premature", { partial: true });',
-                        '```',
-                      ].join('\n')
-                    : 'Javascript Code: await final("done", { data: "done" });',
-                finishReason: 'stop',
-              },
-            ],
+            results: [{ index: 0, content: 'fallback', finishReason: 'stop' }],
             modelUsage: makeModelUsage(),
           };
-        }
+        },
+      });
 
-        if (systemPrompt.includes('Answer Synthesis Agent')) {
+      const runtime: AxCodeRuntime = {
+        ...runtimeWithConsoleMode,
+        ...(language ? { language } : {}),
+        getUsageInstructions: () => usageInstructions,
+        createSession(globals) {
           return {
-            results: [
-              { index: 0, content: 'Answer: done', finishReason: 'stop' },
-            ],
-            modelUsage: makeModelUsage(),
+            execute: async (code: string) => {
+              if (code.startsWith(AX_HOST_SNIPPET_MARKER))
+                return 'host-snippet';
+              executedCode.push(code);
+              if (globals?.final && code.includes('final(')) {
+                (globals.final as (...args: unknown[]) => void)('done', {
+                  data: 'done',
+                });
+              }
+              return 'ok';
+            },
+            patchGlobals: async (patch: Record<string, unknown>) => {
+              const { [AX_INPUTS_PATCH_GLOBAL]: staged, ...rest } = patch;
+              Object.assign(globals ?? {}, rest);
+              if (globals && staged && typeof staged === 'object') {
+                globals.inputs = Object.assign(
+                  (globals.inputs as Record<string, unknown>) ?? {},
+                  staged
+                );
+              }
+            },
+            close: () => {},
           };
-        }
+        },
+      };
 
-        return {
-          results: [{ index: 0, content: 'fallback', finishReason: 'stop' }],
-          modelUsage: makeModelUsage(),
-        };
-      },
-    });
+      const testAgent = agent('query:string -> answer:string', {
+        ai: testMockAI,
+        contextFields: [],
+        runtime,
+        maxTurns: 3,
+        contextPolicy: { preset: 'full' },
+        directResponse: 'off',
+      });
 
-    const runtime: AxCodeRuntime = {
-      ...runtimeWithConsoleMode,
-      createSession(globals) {
-        return {
-          execute: async (code: string) => {
-            if (code.startsWith(AX_HOST_SNIPPET_MARKER)) return 'host-snippet';
-            executedCode.push(code);
-            if (globals?.final && code.includes('final(')) {
-              (globals.final as (...args: unknown[]) => void)('done', {
-                data: 'done',
-              });
-            }
-            return 'ok';
-          },
-          patchGlobals: async (patch: Record<string, unknown>) => {
-            const { [AX_INPUTS_PATCH_GLOBAL]: staged, ...rest } = patch;
-            Object.assign(globals ?? {}, rest);
-            if (globals && staged && typeof staged === 'object') {
-              globals.inputs = Object.assign(
-                (globals.inputs as Record<string, unknown>) ?? {},
-                staged
-              );
-            }
-          },
-          close: () => {},
-        };
-      },
-    };
+      const result = await testAgent.forward(testMockAI, { query: 'test' });
 
-    const testAgent = agent('query:string -> answer:string', {
-      ai: testMockAI,
-      contextFields: [],
-      runtime,
-      maxTurns: 3,
-      contextPolicy: { preset: 'full' },
-    });
-
-    const result = await testAgent.forward(testMockAI, { query: 'test' });
-
-    expect(result.answer).toBe('done');
-    expect(actorCallCount).toBe(2);
-    expect(getActorAuthoredCodes(executedCode)).toEqual([
-      'await final("done", { data: "done" });',
-    ]);
-    expect(secondTurnUserPrompt).toContain(
-      '[POLICY] Javascript Code must contain at most one fenced code block.'
-    );
-    expect(secondTurnUserPrompt).toContain(
-      'contained multiple fenced code blocks, so none of them were executed'
-    );
-  });
+      expect(result.answer).toBe('done');
+      expect(actorCallCount).toBe(2);
+      const actorAuthoredCodes = getActorAuthoredCodes(executedCode);
+      expect(actorAuthoredCodes).toContain(correctedCode);
+      for (const rejectedCode of rejectedCodes) {
+        expect(actorAuthoredCodes).not.toContain(rejectedCode);
+        expect(secondTurnUserPrompt).toContain(rejectedCode);
+      }
+      expect(secondTurnUserPrompt).toContain(
+        `[POLICY] ${codeFieldTitle} must contain at most one fenced code block.`
+      );
+      expect(secondTurnUserPrompt).toContain(
+        `Your previous ${codeFieldTitle} value contained multiple fenced code blocks, so none of them were executed`
+      );
+    }
+  );
 
   it('should strip outer javascript fences before policy validation and replay', async () => {
     let actorCallCount = 0;

--- a/src/ax/agent/agentInternal/actorLoopTurn.ts
+++ b/src/ax/agent/agentInternal/actorLoopTurn.ts
@@ -1,4 +1,5 @@
 import type {
+  AxChatLogEntry,
   AxGenIn,
   AxProgramForwardOptions,
   AxProgramUsage,
@@ -44,6 +45,50 @@ const ACTOR_CODE_POLICY_GUIDANCE =
   'On this turn, set Javascript Code to runnable JavaScript only: use console.log(...) for inspection, ' +
   'await final("...", { ... }) when complete, or await askClarification(...) when blocked. ' +
   'Do not emit plain task:/evidence: labels or prose as the Javascript Code value.';
+
+const MULTIPLE_CODE_BLOCKS_POLICY_VIOLATION =
+  '[POLICY] Javascript Code must contain at most one fenced code block. No code from the previous turn was executed.';
+
+const MULTIPLE_CODE_BLOCKS_POLICY_GUIDANCE =
+  'Your previous Javascript Code value contained multiple fenced code blocks, so none of them were executed. ' +
+  'On this turn, put every executable statement in one Javascript Code value with at most one fence.';
+
+function extractRawActorCode(
+  chatLog: readonly AxChatLogEntry[],
+  runtimeCodeFieldTitle: string
+): string | undefined {
+  const messages = chatLog[chatLog.length - 1]?.messages;
+  if (!messages) {
+    return undefined;
+  }
+
+  for (let index = messages.length - 1; index >= 0; index--) {
+    const message = messages[index];
+    if (message?.role !== 'assistant') {
+      continue;
+    }
+
+    const content = message.content
+      .replace(/<think>[\s\S]*?<\/think>/g, '')
+      .replace(/[^\n]*<\/think>/g, '')
+      .trim();
+
+    const prefix = `${runtimeCodeFieldTitle}:`;
+    const prefixIndex = content.indexOf(prefix);
+    if (prefixIndex >= 0) {
+      return content.slice(prefixIndex + prefix.length).trim();
+    }
+    return content;
+  }
+
+  return undefined;
+}
+
+function countFencedCodeBlocks(code: string): number {
+  return Array.from(
+    code.matchAll(/```(?:[A-Za-z0-9_-]+)?[ \t]*\r?\n[\s\S]*?\r?\n?```/g)
+  ).length;
+}
 
 export async function runActorTurn<_IN extends AxGenIn>(
   ctx: ActorLoopContext,
@@ -259,8 +304,9 @@ export async function runActorTurn<_IN extends AxGenIn>(
     actorCallOptions.model !== undefined
       ? String(actorCallOptions.model)
       : undefined;
+  const actorChatLog = s.actorProgram.getChatLog();
   const turnChatLogMessages = actorTurnCallback
-    ? snapshotChatLogMessages(s.actorProgram.getChatLog())
+    ? snapshotChatLogMessages(actorChatLog)
     : undefined;
 
   if (turn === 0) {
@@ -270,17 +316,34 @@ export async function runActorTurn<_IN extends AxGenIn>(
   const runtimeCodeFieldName = s.runtimeCodeFieldName ?? 'javascriptCode';
   let code = executorResult[runtimeCodeFieldName] as string | undefined;
   const trimmedCode = code?.trim();
-  if (!code || !trimmedCode) {
-    return { shouldBreak: true, shouldContinue: false };
+  // Code-field parsing extracts the first Markdown fence, so inspect the raw
+  // response before a later block can disappear from the actor turn.
+  const rawResponseCode = extractRawActorCode(
+    actorChatLog,
+    s.runtimeCodeFieldTitle ?? 'Javascript Code'
+  )?.trim();
+  const codeBeforeNormalization = rawResponseCode ?? trimmedCode;
+  const hasMultipleFencedCodeBlocks =
+    s.isJavaScriptRuntime !== false &&
+    typeof codeBeforeNormalization === 'string' &&
+    countFencedCodeBlocks(codeBeforeNormalization) > 1;
+  if (hasMultipleFencedCodeBlocks) {
+    code = codeBeforeNormalization;
+  } else {
+    if (!code || !trimmedCode) {
+      return { shouldBreak: true, shouldContinue: false };
+    }
+    code = normalizeActorCode(trimmedCode);
   }
-  code = normalizeActorCode(trimmedCode);
   executorResult[runtimeCodeFieldName] = code;
 
   completionState.payload = undefined;
   const functionCallStartIndex = functionCallRecords?.length ?? 0;
 
-  if (s.enforceIncrementalConsoleTurns) {
-    const policyResult = validateActorTurnCodePolicy(code);
+  if (hasMultipleFencedCodeBlocks || s.enforceIncrementalConsoleTurns) {
+    const policyResult = hasMultipleFencedCodeBlocks
+      ? { violation: MULTIPLE_CODE_BLOCKS_POLICY_VIOLATION }
+      : validateActorTurnCodePolicy(code);
 
     // Auto-split: discovery mixed with other code — run discovery first,
     // then proceed to execute the full code block (discovery calls are
@@ -296,7 +359,9 @@ export async function runActorTurn<_IN extends AxGenIn>(
       const entryTurn = actionLogEntries.length + 1;
       appendGuidanceEntry(guidanceState.entries, {
         turn: entryTurn,
-        guidance: ACTOR_CODE_POLICY_GUIDANCE,
+        guidance: hasMultipleFencedCodeBlocks
+          ? MULTIPLE_CODE_BLOCKS_POLICY_GUIDANCE
+          : ACTOR_CODE_POLICY_GUIDANCE,
         triggeredBy: 'runtime policy',
       });
       actionLogEntries.push({

--- a/src/ax/agent/agentInternal/actorLoopTurn.ts
+++ b/src/ax/agent/agentInternal/actorLoopTurn.ts
@@ -46,12 +46,20 @@ const ACTOR_CODE_POLICY_GUIDANCE =
   'await final("...", { ... }) when complete, or await askClarification(...) when blocked. ' +
   'Do not emit plain task:/evidence: labels or prose as the Javascript Code value.';
 
-const MULTIPLE_CODE_BLOCKS_POLICY_VIOLATION =
-  '[POLICY] Javascript Code must contain at most one fenced code block. No code from the previous turn was executed.';
+function buildMultipleCodeBlocksPolicyViolation(
+  runtimeCodeFieldTitle: string
+): string {
+  return `[POLICY] ${runtimeCodeFieldTitle} must contain at most one fenced code block. No code from the previous turn was executed.`;
+}
 
-const MULTIPLE_CODE_BLOCKS_POLICY_GUIDANCE =
-  'Your previous Javascript Code value contained multiple fenced code blocks, so none of them were executed. ' +
-  'On this turn, put every executable statement in one Javascript Code value with at most one fence.';
+function buildMultipleCodeBlocksPolicyGuidance(
+  runtimeCodeFieldTitle: string
+): string {
+  return (
+    `Your previous ${runtimeCodeFieldTitle} value contained multiple fenced code blocks, so none of them were executed. ` +
+    `On this turn, put every executable statement in one ${runtimeCodeFieldTitle} value with at most one fence.`
+  );
+}
 
 function extractRawActorCode(
   chatLog: readonly AxChatLogEntry[],
@@ -84,10 +92,32 @@ function extractRawActorCode(
   return undefined;
 }
 
-function countFencedCodeBlocks(code: string): number {
-  return Array.from(
-    code.matchAll(/```(?:[A-Za-z0-9_-]+)?[ \t]*\r?\n[\s\S]*?\r?\n?```/g)
-  ).length;
+function containsMultipleFencedCodeBlocks(code: string): boolean {
+  let insideFence = false;
+  let blockCount = 0;
+
+  for (const line of code.split(/\r?\n/)) {
+    // Match the same triple-backtick opener shape accepted by
+    // normalizeActorCode, including prose before the first fence.
+    const fence = line.match(/```([A-Za-z0-9_-]+)?[ \t]*$/);
+    if (!fence) {
+      continue;
+    }
+
+    const hasLanguage = fence[1] !== undefined;
+    if (insideFence && !hasLanguage) {
+      insideFence = false;
+      continue;
+    }
+
+    blockCount++;
+    if (blockCount > 1) {
+      return true;
+    }
+    insideFence = true;
+  }
+
+  return false;
 }
 
 export async function runActorTurn<_IN extends AxGenIn>(
@@ -314,19 +344,19 @@ export async function runActorTurn<_IN extends AxGenIn>(
   }
 
   const runtimeCodeFieldName = s.runtimeCodeFieldName ?? 'javascriptCode';
+  const runtimeCodeFieldTitle = s.runtimeCodeFieldTitle ?? 'Javascript Code';
   let code = executorResult[runtimeCodeFieldName] as string | undefined;
   const trimmedCode = code?.trim();
   // Code-field parsing extracts the first Markdown fence, so inspect the raw
   // response before a later block can disappear from the actor turn.
   const rawResponseCode = extractRawActorCode(
     actorChatLog,
-    s.runtimeCodeFieldTitle ?? 'Javascript Code'
+    runtimeCodeFieldTitle
   )?.trim();
   const codeBeforeNormalization = rawResponseCode ?? trimmedCode;
   const hasMultipleFencedCodeBlocks =
-    s.isJavaScriptRuntime !== false &&
     typeof codeBeforeNormalization === 'string' &&
-    countFencedCodeBlocks(codeBeforeNormalization) > 1;
+    containsMultipleFencedCodeBlocks(codeBeforeNormalization);
   if (hasMultipleFencedCodeBlocks) {
     code = codeBeforeNormalization;
   } else {
@@ -342,7 +372,11 @@ export async function runActorTurn<_IN extends AxGenIn>(
 
   if (hasMultipleFencedCodeBlocks || s.enforceIncrementalConsoleTurns) {
     const policyResult = hasMultipleFencedCodeBlocks
-      ? { violation: MULTIPLE_CODE_BLOCKS_POLICY_VIOLATION }
+      ? {
+          violation: buildMultipleCodeBlocksPolicyViolation(
+            runtimeCodeFieldTitle
+          ),
+        }
       : validateActorTurnCodePolicy(code);
 
     // Auto-split: discovery mixed with other code — run discovery first,
@@ -360,7 +394,7 @@ export async function runActorTurn<_IN extends AxGenIn>(
       appendGuidanceEntry(guidanceState.entries, {
         turn: entryTurn,
         guidance: hasMultipleFencedCodeBlocks
-          ? MULTIPLE_CODE_BLOCKS_POLICY_GUIDANCE
+          ? buildMultipleCodeBlocksPolicyGuidance(runtimeCodeFieldTitle)
           : ACTOR_CODE_POLICY_GUIDANCE,
         triggeredBy: 'runtime policy',
       });

--- a/src/ax/skills/ax-agent.md
+++ b/src/ax/skills/ax-agent.md
@@ -45,6 +45,7 @@ Map user intent to agent shape before writing code:
 ## Critical Rules
 
 - Use `agent(...)` factory syntax for new code.
+- If an actor response contains multiple fenced code blocks, the runtime rejects the whole turn without executing any block and asks for one executable program.
 - Add child agents to the parent's `functions: [...]` list. Each child's `agentIdentity.namespace` (or `utils`, the default) determines the runtime call site, e.g. `await team.writer({...})`.
 - If discovery is enabled, call `discover(...)` before using callables whose docs are not already in the prompt.
 - `autoUpgrade` is ON by default: large tool catalogs auto-enable discovery, and oversized undeclared input values are auto-kept runtime-only with a truncated prompt preview. Explicit `functionDiscovery` and declared `contextFields` always win; set `autoUpgrade: false` to opt out.


### PR DESCRIPTION
## Problem

The actor code parser extracts the first fenced block and silently discards later blocks. A response that includes executable work or `final(...)` in a later block therefore executes a partial program and consumes another turn.

## Change

Inspect the raw actor response before code-field normalization. If it contains multiple fenced blocks, execute none, record a policy violation, and ask for one executable program on the next turn. Single-fenced and plain code keep their existing behavior.

## Verification

- 2,622 tests passed; 3 skipped
- Type checks, lint, formatting, ESM/CJS/IIFE/DTS builds passed
- Regression proves neither block executes and the corrected next turn completes
- Clean merge with current `main`