### PR TITLE
fix(openai): stop sending max reasoning effort on the chat path

### DIFF
--- a/docs/AXIR_BACKLOG.md
+++ b/docs/AXIR_BACKLOG.md
@@ -33,8 +33,8 @@ This ledger tracks portable TypeScript behavior that should be migrated into AxI
 - `axir-2026-07-30-port-the-gpt-5-6-reasoning-effort-ladder` [axai] Port the GPT-5.6 reasoning-effort ladder
   - Status: open
   - Source commit: `cbaf70906d76c8534373451780b240e190a0f22c`
-  - TS paths: `src/ax/ai/openai/api.ts`, `src/ax/ai/openai/responses_api.ts`
-  - Impact: Generated Python/Java/C++/Go/Rust clients have no OpenAI thinkingTokenBudget -> reasoning.effort mapping; AxIR models only the DeepSeek and Grok quirk blocks, so the GPT-5.6 1:1 ladder and its max rung are TS-only.
+  - TS paths: `src/ax/ai/openai/chat_types.ts`, `src/ax/ai/openai/effort.ts`, `src/ax/ai/openai/api.ts`, `src/ax/ai/openai/responses_api.ts`
+  - Impact: Generated Python/Java/C++/Go/Rust clients have no OpenAI thinkingTokenBudget -> reasoning.effort mapping; AxIR models only the DeepSeek and Grok quirk blocks, so the GPT-5.6 ladder is TS-only. The ladder is per API surface: highest reaches xhigh on Chat Completions, which rejects max, and max only on the Responses API.
   - Suggested AxIR work: Add or update the TS-derived conformance fixture.; Update AxIR/Core or descriptor data to match the portable TS behavior.; Run npm run axir:conformance:check and npm run test:axir.
 - `axir-2026-07-31-port-per-item-url-array-validation` [axgen] Port per-item URL array validation
   - Status: open

--- a/docs/AXIR_BACKLOG.md
+++ b/docs/AXIR_BACKLOG.md
@@ -33,7 +33,7 @@ This ledger tracks portable TypeScript behavior that should be migrated into AxI
 - `axir-2026-07-30-port-the-gpt-5-6-reasoning-effort-ladder` [axai] Port the GPT-5.6 reasoning-effort ladder
   - Status: open
   - Source commit: `cbaf70906d76c8534373451780b240e190a0f22c`
-  - TS paths: `src/ax/ai/openai/chat_types.ts`, `src/ax/ai/openai/effort.ts`, `src/ax/ai/openai/api.ts`, `src/ax/ai/openai/responses_api.ts`
+  - TS paths: `src/ax/ai/openai/chat_types.ts`, `src/ax/ai/openai/effort.ts`, `src/ax/ai/openai/effort.test.ts`, `src/ax/ai/openai/api.ts`, `src/ax/ai/openai/api.reasoning.test.ts`, `src/ax/ai/openai/responses_api.ts`, `src/ax/ai/openai/responses_api.phase.test.ts`
   - Impact: Generated Python/Java/C++/Go/Rust clients have no OpenAI thinkingTokenBudget -> reasoning.effort mapping; AxIR models only the DeepSeek and Grok quirk blocks, so the GPT-5.6 ladder is TS-only. The ladder is per API surface: highest reaches xhigh on Chat Completions, which rejects max, and max only on the Responses API.
   - Suggested AxIR work: Add or update the TS-derived conformance fixture.; Update AxIR/Core or descriptor data to match the portable TS behavior.; Run npm run axir:conformance:check and npm run test:axir.
 - `axir-2026-07-31-port-per-item-url-array-validation` [axgen] Port per-item URL array validation

--- a/ir/axir-backlog.json
+++ b/ir/axir-backlog.json
@@ -838,11 +838,13 @@
       "sourcePR": null,
       "sourceCommit": "cbaf70906d76c8534373451780b240e190a0f22c",
       "tsPaths": [
+        "src/ax/ai/openai/chat_types.ts",
+        "src/ax/ai/openai/effort.ts",
         "src/ax/ai/openai/api.ts",
         "src/ax/ai/openai/responses_api.ts"
       ],
       "portableSurface": "axai",
