### PR TITLE
fix(util): classify mid-stream caller aborts

### DIFF
--- a/src/ax/util/apicall.test.ts
+++ b/src/ax/util/apicall.test.ts
@@ -1,9 +1,11 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import {
+  AxAIServiceAbortedError,
   type AxAIServiceError,
   AxAIServiceNetworkError,
   AxAIServiceStatusError,
+  AxAIServiceStreamTerminatedError,
   type AxAPIConfig,
   apiCall,
 } from './apicall.js';
@@ -421,6 +423,134 @@ describe('apiCall', () => {
         const errorString = (error as AxAIServiceError).toString();
         expect(errorString).not.toContain('Request Body:');
         expect(errorString).not.toContain('largeBase64');
+      }
+    });
+  });
+
+  describe('SSE streaming failures', () => {
+    const startStreamingCall = async (abortController?: AbortController) => {
+      let bodyController:
+        | ReadableStreamDefaultController<Uint8Array>
+        | undefined;
+      const mockFetch = vi.fn(
+        async (_input: RequestInfo | URL, init?: RequestInit) => {
+          const body = new ReadableStream<Uint8Array>({
+            start(controller) {
+              bodyController = controller;
+              controller.enqueue(
+                new TextEncoder().encode('data: {"index":0}\n\n')
+              );
+              init?.signal?.addEventListener(
+                'abort',
+                () => controller.error(init.signal?.reason),
+                { once: true }
+              );
+            },
+          });
+
+          return new Response(body, {
+            status: 200,
+            headers: { 'content-type': 'text/event-stream' },
+          });
+        }
+      );
+
+      const stream = (await apiCall<{ test: string }, { index: number }>(
+        {
+          url: 'https://api.example.com/test',
+          fetch: mockFetch,
+          stream: true,
+          ...(abortController ? { abortSignal: abortController.signal } : {}),
+        },
+        { test: 'data' }
+      )) as ReadableStream<{ index: number }>;
+
+      if (!bodyController) {
+        throw new Error('Response body controller was not initialized');
+      }
+
+      return { bodyController, reader: stream.getReader() };
+    };
+
+    describe.each([
+      ['Node', false],
+      ['browser', true],
+    ] as const)('%s reader', (_runtime, browser) => {
+      afterEach(() => {
+        vi.unstubAllGlobals();
+      });
+
+      const configureRuntime = () => {
+        if (browser) {
+          vi.stubGlobal('window', {});
+          vi.stubGlobal('EventSource', vi.fn());
+        }
+      };
+
+      it('classifies a caller abort as AxAIServiceAbortedError', async () => {
+        configureRuntime();
+        const abortController = new AbortController();
+        const { reader } = await startStreamingCall(abortController);
+
+        await expect(reader.read()).resolves.toEqual({
+          done: false,
+          value: { index: 0 },
+        });
+
+        abortController.abort(
+          new DOMException('Caller aborted request', 'AbortError')
+        );
+
+        await expect(reader.read()).rejects.toBeInstanceOf(
+          AxAIServiceAbortedError
+        );
+      });
+
+      it('keeps a remote abort classified as AxAIServiceStreamTerminatedError', async () => {
+        configureRuntime();
+        const { bodyController, reader } = await startStreamingCall();
+
+        await expect(reader.read()).resolves.toEqual({
+          done: false,
+          value: { index: 0 },
+        });
+
+        bodyController.error(
+          new DOMException('Remote stream aborted', 'AbortError')
+        );
+
+        try {
+          await reader.read();
+          expect.fail('Expected the remote stream to terminate');
+        } catch (error) {
+          expect(error).toBeInstanceOf(AxAIServiceStreamTerminatedError);
+          expect((error as AxAIServiceStreamTerminatedError).lastChunk).toEqual(
+            { index: 0 }
+          );
+        }
+      });
+    });
+
+    it('does not orphan the Node reader rejection after a caller abort', async () => {
+      const unhandledRejection = vi.fn();
+      process.on('unhandledRejection', unhandledRejection);
+
+      try {
+        const abortController = new AbortController();
+        const { reader } = await startStreamingCall(abortController);
+
+        await reader.read();
+        abortController.abort(
+          new DOMException('Caller aborted request', 'AbortError')
+        );
+        await expect(reader.read()).rejects.toBeInstanceOf(
+          AxAIServiceAbortedError
+        );
+        await new Promise<void>((resolve) => setImmediate(resolve));
+
+        expect(unhandledRejection).not.toHaveBeenCalled();
+      } finally {
+        process.off('unhandledRejection', unhandledRejection);
       }
     });
   });

