### PR TITLE
ci: allow policy PR comments

### DIFF
--- a/.github/workflows/external-contribution-policy.yml
+++ b/.github/workflows/external-contribution-policy.yml
@@ -13,8 +13,7 @@ on:
 
 permissions:
   contents: read
-  issues: write
-  pull-requests: read
+  pull-requests: write
   statuses: write
 
 concurrency:

--- a/scripts/external-contribution-policy.mjs
+++ b/scripts/external-contribution-policy.mjs
@@ -558,6 +558,9 @@ export async function runExternalContributionPolicy({
     login: pull.user?.login,
     type: pull.user?.type,
   });
+  core.info(
+    `PR #${number} author metadata: login=${pull.user?.login ?? 'unknown'}, type=${pull.user?.type ?? 'unknown'}, association=${pull.author_association ?? 'unknown'}, trusted=${trusted}.`
+  );
   const headSha = pull.head.sha;
   const targetUrl = actionsRunUrl(owner, repo);
   await publishStatus({


### PR DESCRIPTION
The rollout backfill proved that Issues: write is rejected with HTTP 403 when github-actions attempts to create a pull-request comment. Replace it with Pull requests: write, retaining least privilege and leaving the policy evaluator unchanged. Local policy tests (69/69), formatting, and diff checks pass.