### PR TITLE
fix(axir): wrap forced structured-output tool_choice in a function envelope

### DIFF
--- a/ir/axcore/gen.axir
+++ b/ir/axcore/gen.axir
@@ -463,8 +463,11 @@ module @ax.gen version "0.1" {
         core.append %function_specs, %synthetic
         %no_user_functions = core.call intrinsic.eq(%fn_count, 0)
         core.if %no_user_functions {
+          %forced_function_ref = core.map
+          core.set %forced_function_ref["name"] = "__axOutput"
           %forced_function = core.map
-          core.set %forced_function["name"] = "__axOutput"
+          core.set %forced_function["type"] = "function"
+          core.set %forced_function["function"] = %forced_function_ref
           core.set %request["function_call"] = %forced_function
         }
       }

--- a/packages/cpp/axir-provenance.json
+++ b/packages/cpp/axir-provenance.json
@@ -4,8 +4,8 @@
   "emitted_functions": 591,
   "files": {
     "axllm/axllm.cpp": {
-      "emitted_lines": 24418,
-      "total_lines": 30807
+      "emitted_lines": 24421,
+      "total_lines": 30810
     }
   }
 }

--- a/packages/cpp/axllm/axllm.cpp
+++ b/packages/cpp/axllm/axllm.cpp
@@ -11739,8 +11739,11 @@ Value Core::_build_gen_chat_request(Value gen, Value messages, Value options, Va
     Core::append(function_specs, synthetic);
     Value no_user_functions = Core::eq(fn_count, Value(0));
     if (Core::truthy(no_user_functions)) {
+      Value forced_function_ref = Value::object();
+      Core::set(forced_function_ref, Value("name"), Value("__axOutput"));
       Value forced_function = Value::object();
-      Core::set(forced_function, Value("name"), Value("__axOutput"));
+      Core::set(forced_function, Value("type"), Value("function"));
+      Core::set(forced_function, Value("function"), forced_function_ref);
       Core::set(request, Value("function_call"), forced_function);
     }
   }
@@ -11898,6 +11901,21 @@ Value Core::_parse_sample_outputs(Value gen, Value output_fields, Value response
   return bundle;
 }
 