--- a/src/ax/util/apicall.ts
+++ b/src/ax/util/apicall.ts
@@ -1019,13 +1019,21 @@ export const apiCall = async <TRequest = unknown, TResponse = unknown>(
                   error.message?.includes('aborted')
                 ) {
                   controller.error(
-                    new AxAIServiceStreamTerminatedError(
-                      apiUrl.href,
-                      json,
-                      lastChunk,
-                      { streamMetrics },
-                      includeBodyInErrors
-                    )
+                    api.abortSignal?.aborted
+                      ? new AxAIServiceAbortedError(
+                          apiUrl.href,
+                          api.abortSignal.reason,
+                          json,
+                          { streamMetrics },
+                          includeBodyInErrors
+                        )
+                      : new AxAIServiceStreamTerminatedError(
+                          apiUrl.href,
+                          json,
+                          lastChunk,
+                          { streamMetrics },
+                          includeBodyInErrors
+                        )
                   );
                 } else {
                   controller.error(
@@ -1108,13 +1116,21 @@ export const apiCall = async <TRequest = unknown, TResponse = unknown>(
                 error.message?.includes('aborted')
               ) {
                 controller.error(
-                  new AxAIServiceStreamTerminatedError(
-                    apiUrl.href,
-                    json,
-                    lastChunk,
-                    { streamMetrics },
-                    includeBodyInErrors
-                  )
+                  api.abortSignal?.aborted
+                    ? new AxAIServiceAbortedError(
+                        apiUrl.href,
+                        api.abortSignal.reason,
+                        json,
+                        { streamMetrics },
+                        includeBodyInErrors
+                      )
+                    : new AxAIServiceStreamTerminatedError(
+                        apiUrl.href,
+                        json,
+                        lastChunk,
+                        { streamMetrics },
+                        includeBodyInErrors
+                      )
                 );
               } else if (
                 error instanceof TypeError &&
@@ -1146,7 +1162,6 @@ export const apiCall = async <TRequest = unknown, TResponse = unknown>(
                   )
                 );
               }
-              throw error;
             } finally {
               if (timeoutId) {
                 clearTimeout(timeoutId);


### PR DESCRIPTION
- **What kind of change does this PR introduce?**

  Bug fix that aligns mid-stream HTTP abort handling with Ax existing request abort handling.

- **What is the current behavior?**

  Ax already classifies caller cancellation as AxAIServiceAbortedError when the signal is aborted before dispatch and when an AbortError reaches the outer fetch catch. AxGen preserves that typed error and does not treat it as retryable infrastructure failure.

  The browser and Node streaming readers are inconsistent with those paths: they recognize an abort-like reader failure, but do not consult the caller abort signal and therefore report a mid-stream caller cancellation as AxAIServiceStreamTerminatedError. The Node reader driver also rethrows after erroring the returned stream, leaving its discarded promise rejected.

- **What is the new behavior?**

  The streaming readers now apply the same signal-based distinction used by the existing request paths. When an abort-like reader failure occurs while the caller signal is aborted, they emit AxAIServiceAbortedError with the caller reason. Without a pending caller abort, they retain AxAIServiceStreamTerminatedError for remote teardown, preserving its existing retry behavior.

  The Node reader delivers the failure only through the returned stream and no longer creates an orphaned rejection.

- **AxIR portable behavior check**:

  axir-no-impact — this is a TypeScript HTTP transport fix under src/ax/util and does not change AxIR interfaces or conformance behavior.

- **Other information**:

  Added Node and browser regression coverage for caller abort classification, remote teardown classification, retained last-chunk context, and unhandled promise rejections.

  Validation: npm run test --workspace=@ax-llm/ax (206 test files; 2,817 passed and 2 skipped), including type checks, lint, formatting, template checks, and generated-index checks.