### PR TITLE
ci: trust signed PR author metadata

### DIFF
--- a/scripts/external-contribution-policy.mjs
+++ b/scripts/external-contribution-policy.mjs
@@ -94,6 +94,32 @@ export function isTrustedAuthor({ association, login, type } = {}) {
   return isTrustedAssociation(association);
 }
 
+function pullRequestAuthorMetadata({ context, pull, prNumber }) {
+  const eventPull =
+    context.eventName === 'pull_request_target'
+      ? context.payload.pull_request
+      : undefined;
+  const eventNumber = Number(context.payload.number ?? eventPull?.number);
+  if (
+    eventPull &&
+    eventNumber === prNumber &&
+    eventPull.head?.sha === pull.head.sha
+  ) {
+    return {
+      association: eventPull.author_association,
+      login: eventPull.user?.login,
+      type: eventPull.user?.type,
+      source: 'signed pull_request_target event',
+    };
+  }
+  return {
+    association: pull.author_association,
+    login: pull.user?.login,
+    type: pull.user?.type,
+    source: 'pull request API',
+  };
+}
+
 export function classifyExternalPath(filePath) {
   const normalized = normalizePath(filePath);
   if (!isSafeRepositoryPath(normalized)) {
@@ -553,13 +579,10 @@ export async function runExternalContributionPolicy({
   const pull = (
     await github.rest.pulls.get({ owner, repo, pull_number: number })
   ).data;
-  const trusted = isTrustedAuthor({
-    association: pull.author_association,
-    login: pull.user?.login,
-    type: pull.user?.type,
-  });
+  const author = pullRequestAuthorMetadata({ context, pull, prNumber: number });
+  const trusted = isTrustedAuthor(author);
   core.info(
-    `PR #${number} author metadata: login=${pull.user?.login ?? 'unknown'}, type=${pull.user?.type ?? 'unknown'}, association=${pull.author_association ?? 'unknown'}, trusted=${trusted}.`
+    `PR #${number} author metadata (${author.source}): login=${author.login ?? 'unknown'}, type=${author.type ?? 'unknown'}, association=${author.association ?? 'unknown'}, trusted=${trusted}.`
   );
   const headSha = pull.head.sha;
   const targetUrl = actionsRunUrl(owner, repo);
@@ -638,9 +661,9 @@ export async function runExternalContributionPolicy({
     }
 
     const result = evaluateExternalContribution({
-      association: pull.author_association,
-      authorLogin: pull.user?.login,
-      authorType: pull.user?.type,
+      association: author.association,
+      authorLogin: author.login,
+      authorType: author.type,
       files,
       changedFilesCount: pull.changed_files,
       prNumber: number,

--- a/scripts/external-contribution-policy.test.js
+++ b/scripts/external-contribution-policy.test.js
@@ -418,6 +418,58 @@ describe('policy comments and runner', () => {
     ]);
   });
 
+  it('uses matching signed event metadata when the API hides membership', async () => {
+    const pull = pullFixture({
+      author_association: 'COLLABORATOR',
+      changed_files: 99,
+    });
+    const mocks = githubMock({ pull, files: [], comments: [] });
+    const context = contextFixture();
+    context.eventName = 'pull_request_target';
+    context.payload.number = 700;
+    context.payload.pull_request = {
+      number: 700,
+      author_association: 'MEMBER',
+      user: { login: 'member', type: 'User' },
+      head: { sha: 'head-sha' },
+    };
+    const result = await runExternalContributionPolicy({
+      github: mocks.github,
+      context,
+      core: { info: vi.fn() },
+      prNumber: 700,
+    });
+    expect(result).toEqual(
+      expect.objectContaining({ ok: true, trusted: true })
+    );
+    expect(mocks.paginate).toHaveBeenCalledOnce();
+  });
+
+  it('ignores signed event metadata for a different head commit', async () => {
+    const pull = pullFixture({ author_association: 'COLLABORATOR' });
+    const mocks = githubMock({
+      pull,
+      files: [file('packages/go/axllm.go')],
+      comments: [],
+    });
+    const context = contextFixture();
+    context.eventName = 'pull_request_target';
+    context.payload.number = 700;
+    context.payload.pull_request = {
+      number: 700,
+      author_association: 'MEMBER',
+      user: { login: 'member', type: 'User' },
+      head: { sha: 'different-head' },
+    };
+    const result = await runExternalContributionPolicy({
+      github: mocks.github,
+      context,
+      core: { info: vi.fn() },
+      prNumber: 700,
+    });
+    expect(result).toEqual(expect.objectContaining({ ok: false }));
+  });
+
   it('treats a bot with a member association as external', async () => {
     const pull = pullFixture({
       author_association: 'MEMBER',


### PR DESCRIPTION
GitHub Actions installation tokens can see private organization members as COLLABORATOR during REST lookups. On pull_request_target, use the signed event author metadata only when both PR number and latest head SHA match the live PR; manual dispatch continues using the API and therefore fails closed. Adds matching and mismatched-head tests; focused policy suite is 71/71 and formatting passes.