+Value Core::_build_optimization_eval_row(Value task, Value prediction, Value scores, Value scalar, Value trace, Value error) {
+  axir_coverage_mark("_build_optimization_eval_row");
+  Value out = Value::object();
+  Core::set(out, Value("input"), task);
+  Core::set(out, Value("prediction"), prediction);
+  Core::set(out, Value("scores"), scores);
+  Core::set(out, Value("scalar"), scalar);
+  Core::set(out, Value("trace"), trace);
+  Value has_error = Core::is_not_none(error);
+  if (Core::truthy(has_error)) {
+    Core::set(out, Value("error"), error);
+  }
+  return out;
+}
+
 Value Core::_select_sample_index(Value samples, Value options) {
   axir_coverage_mark("_select_sample_index");
   Value picker_snake = Core::get(options, Value("result_picker"), Value());
@@ -11926,21 +11944,6 @@ Value Core::_select_sample_index(Value samples, Value options) {
     throw Core::as_error(error);
   }
   return selected;
-}
-
-Value Core::_build_optimization_eval_row(Value task, Value prediction, Value scores, Value scalar, Value trace, Value error) {
-  axir_coverage_mark("_build_optimization_eval_row");
-  Value out = Value::object();
-  Core::set(out, Value("input"), task);
-  Core::set(out, Value("prediction"), prediction);
-  Core::set(out, Value("scores"), scores);
-  Core::set(out, Value("scalar"), scalar);
-  Core::set(out, Value("trace"), trace);
-  Value has_error = Core::is_not_none(error);
-  if (Core::truthy(has_error)) {
-    Core::set(out, Value("error"), error);
-  }
-  return out;
 }
 
 Value Core::_build_optimization_eval_result(Value rows, Value candidate_map, Value phase) {

--- a/packages/cpp/axllm/axllm.hpp
+++ b/packages/cpp/axllm/axllm.hpp
@@ -494,8 +494,8 @@ struct Core {
   static Value _optimization_action_name_matches(Value expected, Value call);
   static Value _adjust_optimization_score_for_actions(Value score, Value task, Value prediction);
   static Value _parse_sample_outputs(Value gen, Value output_fields, Value response, Value validate_exact_json);
-  static Value _select_sample_index(Value samples, Value options);
   static Value _build_optimization_eval_row(Value task, Value prediction, Value scores, Value scalar, Value trace, Value error);
+  static Value _select_sample_index(Value samples, Value options);
   static Value _build_optimization_eval_result(Value rows, Value candidate_map, Value phase);
   static Value _forward_impl(Value gen, Value client, Value values, Value options);
   static Value _filter_optimization_components(Value components, Value target);

--- a/packages/go/axir-provenance.json
+++ b/packages/go/axir-provenance.json
@@ -4,8 +4,8 @@
   "emitted_functions": 591,
   "files": {
     "axllm.go": {
-      "emitted_lines": 50980,
-      "total_lines": 63011
+      "emitted_lines": 50985,
+      "total_lines": 63016
     }
   }
 }

--- a/packages/go/axllm.go
+++ b/packages/go/axllm.go
@@ -21431,6 +21431,7 @@ func _build_gen_chat_request(args ...Value) (Value, error) {
 	var v_fn Value
 	var v_fn_count Value
 	var v_forced_function Value
+	var v_forced_function_ref Value
 	var v_frequency_penalty Value
 	var v_function_schema Value
 	var v_function_specs Value
@@ -21496,6 +21497,7 @@ func _build_gen_chat_request(args ...Value) (Value, error) {
 	_ = v_fn
 	_ = v_fn_count
 	_ = v_forced_function
+	_ = v_forced_function_ref
 	_ = v_frequency_penalty
 	_ = v_function_schema
 	_ = v_function_specs
@@ -21658,8 +21660,11 @@ func _build_gen_chat_request(args ...Value) (Value, error) {
 		v_function_specs = coreAppend(v_function_specs, v_synthetic)
 		v_no_user_functions = _core_eq(v_fn_count, 0)
 		if coreTruthy(v_no_user_functions) {
+			v_forced_function_ref = Object()
+			if err := coreSet(v_forced_function_ref, "name", "__axOutput"); err != nil { return nil, err }
 			v_forced_function = Object()
-			if err := coreSet(v_forced_function, "name", "__axOutput"); err != nil { return nil, err }
+			if err := coreSet(v_forced_function, "type", "function"); err != nil { return nil, err }
+			if err := coreSet(v_forced_function, "function", v_forced_function_ref); err != nil { return nil, err }
 			if err := coreSet(v_request, "function_call", v_forced_function); err != nil { return nil, err }
 		} else {
 		// empty
@@ -21992,6 +21997,45 @@ func _parse_sample_outputs(args ...Value) (Value, error) {
 	return v_bundle, nil
 }
 
+func _build_optimization_eval_row(args ...Value) (Value, error) {
+	axirCoverageMark("_build_optimization_eval_row")
+	var v_task Value
+	var v_prediction Value
+	var v_scores Value
+	var v_scalar Value
+	var v_trace Value
+	var v_error Value
+	var v_has_error Value
+	var v_out Value
+	if len(args) > 0 { v_task = args[0] }
+	_ = v_task
+	if len(args) > 1 { v_prediction = args[1] }
+	_ = v_prediction
+	if len(args) > 2 { v_scores = args[2] }
+	_ = v_scores
+	if len(args) > 3 { v_scalar = args[3] }
+	_ = v_scalar
+	if len(args) > 4 { v_trace = args[4] }
+	_ = v_trace
+	if len(args) > 5 { v_error = args[5] }
+	_ = v_error
+	_ = v_has_error
+	_ = v_out
+	v_out = Object()
+	if err := coreSet(v_out, "input", v_task); err != nil { return nil, err }
+	if err := coreSet(v_out, "prediction", v_prediction); err != nil { return nil, err }
+	if err := coreSet(v_out, "scores", v_scores); err != nil { return nil, err }
+	if err := coreSet(v_out, "scalar", v_scalar); err != nil { return nil, err }
+	if err := coreSet(v_out, "trace", v_trace); err != nil { return nil, err }
+	v_has_error = _core_is_not_none(v_error)
+	if coreTruthy(v_has_error) {
+		if err := coreSet(v_out, "error", v_error); err != nil { return nil, err }
+	} else {
+	// empty
+	}
+	return v_out, nil
+}
+
 func _select_sample_index(args ...Value) (Value, error) {
 	axirCoverageMark("_select_sample_index")
 	var v_samples Value
@@ -22064,45 +22108,6 @@ func _select_sample_index(args ...Value) (Value, error) {
 	// empty
 	}
 	return v_selected, nil
-}
-
-func _build_optimization_eval_row(args ...Value) (Value, error) {
-	axirCoverageMark("_build_optimization_eval_row")
-	var v_task Value
-	var v_prediction Value
-	var v_scores Value
-	var v_scalar Value
-	var v_trace Value
-	var v_error Value
-	var v_has_error Value
-	var v_out Value
-	if len(args) > 0 { v_task = args[0] }
-	_ = v_task
-	if len(args) > 1 { v_prediction = args[1] }
-	_ = v_prediction
-	if len(args) > 2 { v_scores = args[2] }
-	_ = v_scores
-	if len(args) > 3 { v_scalar = args[3] }
-	_ = v_scalar
-	if len(args) > 4 { v_trace = args[4] }
-	_ = v_trace
-	if len(args) > 5 { v_error = args[5] }
-	_ = v_error
-	_ = v_has_error
-	_ = v_out
-	v_out = Object()
-	if err := coreSet(v_out, "input", v_task); err != nil { return nil, err }
-	if err := coreSet(v_out, "prediction", v_prediction); err != nil { return nil, err }
-	if err := coreSet(v_out, "scores", v_scores); err != nil { return nil, err }
-	if err := coreSet(v_out, "scalar", v_scalar); err != nil { return nil, err }
-	if err := coreSet(v_out, "trace", v_trace); err != nil { return nil, err }
-	v_has_error = _core_is_not_none(v_error)
-	if coreTruthy(v_has_error) {
-		if err := coreSet(v_out, "error", v_error); err != nil { return nil, err }
-	} else {
-	// empty
-	}
-	return v_out, nil
 }
 
 func _build_optimization_eval_result(args ...Value) (Value, error) {

--- a/packages/java/axir-provenance.json
+++ b/packages/java/axir-provenance.json
@@ -4,8 +4,8 @@
   "emitted_functions": 591,
   "files": {
     "dev/axllm/ax/Core.java": {
-      "emitted_lines": 24446,
-      "total_lines": 25743
+      "emitted_lines": 24449,
+      "total_lines": 25746
     }
   }
 }

--- a/packages/java/dev/axllm/ax/Core.java
+++ b/packages/java/dev/axllm/ax/Core.java
@@ -10671,8 +10671,11 @@ final class Core {
       Core.append(function_specs, synthetic);
       Object no_user_functions = Core.eq(fn_count, 0);
       if (Core.truthy(no_user_functions)) {
+        Object forced_function_ref = new java.util.LinkedHashMap<String, Object>();
+        Core.set(forced_function_ref, "name", "__axOutput");
         Object forced_function = new java.util.LinkedHashMap<String, Object>();
-        Core.set(forced_function, "name", "__axOutput");
+        Core.set(forced_function, "type", "function");
+        Core.set(forced_function, "function", forced_function_ref);
         Core.set(request, "function_call", forced_function);
       }
     }
@@ -10830,6 +10833,21 @@ final class Core {
     return bundle;
   }
 
+  static Object _build_optimization_eval_row(Object task, Object prediction, Object scores, Object scalar, Object trace, Object error) {
+    axirCoverageMark("_build_optimization_eval_row");
+    Object out = new java.util.LinkedHashMap<String, Object>();
+    Core.set(out, "input", task);
+    Core.set(out, "prediction", prediction);
+    Core.set(out, "scores", scores);
+    Core.set(out, "scalar", scalar);
+    Core.set(out, "trace", trace);
+    Object has_error = Core.isNotNone(error);
+    if (Core.truthy(has_error)) {
+      Core.set(out, "error", error);
+    }
+    return out;
+  }
+
   static Object _select_sample_index(Object samples, Object options) {
     axirCoverageMark("_select_sample_index");
     Object picker_snake = Core.get(options, "result_picker", null);
@@ -10858,21 +10876,6 @@ final class Core {
       throw Core.asRuntime(error);
     }
     return selected;
-  }
-
-  static Object _build_optimization_eval_row(Object task, Object prediction, Object scores, Object scalar, Object trace, Object error) {
-    axirCoverageMark("_build_optimization_eval_row");
-    Object out = new java.util.LinkedHashMap<String, Object>();
-    Core.set(out, "input", task);
-    Core.set(out, "prediction", prediction);
-    Core.set(out, "scores", scores);
-    Core.set(out, "scalar", scalar);
-    Core.set(out, "trace", trace);
-    Object has_error = Core.isNotNone(error);
-    if (Core.truthy(has_error)) {
-      Core.set(out, "error", error);
-    }
-    return out;
   }
 
   static Object _build_optimization_eval_result(Object rows, Object candidate_map, Object phase) {

--- a/packages/python/axir-provenance.json
+++ b/packages/python/axir-provenance.json
@@ -16,8 +16,8 @@
       "total_lines": 2808
     },
     "axllm/gen.py": {
-      "emitted_lines": 3018,
-      "total_lines": 4033
+      "emitted_lines": 3021,
+      "total_lines": 4036
     },
     "axllm/mcp.py": {
       "emitted_lines": 2192,

--- a/packages/python/axllm/gen.py
+++ b/packages/python/axllm/gen.py
@@ -1936,8 +1936,11 @@ def _build_gen_chat_request(gen: AxGen, messages: list[Any], options: Any, selec
         function_specs.append(synthetic)
         no_user_functions = _core_eq(fn_count, 0)
         if no_user_functions:
+            forced_function_ref = {}
+            forced_function_ref["name"] = "__axOutput"
             forced_function = {}
-            forced_function["name"] = "__axOutput"
+            forced_function["type"] = "function"
+            forced_function["function"] = forced_function_ref
             request["function_call"] = forced_function
         else:
             pass
@@ -2102,6 +2105,22 @@ def _parse_sample_outputs(gen: AxGen, output_fields: list[Any], response: Any, v
     return bundle
 
 
+def _build_optimization_eval_row(task: Any, prediction: Any, scores: Any, scalar: Any, trace: Any, error: Any) -> Any:
+    _core_coverage_mark("_build_optimization_eval_row")
+    out = {}
+    out["input"] = task
+    out["prediction"] = prediction
+    out["scores"] = scores
+    out["scalar"] = scalar
+    out["trace"] = trace
+    has_error = _core_is_not_none(error)
+    if has_error:
+        out["error"] = error
+    else:
+        pass
+    return out
+
+
 def _select_sample_index(samples: list[Any], options: Any) -> number:
     _core_coverage_mark("_select_sample_index")
     picker_snake = _core_get(options, "result_picker", None)
@@ -2132,22 +2151,6 @@ def _select_sample_index(samples: list[Any], options: Any) -> number:
     else:
         pass
     return selected
-
-
-def _build_optimization_eval_row(task: Any, prediction: Any, scores: Any, scalar: Any, trace: Any, error: Any) -> Any:
-    _core_coverage_mark("_build_optimization_eval_row")
-    out = {}
-    out["input"] = task
-    out["prediction"] = prediction
-    out["scores"] = scores
-    out["scalar"] = scalar
-    out["trace"] = trace
-    has_error = _core_is_not_none(error)
-    if has_error:
-        out["error"] = error
-    else:
-        pass
-    return out
 
 
 def _build_optimization_eval_result(rows: Any, candidate_map: Any, phase: str) -> Any:

--- a/packages/rust/axir-provenance.json
+++ b/packages/rust/axir-provenance.json
@@ -4,8 +4,8 @@
   "emitted_functions": 591,
   "files": {
     "src/lib.rs": {
-      "emitted_lines": 56316,
-      "total_lines": 79346
+      "emitted_lines": 56328,
+      "total_lines": 79358
     }
   }
 }

--- a/packages/rust/src/lib.rs
+++ b/packages/rust/src/lib.rs
@@ -44336,6 +44336,7 @@ fn _build_gen_chat_request(args: &[CoreValue]) -> Result<CoreValue, AxError> {
     let mut v_fn = CoreValue::Null;
     let mut v_fn_count = CoreValue::Null;
     let mut v_forced_function = CoreValue::Null;
+    let mut v_forced_function_ref = CoreValue::Null;
     let mut v_frequency_penalty = CoreValue::Null;
     let mut v_function_schema = CoreValue::Null;
     let mut v_function_specs = CoreValue::Null;
@@ -44605,11 +44606,22 @@ fn _build_gen_chat_request(args: &[CoreValue]) -> Result<CoreValue, AxError> {
         core_append(&v_function_specs, v_synthetic.clone())?;
         v_no_user_functions = core_eq(&[v_fn_count.clone(), CoreValue::Num(0f64)])?;
         if core_truthy(&v_no_user_functions) {
+            v_forced_function_ref = CoreValue::new_map();
+            core_set(
+                &v_forced_function_ref,
+                CoreValue::from("name"),
+                CoreValue::from("__axOutput"),
+            )?;
             v_forced_function = CoreValue::new_map();
             core_set(
                 &v_forced_function,
-                CoreValue::from("name"),
-                CoreValue::from("__axOutput"),
+                CoreValue::from("type"),
+                CoreValue::from("function"),
+            )?;
+            core_set(
+                &v_forced_function,
+                CoreValue::from("function"),
+                v_forced_function_ref.clone(),
             )?;
             core_set(
                 &v_request,
@@ -44984,6 +44996,36 @@ fn _parse_sample_outputs(args: &[CoreValue]) -> Result<CoreValue, AxError> {
     unreachable_code,
     clippy::all
 )]
+fn _build_optimization_eval_row(args: &[CoreValue]) -> Result<CoreValue, AxError> {
+    axir_coverage_mark("_build_optimization_eval_row");
+    let mut v_task = core_arg(args, 0);
+    let mut v_prediction = core_arg(args, 1);
+    let mut v_scores = core_arg(args, 2);
+    let mut v_scalar = core_arg(args, 3);
+    let mut v_trace = core_arg(args, 4);
+    let mut v_error = core_arg(args, 5);
+    let mut v_has_error = CoreValue::Null;
+    let mut v_out = CoreValue::Null;
+    v_out = CoreValue::new_map();
+    core_set(&v_out, CoreValue::from("input"), v_task.clone())?;
+    core_set(&v_out, CoreValue::from("prediction"), v_prediction.clone())?;
+    core_set(&v_out, CoreValue::from("scores"), v_scores.clone())?;
+    core_set(&v_out, CoreValue::from("scalar"), v_scalar.clone())?;
+    core_set(&v_out, CoreValue::from("trace"), v_trace.clone())?;
+    v_has_error = core_is_not_none(&[v_error.clone()])?;
+    if core_truthy(&v_has_error) {
+        core_set(&v_out, CoreValue::from("error"), v_error.clone())?;
+    }
+    return Ok(v_out.clone());
+}
+
+#[allow(
+    unused_variables,
+    unused_assignments,
+    unused_mut,
+    unreachable_code,
+    clippy::all
+)]
 fn _select_sample_index(args: &[CoreValue]) -> Result<CoreValue, AxError> {
     axir_coverage_mark("_select_sample_index");
     let mut v_samples = core_arg(args, 0);
@@ -45048,36 +45090,6 @@ fn _select_sample_index(args: &[CoreValue]) -> Result<CoreValue, AxError> {
         return Err(core_as_error(&v_error));
     }
     return Ok(v_selected.clone());
-}
-
-#[allow(
-    unused_variables,
-    unused_assignments,
-    unused_mut,
-    unreachable_code,
-    clippy::all
-)]
-fn _build_optimization_eval_row(args: &[CoreValue]) -> Result<CoreValue, AxError> {
-    axir_coverage_mark("_build_optimization_eval_row");
-    let mut v_task = core_arg(args, 0);
-    let mut v_prediction = core_arg(args, 1);
-    let mut v_scores = core_arg(args, 2);
-    let mut v_scalar = core_arg(args, 3);
-    let mut v_trace = core_arg(args, 4);
-    let mut v_error = core_arg(args, 5);
-    let mut v_has_error = CoreValue::Null;
-    let mut v_out = CoreValue::Null;
-    v_out = CoreValue::new_map();
-    core_set(&v_out, CoreValue::from("input"), v_task.clone())?;
-    core_set(&v_out, CoreValue::from("prediction"), v_prediction.clone())?;
-    core_set(&v_out, CoreValue::from("scores"), v_scores.clone())?;
-    core_set(&v_out, CoreValue::from("scalar"), v_scalar.clone())?;
-    core_set(&v_out, CoreValue::from("trace"), v_trace.clone())?;
-    v_has_error = core_is_not_none(&[v_error.clone()])?;
-    if core_truthy(&v_has_error) {
-        core_set(&v_out, CoreValue::from("error"), v_error.clone())?;
-    }
-    return Ok(v_out.clone());
 }
 
 #[allow(


### PR DESCRIPTION
## The defect

When the function rung forces the synthetic output tool, `ir/axcore/gen.axir`
built the choice as a bare `{name: "__axOutput"}`:

```
%forced_function = core.map
core.set %forced_function["name"] = "__axOutput"
core.set %request["function_call"] = %forced_function
```

The openai-chat transport passes `function_call` straight through to the wire
field `tool_choice`, which accepts only `none`, `auto`, `required`, or
`{type: "function", function: {name}}`. Servers that validate the body reject
the request **before any inference happens**:

| provider | response |
| --- | --- |
| Together | `Invalid JSON data: Failed to deserialize the JSON body into the target type: tool_choice: data did not match any variant of untagged enum ToolChoice` |
| DeepSeek | `tool_choice: expected one of 'none', 'auto', 'required' or a tool` |

The TypeScript library is **not** affected — `src/ax/dsp/generate.ts` already
builds the correct envelope, and `AxChatRequest['functionCall']` declares
exactly that shape. Only the generated bindings diverged, so this change brings
the IR back in line with both.

## Blast radius

Every openai-chat profile whose structured output resolves to the function rung
— 32 of them:

`together`, `deepseek`, `openrouter`, `openai-compatible`, `vertex-ai`,
`amazon-bedrock`, `azure-foundry`, `cohere`, `databricks`, `deepinfra`,
`huggingface-router`, `nebius`, `novita`, `nscale`, `nvidia-nim`, `sambanova`,
`siliconflow`, `scaleway`, `ovhcloud`, `reka`, `friendli`, `featherless`,
`hyperbolic`, `baseten-engine`, `cloudflare-workers-ai`, `runpod-vllm`,
`sagemaker-vllm`, plus the local runtimes `ollama`, `vllm`, `lm-studio`,
`localai`, `llama-cpp`.

Profiles that reach `native` or `json_object` never build a forced choice, which
is why `openai` and `google-gemini` looked healthy.

There is a second-order effect: the malformed shape also defeats the
unforced-profile check in `provider_profiles`, which looks for
`tool_choice.function.name == "__axOutput"` to recognize an Ax-generated choice.
With the bare shape it sees a caller-forced choice and raises
`deployment profile does not support explicitly forced tool choices` instead.

This is the same class of defect as #518, reintroduced under the `__axOutput`
name by the portable structured output work in v24.0.0.

## Reproduce

```bash
curl -s https://api.together.xyz/v1/chat/completions \
  -H "Authorization: Bearer $TOGETHER_API_KEY" -H 'Content-Type: application/json' \
  -d '{"model":"meta-models/Muse-Glimmer-30B",
       "messages":[{"role":"user","content":"hi"}],
       "tools":[{"type":"function","function":{"name":"__axOutput","description":"e",
                 "parameters":{"type":"object","properties":{"a":{"type":"string"}},"required":["a"]}}}],
       "tool_choice":{"name":"__axOutput"}}'
```

Swapping `tool_choice` to `{"type":"function","function":{"name":"__axOutput"}}`
returns 200 with a clean tool call.

## Verification

- Live end to end through a Go consumer against **Together**
  (`meta-models/Muse-Glimmer-30B`) and **DeepSeek**: every request was rejected
  with 0 LLM calls before this change, and both complete normally after it.
- `npm run axir:check-packages` — committed packages up to date.
- `npm run axir:conformance:check` — fixtures and provider catalog in sync.
- `npm run test:axir` — full release verify across python, java, cpp, go, rust.
- Regeneration is byte-for-byte deterministic across repeated runs; the only
  semantic change in the emitted bindings is the three-line envelope. Two
  adjacent emitted functions swap position, which is inert.

## Separate issue, not fixed here

The `deepseek` profile declares `structuredOutputModes: ["function"]`, but the
DeepSeek API accepts `response_format: {"type":"json_object"}` (verified: it
returns `{"n":3}` on request). Understating the capability forces DeepSeek onto
the weaker function-calling path. `together` looks similar. Worth a follow-up
against the profile capability data rather than folding into this fix.
