### PR TITLE
fix(util): browser SSE streams end with a spurious network error

### DIFF
--- a/src/ax/util/apicall.test.ts
+++ b/src/ax/util/apicall.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import {
   type AxAIServiceError,
@@ -422,6 +422,77 @@ describe('apiCall', () => {
         expect(errorString).not.toContain('Request Body:');
         expect(errorString).not.toContain('largeBase64');
       }
+    });
+  });
+
+  describe('browser SSE streaming', () => {
+    // apicall.ts switches to its browser-optimized SSE reader when both
+    // `window` and `EventSource` are defined. Vitest runs in a node
+    // environment, so stub them to reach that branch.
+    const stubBrowserGlobals = () => {
+      vi.stubGlobal('window', {});
+      vi.stubGlobal('EventSource', vi.fn());
+    };
+
+    afterEach(() => {
+      vi.unstubAllGlobals();
+    });
+
+    const sseResponse = (events: string): Response =>
+      new Response(events, {
+        status: 200,
+        headers: { 'content-type': 'text/event-stream' },
+      });
+
+    const collectStream = async (events: string) => {
+      const mockFetch = vi.fn().mockResolvedValue(sseResponse(events));
+
+      const stream = (await apiCall<{ test: string }, { index: number }>(
+        {
+          url: 'https://api.example.com/test',
+          fetch: mockFetch,
+          stream: true,
+        },
+        { test: 'data' }
+      )) as ReadableStream<{ index: number }>;
+
+      const reader = stream.getReader();
+      const chunks: { index: number }[] = [];
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) {
+          break;
+        }
+        chunks.push(value);
+      }
+      return chunks;
+    };
+
+    it('ends the stream when the provider sends no [DONE] sentinel', async () => {
+      stubBrowserGlobals();
+
+      await expect(
+        collectStream('data: {"index":0}\n\ndata: {"index":1}\n\n')
+      ).resolves.toEqual([{ index: 0 }, { index: 1 }]);
+    });
+
+    it('ends the stream when the last event has no trailing blank line', async () => {
+      stubBrowserGlobals();
+
+      await expect(
+        collectStream('data: {"index":0}\n\ndata: {"index":1}')
+      ).resolves.toEqual([{ index: 0 }, { index: 1 }]);
+    });
+
+    it.each([
+      ['terminated by a blank line', 'data: [DONE]\n\n'],
+      ['sent as a trailing event', 'data: [DONE]'],
+    ])('stops at the [DONE] sentinel %s', async (_label, sentinel) => {
+      stubBrowserGlobals();
+
+      await expect(
+        collectStream(`data: {"index":0}\n\ndata: {"index":1}\n\n${sentinel}`)
+      ).resolves.toEqual([{ index: 0 }, { index: 1 }]);
     });
   });
 });

--- a/src/ax/util/apicall.ts
+++ b/src/ax/util/apicall.ts
@@ -985,12 +985,16 @@ export const apiCall = async <TRequest = unknown, TResponse = unknown>(
                     // Providers are allowed to end the stream without a final
                     // blank line; the Node SSEParser path handles this via
                     // handleFlush, so match that behavior here.
+                    let sawDone = false;
                     if (buffer.length > 0) {
-                      processEvent(buffer);
+                      sawDone = processEvent(buffer);
                       buffer = '';
                     }
-                    closed = true;
-                    controller.close();
+                    // processEvent already closed the controller if it saw
+                    // the [DONE] sentinel, so only close it here if it did not.
+                    if (!sawDone) {
+                      controller.close();
+                    }
                     break;
                   }
 


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix, plus the unit tests that cover it. Two files, `+79 / -4`, no dependency and no public API change.

- **What is the current behavior?** (You can also link to an open issue here)

When `apiCall` runs in a browser (`typeof window !== 'undefined' && typeof EventSource !== 'undefined'`), streaming responses end with a spurious `AxAIServiceNetworkError` instead of closing cleanly.

The browser SSE reader assigns a flag that is not in scope on that code path. `src/ax/util/apicall.ts:992`, inside `read()`:

```ts
if (done) {
  // Flush any trailing event that wasn't terminated by \n\n. ...
  if (buffer.length > 0) {
    processEvent(buffer);
    buffer = '';
  }
  closed = true;          // <- line 992
  controller.close();
  break;
}
```

The only declaration of `closed` is `let closed = false;` at line 1068, which sits *after* the `if (isBrowser)` block — and that block already returned its `ReadableStream` at line 927. So line 1068 is never evaluated on this path and the binding is permanently in the temporal dead zone. `tsc` does not catch it because the reference lives inside a nested function, which is the legal hoisted-closure pattern.

The result at runtime:

```
ReferenceError: Cannot access 'closed' before initialization
    at read (src/ax/util/apicall.ts:992:21)
```

That throw is caught by this stream's own `catch (e)` (line 1006). `error.name` is `ReferenceError` and the message contains no `'aborted'`, so it falls through to the `else` at line 1026 and calls `controller.error(new AxAIServiceNetworkError(...))`. Erroring a still-readable controller also resets its queue per the Streams spec, so any chunks not yet pulled by the consumer are dropped.

**Scope, stated plainly:** chunks are parsed and enqueued correctly right up to the end — `streamMetrics.streamChunks` is 2 out of 2 in the failing test. What is corrupted is the end-of-stream signal. Depending on how fast the consumer reads, a caller sees either the full response followed by a network error, or a truncated response followed by a network error.

