### PR TITLE
fix: preserve native images in provider router

### DIFF
--- a/docs/AXIR_BACKLOG.md
+++ b/docs/AXIR_BACKLOG.md
@@ -18,7 +18,13 @@ This ledger tracks portable TypeScript behavior that should be migrated into AxI
 
 ## Open
 
-No entries.
+- `axir-2026-08-18-preserve-native-image-content-in-provider-routing` [axai] Preserve native image content in provider routing
+  - Status: open
+  - Source PR: #580
+  - Source commit: `9ef377ef736a22d60164e807dcd51bc72b4e7498`
+  - TS paths: `src/ax/ai/processor.ts`, `src/ax/ai/router.test.ts`, `src/ax/ai/router.ts`
+  - Impact: TypeScript provider routing now keeps image payloads intact when the selected provider supports images, while generated Python, Java, C++, Go, and Rust routers may still replace supported images with text placeholders and lose image bytes, MIME type, ordering, and metadata.
+  - Suggested AxIR work: Add or update the TS-derived conformance fixture.; Update AxIR/Core or descriptor data to match the portable TS behavior.; Run npm run axir:conformance:check and npm run test:axir.
 
 ## Done
 

--- a/ir/axir-backlog.json
+++ b/ir/axir-backlog.json
@@ -1192,6 +1192,29 @@
       "completedAt": "2026-08-16",
       "completedByCommit": "43c98eceafbbefcb6cf9ed99086ced5a52ebb7f0",
       "verification": "Exact MCP/UCP runtime-module paths, dynamic executor authority, and no actor provider-native leakage are covered by the execution-context-ucp fixture across generated Python, Java, C++, Go, and Rust; axir:conformance:check, axir:check-packages, and the full generated-example matrix pass. npm run test:axir compiled the generated packages before unrelated audio HTTP examples hit the sandbox loopback-bind restriction."
