### PR TITLE
docs(skills): document assertion return values in ax-gen

### DIFF
--- a/src/ax/skills/ax-gen.md
+++ b/src/ax/skills/ax-gen.md
@@ -221,6 +221,20 @@ Rules:
 - `addStreamingAssert(...)` targets a string/code output field and receives partial text so far.
 - Streaming assertions abort the current stream attempt by throwing `AxStreamingAssertionError`, then feed correction feedback into AxGen retries.
 
+Assertion return values, for both `addAssert(...)` and `addStreamingAssert(...)`:
+
+| Return | Meaning |
+| --- | --- |
+| `true` | Passes; continue. |
+| `false` | Fails; the `message` argument is used as the correction message. |
+| `string` | Fails; the returned string is used as the correction message. |
+| `undefined` | Skips this assertion, for conditional validation. |
+| a thrown error | Propagates as-is; only assertion errors are retried. |
+
+- `undefined` skips the check rather than passing it, so use it when an assertion does not apply to the current output.
+- `addAssert(...)` returning `false` without a `message` throws `Assertion failed without message`, which is not retried; pass `message` to get correction feedback.
+- `addStreamingAssert(...)` returning `false` without a `message` uses a generated message and is retried.
+
 ## Field Processors
 
 ```typescript


### PR DESCRIPTION
- **What kind of change does this PR introduce?**

  Docs update. No code changes.

- **What is the current behavior?**

  `addAssert(...)` and `addStreamingAssert(...)` accept `boolean | string | undefined`, but the skill docs don't say what each value does. `undefined` is the one that catches people out — it currently appears only in the type signature reproduced in `ax-llm.md`, with no explanation anywhere.

  This was documented once: `docs/DSPY.md` and `docs/EXAMPLES.md` carried an "Assertion Return Values" list added in 2770a074, and it went away when those files were removed.

- **What is the new behavior (if this is a feature change)?**

  Not a behavior change. Adds a small return-value table plus three notes to the assertions section of `src/ax/skills/ax-gen.md`, describing what `asserts.ts` already does.

  Two cases seemed worth calling out explicitly, since they're easy to hit by accident:

  - `undefined` skips the assertion rather than passing it.
  - `addAssert(...)` returning `false` with no `message` throws `Assertion failed without message`, which isn't retried, whereas the streaming variant falls back to a generated message and is retried.

- **AxIR portable behavior check**:

  No impact — documentation only, nothing under `src/ax/ai/`, `src/ax/dsp/`, `src/ax/agent/` or `src/ax/flow/`. `axir-no-impact` is in the commit message.

- **Other information**:

  `npm run skills:check` and `npm run test:format` both pass.

  I left out the generated copies under `website/static/**/.well-known/agent-skills/`. Running `npm run website:prepare` regenerates all of them and rewrites every `version:` stamp to the current package version, which would add ~100 unrelated files here. It looked like those are refreshed on release rather than per-PR, but happy to include them if you'd rather they ship together.