Who is affected:

| Case | Today |
| --- | --- |
| Provider sends `data: [DONE]` + blank line (OpenAI) | **Fine.** `processEvent` returns `true`, line 1003 returns early, line 992 is never reached. |
| Provider ends the stream with no `[DONE]` sentinel (Anthropic-/Gemini-style SSE, proxies, gateways) | **Broken.** |
| Last event arrives without a trailing blank line | **Broken** — even though the comment right above line 992 says this case is meant to be handled, matching `handleFlush` in the Node `SSEParser`. |

This is a latent defect I found reading the code, not a production report. The path is real rather than dead code: `AGENTS.md` under *Important Repo Constraints* requires keeping `src/ax/` browser-compatible, and the browser route is a first-class supported scenario — `AxAPIConfig` exposes a `corsProxy` option (line 74) that `apiCall` applies at lines 613-615, and a CORS proxy only exists for calls made from a browser. It is not covered by CI today — `src/ax/util/apicall.test.ts` never touches `window`/`EventSource`, and there is no `vitest.config.*` under `src/ax/`, so vitest runs with the default `node` environment and the branch never executes.

- **What is the new behavior (if this is a feature change)?**

The browser stream closes exactly once, and end of stream is a clean close for every provider shape.

```diff
+                    let sawDone = false;
                     if (buffer.length > 0) {
-                      processEvent(buffer);
+                      sawDone = processEvent(buffer);
                       buffer = '';
                     }
-                    closed = true;
-                    controller.close();
+                    // processEvent already closed the controller if it saw
+                    // the [DONE] sentinel, so only close it here if it did not.
+                    if (!sawDone) {
+                      controller.close();
+                    }
                     break;
```

Two things, both inside the same `if (done)` block:

1. **The fix.** The out-of-scope write is gone. Nothing inside the browser branch ever read `closed` (it is the only occurrence between lines 921 and 1048), and this `ReadableStream` has no `cancel()` handler, so the flag had no job here — it belongs to the Node stream further down.
2. **Using `processEvent`'s return value at the flush site.** This is not cosmetic, and I checked rather than assumed. `processEvent` is documented in this file as *"Returns true if the caller should stop reading (e.g. saw `[DONE]`)"* and it calls `controller.close()` itself in that case, but the flush site discards the result. If you apply only change 1, a stream whose last event is `data: [DONE]` with no trailing blank line closes the controller twice, the second `close()` throws `TypeError: Invalid state: Controller is already closed`, and the same `catch` turns that into another spurious `AxAIServiceNetworkError`. I verified this by applying the one-line deletion alone: one of the four new tests still fails with exactly that message.

The Node/server path is untouched. `let closed = false;` and its three uses in the Node `ReadableStream` stay exactly where they are; only their line numbers shift. I also considered hoisting the existing declaration above `if (isBrowser)`, which fixes the `ReferenceError` in one line, but it moves state used by the hot server path and would still need the double-close guard. Happy to switch if you prefer that shape.

Four tests added to `src/ax/util/apicall.test.ts` (16 → 20), stubbing `window`/`EventSource` with `vi.stubGlobal` and restoring them in `afterEach`, following `src/ax/mcp/transports/httpStreamTransport.test.ts`. Three of them fail on `main` today at `apicall.ts:992:21`; the fourth covers the OpenAI `[DONE]` path and passes before and after, so it only guards against regressions.

- **AxIR portable behavior check**:

TS-only, no AxIR impact. `src/ax/util/` is not one of the portable roots in `scripts/axir-backlog.mjs` (`src/ax/ai/`, `src/ax/dsp/`, `src/ax/agent/`, `src/ax/flow/`, `src/ax/mcp/`, `src/ax/mem/`). Confirmed by running the gate on this branch:

```
$ npm run axir:backlog:check
AxIR backlog check ok: No portable TypeScript paths changed.
```

`axir-no-impact` is included in the commit message, since external contributors cannot set labels.

- **Other information**:

**Verification, including the revert step.** I ran the suite in all three states rather than only the green one:

| State | Result |
| --- | --- |
| `main` unmodified + new tests | **3 failed**, 17 passed — all three `Caused by: AxAIServiceNetworkError: Network Error: Cannot access 'closed' before initialization` at `read (apicall.ts:992:21)` |
| Only `closed = true;` deleted | **1 failed**, 19 passed — `Caused by: AxAIServiceNetworkError: Network Error: Invalid state: Controller is already closed` |
| Full patch | **20 passed** |

Repo gates on the patched tree: `biome check` clean on both files, `cspell` clean with no new dictionary words, `tsc --noEmit` clean with the repo's exact `compilerOptions` (I type-checked the test file too, even though the root `tsconfig.json` excludes `src/**/*.test.ts`), and `axir:backlog:check` as quoted above.

**Deliberately out of scope.** The browser `ReadableStream` still has no `cancel()` handler, unlike the Node one, so a consumer cancelling mid-stream does not stop the read loop early. That is a behavioural change rather than a bug fix and I left it out; happy to open it separately if it is worth having.

**Assistance disclosure.** I used an AI coding assistant while investigating and drafting this change. I could not find a disclosure requirement in the repo (`README.md` → Contributing, `AGENTS.md`, `.github/CONTRIBUTING.md`), so I am noting it voluntarily. Every claim above is backed by output I ran myself against `main` at `fd1b967`, including the revert step, and I am happy to rework the patch shape or narrow the tests if you would rather take a smaller diff.