+    },
+    {
+      "id": "axir-2026-08-18-preserve-native-image-content-in-provider-routing",
+      "status": "open",
+      "title": "Preserve native image content in provider routing",
+      "createdAt": "2026-08-20",
+      "sourcePR": 580,
+      "sourceCommit": "9ef377ef736a22d60164e807dcd51bc72b4e7498",
+      "tsPaths": [
+        "src/ax/ai/processor.ts",
+        "src/ax/ai/router.test.ts",
+        "src/ax/ai/router.ts"
+      ],
+      "portableSurface": "axai",
+      "impact": "TypeScript provider routing now keeps image payloads intact when the selected provider supports images, while generated Python, Java, C++, Go, and Rust routers may still replace supported images with text placeholders and lose image bytes, MIME type, ordering, and metadata.",
+      "suggestedAxirWork": [
+        "Add or update the TS-derived conformance fixture.",
+        "Update AxIR/Core or descriptor data to match the portable TS behavior.",
+        "Run npm run axir:conformance:check and npm run test:axir."
+      ],
+      "completedAt": null,
+      "completedByCommit": null,
+      "verification": null
     }
   ],
   "nonPortableExemptions": [

--- a/src/ax/ai/processor.ts
+++ b/src/ax/ai/processor.ts
@@ -101,10 +101,12 @@ export async function axProcessContentForProvider(
         case 'image':
           if (features.media.images.supported) {
             // Preserve native image content for providers that support it.
-            processedContent.push(item as Extract<
-              AxFunctionResultContent[number],
-              { type: 'image' }
-            >);
+            processedContent.push(
+              item as Extract<
+                AxFunctionResultContent[number],
+                { type: 'image' }
+              >
+            );
           } else if (item.altText) {
             // Fallback to alt text
             processedContent.push({ type: 'text', text: item.altText });

--- a/src/ax/ai/processor.ts
+++ b/src/ax/ai/processor.ts
@@ -2,7 +2,7 @@ import {
   AxContentProcessingError,
   AxMediaNotSupportedError,
 } from '../util/apicall.js';
-import type { AxAIService } from './types.js';
+import type { AxAIService, AxFunctionResultContent } from './types.js';
 
 /**
  * Configuration options for content processing and fallback behavior
@@ -21,14 +21,12 @@ export interface ProcessingOptions {
 }
 
 /**
- * Represents processed content that has been converted to text format
+ * Represents content after provider-specific processing. Native image content
+ * is retained when the provider advertises image support.
  */
-export interface ProcessedContent {
-  /** Content type after processing (always 'text') */
-  type: 'text';
-  /** The processed text content */
-  text: string;
-}
+export type ProcessedContent =
+  | { type: 'text'; text: string }
+  | Extract<AxFunctionResultContent[number], { type: 'image' }>;
 
 /**
  * Indicates what types of media content are present in a request
@@ -57,7 +55,7 @@ export interface MediaRequirements {
  * @param content - The content to process (string, object, or array of content items)
  * @param provider - The target AI service provider
  * @param options - Processing options including fallback behavior and conversion services
- * @returns Promise resolving to array of processed content items (all converted to text)
+ * @returns Promise resolving to processed text and supported native media items
  * @throws AxMediaNotSupportedError when fallbackBehavior is 'error' and content is unsupported
  * @throws AxContentProcessingError when a conversion service fails
  *
@@ -74,7 +72,7 @@ export interface MediaRequirements {
  *     imageToText: async (data) => await visionService.describe(data)
  *   }
  * );
- * // Result: [{ type: 'text', text: 'Analyze this:' }, { type: 'text', text: 'Chart showing sales data' }]
+ * // Result for a text-only provider: [{ type: 'text', text: 'Analyze this:' }, { type: 'text', text: 'Chart showing sales data' }]
  * ```
  */
 export async function axProcessContentForProvider(
@@ -102,18 +100,11 @@ export async function axProcessContentForProvider(
 
         case 'image':
           if (features.media.images.supported) {
-            // Provider supports images - validate and pass through as text description
-            if (item.altText) {
-              processedContent.push({
-                type: 'text',
-                text: `[Image: ${item.altText}]`,
-              });
-            } else {
-              processedContent.push({
-                type: 'text',
-                text: '[Image content]',
-              });
-            }
+            // Preserve native image content for providers that support it.
+            processedContent.push(item as Extract<
+              AxFunctionResultContent[number],
+              { type: 'image' }
+            >);
           } else if (item.altText) {
             // Fallback to alt text
             processedContent.push({ type: 'text', text: item.altText });

--- a/src/ax/ai/processor.ts
+++ b/src/ax/ai/processor.ts
@@ -2,7 +2,14 @@ import {
   AxContentProcessingError,
   AxMediaNotSupportedError,
 } from '../util/apicall.js';
-import type { AxAIService, AxFunctionResultContent } from './types.js';
+import type { AxAIService, AxChatRequest } from './types.js';
+
+type AxUserMessage = Extract<
+  AxChatRequest['chatPrompt'][number],
+  { role: 'user' }
+>;
+type AxUserContentItem = Exclude<AxUserMessage['content'], string>[number];
+type AxUserImageContent = Extract<AxUserContentItem, { type: 'image' }>;
 
 /**
  * Configuration options for content processing and fallback behavior
@@ -26,7 +33,7 @@ export interface ProcessingOptions {
  */
 export type ProcessedContent =
   | { type: 'text'; text: string }
-  | Extract<AxFunctionResultContent[number], { type: 'image' }>;
+  | AxUserImageContent;
 
 /**
  * Indicates what types of media content are present in a request
@@ -101,12 +108,7 @@ export async function axProcessContentForProvider(
         case 'image':
           if (features.media.images.supported) {
             // Preserve native image content for providers that support it.
-            processedContent.push(
-              item as Extract<
-                AxFunctionResultContent[number],
-                { type: 'image' }
-              >
-            );
+            processedContent.push(item as AxUserImageContent);
           } else if (item.altText) {
             // Fallback to alt text
             processedContent.push({ type: 'text', text: item.altText });

--- a/src/ax/ai/router.test.ts
+++ b/src/ax/ai/router.test.ts
@@ -1,12 +1,12 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { AxProviderRouter } from './router.js';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import {
-  AxMediaNotSupportedError,
   AxContentProcessingError,
+  AxMediaNotSupportedError,
 } from '../util/apicall.js';
+import { AxProviderRouter } from './router.js';
 import type {
-  AxAIService,
   AxAIFeatures,
+  AxAIService,
   AxChatRequest,
   AxChatResponse,
 } from './types.js';
@@ -205,8 +205,9 @@ describe('AxProviderRouter', () => {
       (mockMultiModalProvider.chat as ReturnType<typeof vi.fn>).mockClear();
       await router.chat(request);
 
-      const sentRequest = (mockMultiModalProvider.chat as ReturnType<typeof vi.fn>)
-        .mock.calls[0][0] as AxChatRequest;
+      const sentRequest = (
+        mockMultiModalProvider.chat as ReturnType<typeof vi.fn>
+      ).mock.calls[0][0] as AxChatRequest;
       expect(sentRequest.chatPrompt[0]).toMatchObject({
         role: 'user',
         content: [
@@ -232,8 +233,9 @@ describe('AxProviderRouter', () => {
       (mockMultiModalProvider.chat as ReturnType<typeof vi.fn>).mockClear();
       await router.chat(request);
 
-      const sentRequest = (mockMultiModalProvider.chat as ReturnType<typeof vi.fn>)
-        .mock.calls[0][0] as AxChatRequest;
+      const sentRequest = (
+        mockMultiModalProvider.chat as ReturnType<typeof vi.fn>
+      ).mock.calls[0][0] as AxChatRequest;
       expect(sentRequest.chatPrompt[0]).toMatchObject({
         content: [
           { type: 'image', image: 'first', mimeType: 'image/jpeg' },

--- a/src/ax/ai/router.test.ts
+++ b/src/ax/ai/router.test.ts
@@ -196,7 +196,15 @@ describe('AxProviderRouter', () => {
             role: 'user',
             content: [
               { type: 'text', text: 'What is in this image?' },
-              { type: 'image', image: 'base64data', mimeType: 'image/jpeg' },
+              {
+                type: 'image',
+                image: 'base64data',
+                mimeType: 'image/jpeg',
+                details: 'high',
+                cache: true,
+                optimize: 'quality',
+                altText: 'A detailed chart',
+              },
             ],
           },
         ],
@@ -208,11 +216,19 @@ describe('AxProviderRouter', () => {
       const sentRequest = (
         mockMultiModalProvider.chat as ReturnType<typeof vi.fn>
       ).mock.calls[0][0] as AxChatRequest;
-      expect(sentRequest.chatPrompt[0]).toMatchObject({
+      expect(sentRequest.chatPrompt[0]).toEqual({
         role: 'user',
         content: [
           { type: 'text', text: 'What is in this image?' },
-          { type: 'image', image: 'base64data', mimeType: 'image/jpeg' },
+          {
+            type: 'image',
+            image: 'base64data',
+            mimeType: 'image/jpeg',
+            details: 'high',
+            cache: true,
+            optimize: 'quality',
+            altText: 'A detailed chart',
+          },
         ],
       });
     });

--- a/src/ax/ai/router.test.ts
+++ b/src/ax/ai/router.test.ts
@@ -189,6 +189,59 @@ describe('AxProviderRouter', () => {
       expect(result.routing.processingApplied).toHaveLength(0);
     });
 
+    it('should preserve native image content for an image-capable provider', async () => {
+      const request: AxChatRequest = {
+        chatPrompt: [
+          {
+            role: 'user',
+            content: [
+              { type: 'text', text: 'What is in this image?' },
+              { type: 'image', image: 'base64data', mimeType: 'image/jpeg' },
+            ],
+          },
+        ],
+      };
+
+      (mockMultiModalProvider.chat as ReturnType<typeof vi.fn>).mockClear();
+      await router.chat(request);
+
+      const sentRequest = (mockMultiModalProvider.chat as ReturnType<typeof vi.fn>)
+        .mock.calls[0][0] as AxChatRequest;
+      expect(sentRequest.chatPrompt[0]).toMatchObject({
+        role: 'user',
+        content: [
+          { type: 'text', text: 'What is in this image?' },
+          { type: 'image', image: 'base64data', mimeType: 'image/jpeg' },
+        ],
+      });
+    });
+
+    it('should preserve multiple native images in their original order', async () => {
+      const request: AxChatRequest = {
+        chatPrompt: [
+          {
+            role: 'user',
+            content: [
+              { type: 'image', image: 'first', mimeType: 'image/jpeg' },
+              { type: 'image', image: 'second', mimeType: 'image/png' },
+            ],
+          },
+        ],
+      };
+
+      (mockMultiModalProvider.chat as ReturnType<typeof vi.fn>).mockClear();
+      await router.chat(request);
+
+      const sentRequest = (mockMultiModalProvider.chat as ReturnType<typeof vi.fn>)
+        .mock.calls[0][0] as AxChatRequest;
+      expect(sentRequest.chatPrompt[0]).toMatchObject({
+        content: [
+          { type: 'image', image: 'first', mimeType: 'image/jpeg' },
+          { type: 'image', image: 'second', mimeType: 'image/png' },
+        ],
+      });
+    });
+
     it('should apply content processing when provider lacks capability', async () => {
       // Create router with text-only primary provider
       const textOnlyRouter = new AxProviderRouter({

--- a/src/ax/ai/router.ts
+++ b/src/ax/ai/router.ts
@@ -261,10 +261,11 @@ export class AxProviderRouter {
           // Keep as array format
           processedChatPrompt.push({
             ...message,
-            content: processedContent.map((item) => ({
-              type: 'text' as const,
-              text: item.text,
-            })),
+            content: processedContent.map((item) =>
+              item.type === 'image'
+                ? item
+                : { type: 'text' as const, text: item.text }
+            ),
           });
         }
       } else {


### PR DESCRIPTION
## Summary

- Preserve native image content when the selected provider advertises image support.
- Keep text fallbacks for providers that do not support images.
- Add regression coverage for mixed text plus image content and multiple images.

## Testing

- `vitest run src/ax/ai/router.test.ts src/ax/ai/processor.test.ts --pool=forks --maxWorkers=1 --minWorkers=1`
- `tsc --noEmit --skipLibCheck --target ES2022 --module NodeNext --moduleResolution NodeNext src/ax/ai/processor.ts src/ax/ai/router.ts`

Both checks pass locally.