-      "impact": "Generated Python/Java/C++/Go/Rust clients have no OpenAI thinkingTokenBudget -> reasoning.effort mapping; AxIR models only the DeepSeek and Grok quirk blocks, so the GPT-5.6 1:1 ladder and its max rung are TS-only.",
+      "impact": "Generated Python/Java/C++/Go/Rust clients have no OpenAI thinkingTokenBudget -> reasoning.effort mapping; AxIR models only the DeepSeek and Grok quirk blocks, so the GPT-5.6 ladder is TS-only. The ladder is per API surface: highest reaches xhigh on Chat Completions, which rejects max, and max only on the Responses API.",
       "suggestedAxirWork": [
         "Add or update the TS-derived conformance fixture.",
         "Update AxIR/Core or descriptor data to match the portable TS behavior.",

--- a/ir/axir-backlog.json
+++ b/ir/axir-backlog.json
@@ -840,8 +840,11 @@
       "tsPaths": [
         "src/ax/ai/openai/chat_types.ts",
         "src/ax/ai/openai/effort.ts",
+        "src/ax/ai/openai/effort.test.ts",
         "src/ax/ai/openai/api.ts",
-        "src/ax/ai/openai/responses_api.ts"
+        "src/ax/ai/openai/api.reasoning.test.ts",
+        "src/ax/ai/openai/responses_api.ts",
+        "src/ax/ai/openai/responses_api.phase.test.ts"
       ],
       "portableSurface": "axai",
       "impact": "Generated Python/Java/C++/Go/Rust clients have no OpenAI thinkingTokenBudget -> reasoning.effort mapping; AxIR models only the DeepSeek and Grok quirk blocks, so the GPT-5.6 ladder is TS-only. The ladder is per API surface: highest reaches xhigh on Chat Completions, which rejects max, and max only on the Responses API.",

--- a/src/ax/ai/openai/api.reasoning.test.ts
+++ b/src/ax/ai/openai/api.reasoning.test.ts
@@ -66,26 +66,33 @@ function responsesReasoning(
 // only prove both request builders route through the resolver and hand it the
 // model, so they cover the rungs where the two ladders disagree.
 describe('OpenAI reasoning effort ladder', () => {
+  // `highest` is where the two surfaces part: Chat Completions rejects `max`,
+  // so it stops at `xhigh` while Responses goes the rung higher.
   const budgets = [
-    { budget: 'medium', legacy: 'high', gpt56: 'medium' },
-    { budget: 'highest', legacy: 'xhigh', gpt56: 'max' },
+    {
+      budget: 'medium',
+      legacy: 'high',
+      chat56: 'medium',
+      responses56: 'medium',
+    },
+    { budget: 'highest', legacy: 'xhigh', chat56: 'xhigh', responses56: 'max' },
   ] as const;
 
   it.each(budgets)(
-    'Chat maps $budget to $legacy on gpt-5.5 and $gpt56 on gpt-5.6',
-    async ({ budget, legacy, gpt56 }) => {
+    'Chat maps $budget to $legacy on gpt-5.5 and $chat56 on gpt-5.6',
+    async ({ budget, legacy, chat56 }) => {
       await expect(
         chatEffort(AxAIOpenAIModel.GPT55, { thinkingTokenBudget: budget })
       ).resolves.toBe(legacy);
       await expect(
         chatEffort(AxAIOpenAIModel.GPT56, { thinkingTokenBudget: budget })
-      ).resolves.toBe(gpt56);
+      ).resolves.toBe(chat56);
     }
   );
 
   it.each(budgets)(
-    'Responses maps $budget to $legacy on gpt-5.5 and $gpt56 on gpt-5.6',
-    ({ budget, legacy, gpt56 }) => {
+    'Responses maps $budget to $legacy on gpt-5.5 and $responses56 on gpt-5.6',
+    ({ budget, legacy, responses56 }) => {
       expect(
         responsesReasoning(AxAIOpenAIResponsesModel.GPT55, {
           thinkingTokenBudget: budget,
@@ -95,7 +102,7 @@ describe('OpenAI reasoning effort ladder', () => {
         responsesReasoning(AxAIOpenAIResponsesModel.GPT56, {
           thinkingTokenBudget: budget,
         })?.effort
-      ).toBe(gpt56);
+      ).toBe(responses56);
     }
   );
 
@@ -108,7 +115,7 @@ describe('OpenAI reasoning effort ladder', () => {
   ])('Chat applies the 5.6 ladder to %s', async (model) => {
     await expect(
       chatEffort(model, { thinkingTokenBudget: 'highest' })
-    ).resolves.toBe('max');
+    ).resolves.toBe('xhigh');
   });
 
   it.each([
@@ -184,11 +191,8 @@ describe('OpenAI thinkingTokenBudget=none', () => {
 // verbatim — including the rungs the budget ladder cannot reach.
 describe('OpenAI explicit reasoningEffort', () => {
   it.each(['xhigh', 'max'] as const)(
-    'forwards %s unchanged on gpt-5.6',
-    async (effort) => {
-      await expect(
-        chatEffort(AxAIOpenAIModel.GPT56, {}, { reasoningEffort: effort })
-      ).resolves.toBe(effort);
+    'forwards %s unchanged on gpt-5.6 responses',
+    (effort) => {
       expect(
         responsesReasoning(
           AxAIOpenAIResponsesModel.GPT56,
@@ -199,12 +203,28 @@ describe('OpenAI explicit reasoningEffort', () => {
     }
   );
 
+  it('forwards xhigh unchanged on gpt-5.6 chat', async () => {
+    await expect(
+      chatEffort(AxAIOpenAIModel.GPT56, {}, { reasoningEffort: 'xhigh' })
+    ).resolves.toBe('xhigh');
+  });
+
+  // The chat config type no longer offers `max`, but the escape hatch is a
+  // passthrough rather than a validator — the same hook lets DeepSeek send its
+  // own `max`. A caller who forces one past the type still gets it on the wire,
+  // and OpenAI answers with a 400. Pinned so nobody adds a silent clamp here.
+  it('forwards an unsupported chat effort as-is rather than clamping it', async () => {
+    await expect(
+      chatEffort(AxAIOpenAIModel.GPT56, {}, { reasoningEffort: 'max' })
+    ).resolves.toBe('max');
+  });
+
   it('is overridden by an explicit thinkingTokenBudget', async () => {
     await expect(
       chatEffort(
         AxAIOpenAIModel.GPT56,
         { thinkingTokenBudget: 'low' },
-        { reasoningEffort: 'max' }
+        { reasoningEffort: 'xhigh' }
       )
     ).resolves.toBe('low');
   });

--- a/src/ax/ai/openai/api.ts
+++ b/src/ax/ai/openai/api.ts
@@ -47,7 +47,7 @@ import {
   type AxAIOpenAIEmbedResponse,
   AxAIOpenAIModel,
 } from './chat_types.js';
-import { axResolveOpenAIReasoningEffort } from './effort.js';
+import { axResolveOpenAIChatReasoningEffort } from './effort.js';
 import { axModelInfoOpenAI } from './info.js';
 import {
   axAIOpenAIRealtimeDefaultConfig,
@@ -423,7 +423,7 @@ class AxAIOpenAIImpl<
 
     // Then, override based on prompt-specific config
     if (config?.thinkingTokenBudget) {
-      reqValue.reasoning_effort = axResolveOpenAIReasoningEffort(
+      reqValue.reasoning_effort = axResolveOpenAIChatReasoningEffort(
         model,
         config.thinkingTokenBudget
       );

--- a/src/ax/ai/openai/chat_types.ts
+++ b/src/ax/ai/openai/chat_types.ts
@@ -92,14 +92,7 @@ export type AxAIOpenAIConfig<TModel, TEmbedModel> = Omit<
   logprobs?: number;
   echo?: boolean;
   dimensions?: number;
-  reasoningEffort?:
-    | 'none'
-    | 'minimal'
-    | 'low'
-    | 'medium'
-    | 'high'
-    | 'xhigh'
-    | 'max';
+  reasoningEffort?: 'none' | 'minimal' | 'low' | 'medium' | 'high' | 'xhigh';
   store?: boolean;
   serviceTier?: 'auto' | 'default' | 'flex';
   webSearchOptions?: {
@@ -151,14 +144,9 @@ export interface AxAIOpenAIResponseDelta<T> {
 
 export type AxAIOpenAIChatRequest<TModel> = {
   model: TModel;
-  reasoning_effort?:
-    | 'none'
-    | 'minimal'
-    | 'low'
-    | 'medium'
-    | 'high'
-    | 'xhigh'
-    | 'max';
+  // `max` is absent on purpose: Chat Completions rejects it even on the models
+  // whose Responses endpoint serves it. See effort.ts for the ladders.
+  reasoning_effort?: 'none' | 'minimal' | 'low' | 'medium' | 'high' | 'xhigh';
   store?: boolean;
   modalities?: readonly ('text' | 'audio')[];
   audio?: {

--- a/src/ax/ai/openai/effort.test.ts
+++ b/src/ax/ai/openai/effort.test.ts
@@ -1,9 +1,12 @@
 import { describe, expect, it } from 'vitest';
 
 import { AxAIOpenAIModel } from './chat_types.js';
-import { axResolveOpenAIReasoningEffort } from './effort.js';
+import {
+  axResolveOpenAIChatReasoningEffort,
+  axResolveOpenAIResponsesReasoningEffort,
+} from './effort.js';
 
-describe('axResolveOpenAIReasoningEffort', () => {
+describe('OpenAI reasoning effort resolvers', () => {
   const gpt56Models = [
     AxAIOpenAIModel.GPT56,
     AxAIOpenAIModel.GPT56Sol,
@@ -11,23 +14,51 @@ describe('axResolveOpenAIReasoningEffort', () => {
     AxAIOpenAIModel.GPT56Luna,
   ];
 
-  // GPT-5.6 is the only generation serving `max`, so `highest` finally reaches
-  // the top rung instead of collapsing onto `xhigh`. It dropped `minimal`.
+  const budgets = [
+    'none',
+    'minimal',
+    'low',
+    'medium',
+    'high',
+    'highest',
+  ] as const;
+
+  // GPT-5.6 dropped `minimal`, so it shares `low` with the rung below. The two
+  // surfaces agree everywhere except the top: `max` exists only on Responses.
   it.each([
-    ['none', 'none'],
-    ['minimal', 'low'],
-    ['low', 'low'],
-    ['medium', 'medium'],
-    ['high', 'high'],
-    ['highest', 'max'],
-  ] as const)('maps %s to %s on every GPT-5.6 tier', (budget, expected) => {
+    ['none', 'none', 'none'],
+    ['minimal', 'low', 'low'],
+    ['low', 'low', 'low'],
+    ['medium', 'medium', 'medium'],
+    ['high', 'high', 'high'],
+    ['highest', 'xhigh', 'max'],
+  ] as const)(
+    'maps %s to %s on chat and %s on responses for every GPT-5.6 tier',
+    (budget, chat, responses) => {
+      for (const model of gpt56Models) {
+        expect(axResolveOpenAIChatReasoningEffort(model, budget)).toBe(chat);
+        expect(axResolveOpenAIResponsesReasoningEffort(model, budget)).toBe(
+          responses
+        );
+      }
+    }
+  );
+
+  // Chat Completions 400s on `max`, which is what shipped in 23.0.7. No rung on
+  // any 5.6 tier may produce it.
+  it('never resolves max on the chat path', () => {
     for (const model of gpt56Models) {
-      expect(axResolveOpenAIReasoningEffort(model, budget)).toBe(expected);
+      for (const budget of budgets) {
+        expect(axResolveOpenAIChatReasoningEffort(model, budget)).not.toBe(
+          'max'
+        );
+      }
     }
   });
 
-  // Everything else keeps the historical ladder byte-for-byte. The non-OpenAI
-  // names matter most: their own request updaters read what this produced.
+  // Everything else keeps the historical ladder byte-for-byte, on both
+  // surfaces. The non-OpenAI names matter most: their own request updaters read
+  // what this produced.
   it.each([
     ['none', undefined],
     ['minimal', 'minimal'],
@@ -47,16 +78,19 @@ describe('axResolveOpenAIReasoningEffort', () => {
       'grok-4',
       undefined,
     ]) {
-      expect(axResolveOpenAIReasoningEffort(model, budget)).toBe(expected);
+      expect(axResolveOpenAIChatReasoningEffort(model, budget)).toBe(expected);
+      expect(axResolveOpenAIResponsesReasoningEffort(model, budget)).toBe(
+        expected
+      );
     }
   });
 
   it('does not mistake other 5.x generations for 5.6', () => {
     expect(
-      axResolveOpenAIReasoningEffort(AxAIOpenAIModel.GPT55, 'highest')
+      axResolveOpenAIResponsesReasoningEffort(AxAIOpenAIModel.GPT55, 'highest')
     ).toBe('xhigh');
-    expect(axResolveOpenAIReasoningEffort('gpt-5.6-sol', 'highest')).toBe(
-      'max'
-    );
+    expect(
+      axResolveOpenAIResponsesReasoningEffort('gpt-5.6-sol', 'highest')
+    ).toBe('max');
   });
 });

--- a/src/ax/ai/openai/effort.ts
+++ b/src/ax/ai/openai/effort.ts
@@ -1,15 +1,24 @@
 import type { AxAIServiceOptions } from '../types.js';
 import type { AxAIOpenAIChatRequest } from './chat_types.js';
+import type { AxAIOpenAIResponsesRequest } from './responses_types.js';
 
 /**
- * The `reasoning.effort` vocabulary across the OpenAI reasoning line. No single
- * model accepts all of these — the vocabulary is not shared across generations,
- * and OpenAI rejects an effort its model doesn't know with a 400 rather than
+ * The `reasoning_effort` vocabulary Chat Completions accepts. No single model
+ * accepts all of these — the vocabulary is not shared across generations, and
+ * OpenAI rejects an effort its model doesn't know with a 400 rather than
  * degrading gracefully. Taken from the request type so the ladders below cannot
  * drift from what the wire format accepts.
  */
-export type AxAIOpenAIReasoningEffort = NonNullable<
+export type AxAIOpenAIChatReasoningEffort = NonNullable<
   AxAIOpenAIChatRequest<unknown>['reasoning_effort']
+>;
+
+/**
+ * The same vocabulary on the Responses API, which serves one rung more. The
+ * property is optional and nullable, hence the two unwraps.
+ */
+export type AxAIOpenAIResponsesReasoningEffort = NonNullable<
+  NonNullable<AxAIOpenAIResponsesRequest<unknown>['reasoning']>['effort']
 >;
 
 type ThinkingTokenBudget = NonNullable<
@@ -20,24 +29,40 @@ type ThinkingTokenBudget = NonNullable<
  * A budget rung mapped to the effort to put on the wire. `none` is absent
  * because it means "send no effort at all" rather than an effort value.
  */
-type EffortLadder = Record<
+type EffortLadder<TEffort> = Record<
   Exclude<ThinkingTokenBudget, 'none'>,
-  AxAIOpenAIReasoningEffort
+  TEffort
 >;
 
 /**
- * GPT-5.6 serves `none`, `low`, `medium`, `high`, `xhigh` and `max`, so the
- * ladder maps one-to-one and `highest` can finally reach `max`. It does not
- * serve `minimal` — that rung was retired after GPT-5 — so `minimal` takes the
- * lowest thinking level 5.6 does offer.
+ * GPT-5.6 on Chat Completions serves `none`, `low`, `medium`, `high` and
+ * `xhigh`, so the ladder maps onto them in order. It does not serve `minimal` —
+ * that rung was retired after GPT-5 — so `minimal` takes the lowest thinking
+ * level 5.6 does offer, which is also where `low` lands.
  */
-const GPT56_LADDER: EffortLadder = {
+const GPT56_CHAT_LADDER: EffortLadder<AxAIOpenAIChatReasoningEffort> = {
   minimal: 'low',
   low: 'low',
   medium: 'medium',
   high: 'high',
-  highest: 'max',
+  highest: 'xhigh',
 };
+
+/**
+ * The Responses API serves one rung above `xhigh`, so `highest` reaches `max`
+ * there and only there. Chat Completions refuses the same value on the same
+ * model:
+ *
+ *   Unsupported value: `reasoning_effort` does not support `max` with this
+ *   model. Supported values are: `none`, `low`, `medium`, `high`, and `xhigh`.
+ *
+ * Observed on all three 5.6 tiers, so the two surfaces cannot share a ladder.
+ */
+const GPT56_RESPONSES_LADDER: EffortLadder<AxAIOpenAIResponsesReasoningEffort> =
+  {
+    ...GPT56_CHAT_LADDER,
+    highest: 'max',
+  };
 
 /**
  * Every other model keeps the historical mapping verbatim. It is shifted and
@@ -49,9 +74,10 @@ const GPT56_LADDER: EffortLadder = {
  *
  * This request builder is also shared with DeepSeek, Grok, Mistral, Cohere and
  * Reka, whose own request updaters read the effort this produced. Leaving them
- * on the historical ladder keeps their wire output byte-identical.
+ * on the historical ladder keeps their wire output byte-identical. It never
+ * produces `max`, so both surfaces can share it.
  */
-const LEGACY_LADDER: EffortLadder = {
+const LEGACY_LADDER: EffortLadder<AxAIOpenAIChatReasoningEffort> = {
   minimal: 'minimal',
   low: 'medium',
   medium: 'high',
@@ -62,20 +88,46 @@ const LEGACY_LADDER: EffortLadder = {
 /** Matches `gpt-5.6` and every tier suffix (`-sol`, `-terra`, `-luna`). */
 const GPT56_MODELS = /^gpt-5\.6($|-)/;
 
+function isGPT56(model: unknown): boolean {
+  return GPT56_MODELS.test(typeof model === 'string' ? model : '');
+}
+
 /**
- * Resolve a thinking-budget rung to the `reasoning.effort` value to send, or
- * `undefined` when no effort should be sent at all.
+ * GPT-5.6 defaults an omitted effort to `medium`, so disabling reasoning
+ * requires an explicit `none`. Every other model and OpenAI-compatible provider
+ * keeps the historical omission.
  */
-export function axResolveOpenAIReasoningEffort(
+function resolveNone(model: unknown): 'none' | undefined {
+  return isGPT56(model) ? 'none' : undefined;
+}
+
+/**
+ * Resolve a thinking-budget rung to the `reasoning_effort` value to send on a
+ * Chat Completions request, or `undefined` when no effort should be sent.
+ */
+export function axResolveOpenAIChatReasoningEffort(
   model: unknown,
   budget: ThinkingTokenBudget
-): AxAIOpenAIReasoningEffort | undefined {
-  const name = typeof model === 'string' ? model : '';
+): AxAIOpenAIChatReasoningEffort | undefined {
   if (budget === 'none') {
-    // GPT-5.6 defaults an omitted effort to `medium`, so disabling reasoning
-    // requires an explicit `none`. Preserve the historical omission for every
-    // other model and OpenAI-compatible provider.
-    return GPT56_MODELS.test(name) ? 'none' : undefined;
+    return resolveNone(model);
   }
-  return GPT56_MODELS.test(name) ? GPT56_LADDER[budget] : LEGACY_LADDER[budget];
+  return isGPT56(model) ? GPT56_CHAT_LADDER[budget] : LEGACY_LADDER[budget];
+}
+
+/**
+ * The same resolution for a Responses request, where `highest` reaches `max` on
+ * GPT-5.6. Kept separate from the chat resolver rather than defaulted behind a
+ * surface argument: a default is what sent `max` to Chat Completions.
+ */
+export function axResolveOpenAIResponsesReasoningEffort(
+  model: unknown,
+  budget: ThinkingTokenBudget
+): AxAIOpenAIResponsesReasoningEffort | undefined {
+  if (budget === 'none') {
+    return resolveNone(model);
+  }
+  return isGPT56(model)
+    ? GPT56_RESPONSES_LADDER[budget]
+    : LEGACY_LADDER[budget];
 }

--- a/src/ax/ai/openai/responses_api.phase.test.ts
+++ b/src/ax/ai/openai/responses_api.phase.test.ts
@@ -23,20 +23,19 @@ describe('Responses API type extensions (2026)', () => {
     expect(req.include).toContain('web_search_call.action.return_token_budget');
   });
 
-  it('accepts xhigh and none on reasoning.effort', () => {
-    const reqXhigh: AxAIOpenAIResponsesRequest<AxAIOpenAIResponsesModel> = {
-      model: AxAIOpenAIResponsesModel.GPT55,
-      input: 'hi',
-      reasoning: { effort: 'xhigh' },
-    };
-    const reqNone: AxAIOpenAIResponsesRequest<AxAIOpenAIResponsesModel> = {
-      model: AxAIOpenAIResponsesModel.GPT55,
-      input: 'hi',
-      reasoning: { effort: 'none' },
-    };
-    expect(reqXhigh.reasoning?.effort).toBe('xhigh');
-    expect(reqNone.reasoning?.effort).toBe('none');
-  });
+  // `max` is Responses-only — the chat request type deliberately omits it, so
+  // this is the one place the top rung is pinned to a wire format.
+  it.each(['xhigh', 'none', 'max'] as const)(
+    'accepts %s on reasoning.effort',
+    (effort) => {
+      const req: AxAIOpenAIResponsesRequest<AxAIOpenAIResponsesModel> = {
+        model: AxAIOpenAIResponsesModel.GPT55,
+        input: 'hi',
+        reasoning: { effort },
+      };
+      expect(req.reasoning?.effort).toBe(effort);
+    }
+  );
 
   it('passes through the phase field on output message items', () => {
     const impl = new AxAIOpenAIResponsesImpl(config, false);

--- a/src/ax/ai/openai/responses_api.ts
+++ b/src/ax/ai/openai/responses_api.ts
@@ -16,7 +16,7 @@ import type {
   AxModelConfig,
   AxTokenUsage,
 } from '../types.js';
-import { axResolveOpenAIReasoningEffort } from './effort.js';
+import { axResolveOpenAIResponsesReasoningEffort } from './effort.js';
 import type {
   AxAIOpenAIResponsesCodeInterpreterToolCall,
   AxAIOpenAIResponsesComputerToolCall,
@@ -387,7 +387,7 @@ export class AxAIOpenAIResponsesImpl<
 
     // Handle thinkingTokenBudget config parameter
     if (config?.thinkingTokenBudget) {
-      reasoningEffort = axResolveOpenAIReasoningEffort(
+      reasoningEffort = axResolveOpenAIResponsesReasoningEffort(
         model,
         config.thinkingTokenBudget
       );

--- a/src/ax/index.test-d.ts
+++ b/src/ax/index.test-d.ts
@@ -7,6 +7,10 @@ import { AxSignature } from './dsp/sig.js';
 import type { AxExamples } from './dsp/types.js';
 import {
   type AxAgentFunction,
+  type AxAIOpenAIChatRequest,
+  type AxAIOpenAIConfig,
+  type AxAIOpenAIResponsesConfig,
+  type AxAIOpenAIResponsesRequest,
   type AxAIService,
   type AxFunction,
   type AxFunctionHandler,
@@ -544,3 +548,32 @@ const arrayFlow = flow<{ items: string[] }>().map((state) => ({
   uppercaseItems: state.items.map((item) => item.toUpperCase()),
 }));
 void arrayFlow.forward;
+
+// === OpenAI reasoning effort surfaces ===
+// `max` exists only on the Responses API. Chat Completions answers a chat
+// request carrying it with a 400, so the chat types must not offer it while the
+// Responses ones must.
+const chatReqTopEffort: AxAIOpenAIChatRequest<string>['reasoning_effort'] =
+  'xhigh';
+void chatReqTopEffort;
+
+// @ts-expect-error `max` is Responses-only; Chat Completions rejects it
+const chatReqMaxEffort: AxAIOpenAIChatRequest<string>['reasoning_effort'] =
+  'max';
+void chatReqMaxEffort;
+
+// @ts-expect-error same for the config that feeds the chat request
+const chatConfigMaxEffort: AxAIOpenAIConfig<string, string>['reasoningEffort'] =
+  'max';
+void chatConfigMaxEffort;
+
+const responsesReqMaxEffort: NonNullable<
+  AxAIOpenAIResponsesRequest<string>['reasoning']
+>['effort'] = 'max';
+void responsesReqMaxEffort;
+
+const responsesConfigMaxEffort: AxAIOpenAIResponsesConfig<
+  string,
+  string
+>['reasoningEffort'] = 'max';
+void responsesConfigMaxEffort;

--- a/src/ax/skills/ax-ai.md
+++ b/src/ax/skills/ax-ai.md
@@ -293,8 +293,10 @@ console.log(res.results[0]?.content);
 | `'high'` | 20,000 | 10,000 |
 | `'highest'` | 32,000 | 24,500 |
 
-For GPT-5.6, these map to `none`, `low`, `low`, `medium`, `high`, and `max`
-respectively. Earlier OpenAI models retain their existing mapping.
+For GPT-5.6, these map to `none`, `low`, `low`, `medium`, `high`, and a top rung
+that depends on the API surface: `xhigh` on Chat Completions, which rejects
+`max`, and `max` on the Responses API, which is the only place it is served.
+Earlier OpenAI models retain their existing mapping.
 
 ### Anthropic Model-Specific Behavior
 


### PR DESCRIPTION
Regression from #568, shipped in v23.0.7: `thinkingTokenBudget: 'highest'` on any GPT-5.6 tier resolves to `reasoning_effort: 'max'`, and Chat Completions rejects that value. Every such request 400s:

> Unsupported value: `reasoning_effort` does not support `max` with this model. Supported values are: `none`, `low`, `medium`, `high`, and `xhigh`.

Verified live on all three tiers. The same value succeeds on `/v1/responses` — `max` is a Responses-only rung. Because 5.6 realigned the ladder, `highest` is the only rung that reached above `high`, so on the chat path nothing can currently exceed `high` at all.

## What changed

`effort.ts` had one resolver serving both request builders. It now has one ladder per API surface, differing at exactly one rung:

| budget | chat | responses |
| --- | --- | --- |
| `none` | `none` | `none` |
| `minimal` / `low` | `low` | `low` |
| `medium` | `medium` | `medium` |
| `high` | `high` | `high` |
| `highest` | **`xhigh`** | `max` |

The two resolvers stay separate rather than sharing a surface argument with a default — a default is what put `max` on a chat request to begin with. `LEGACY_LADDER` never produced `max`, so it is shared unchanged and DeepSeek, Grok, Mistral, Cohere and Reka keep byte-identical wire output.

`max` also comes back out of `AxAIOpenAIChatRequest['reasoning_effort']` and `AxAIOpenAIConfig['reasoningEffort']`, restoring both to their pre-5.6 shape. `responses_types.ts` keeps it.

## One consequence worth flagging

Those two types are public and shared by every OpenAI-compatible provider. DeepSeek is the only one whose API genuinely accepts `max`; it re-adds the value locally (`deepseek/api.ts:21`) and casts on assignment, so its `xhigh` → `max` rewrite and its wire output are unaffected. What a DeepSeek caller loses is setting `reasoningEffort: 'max'` *directly* — possible only in 23.0.7, and still reachable via `xhigh` or `thinkingTokenBudget: 'highest'`.

## The escape hatch is deliberately not clamped

`config.reasoningEffort` is forwarded verbatim, so an effort forced past the type still reaches the wire and OpenAI answers with a 400. That is the intended contract: the same post-resolver hook is how DeepSeek injects its own `max`, and clamping per-value here would break it. The type change is what stops ax from advertising the value; a test pins the passthrough so nobody adds a silent clamp later.

## Verification

- `vitest` over `openai/`, `deepseek/` and `x-grok/` — 88 pass; full `src/ax` suite 2777 pass.
- `test:type-check` and `test:type-tests` clean. `index.test-d.ts` gains assertions that the chat types reject `max` while the Responses ones accept it — the reasoning tests take `Record<string, unknown>` and cannot see the narrowing.
- `axir:conformance:check` clean, which is what proves the DeepSeek golden still puts `reasoning_effort: 'max'` on the wire.
- `axir:backlog:validate` clean; the 5.6 ladder backlog entry had stale `tsPaths` (the ladder moved to `effort.ts`) and impact text, both corrected and re-rendered.
- Docs: the skill's 5.6 mapping note said the top rung was `max`; it now gives both surfaces.

No version bump here — release commits land separately. `bigbasinlabs/bigb#6079` can restore its `highest` variants once it picks up the release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016fpbeRif6Sw93e85gUxtxz
