### PR TITLE
ci: migrate npm publishing to OIDC

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,10 +1,11 @@
-# This workflow will run tests using node and then publish a package to GitHub Packages when a release is created
+# Build and publish the npm workspaces on a release or manual dispatch.
 # For more information see: https://docs.github.com/en/actions/publishing-packages/publishing-nodejs-packages
 
 name: Publish Package to npmjs
 on:
   release:
     types: [published]
+  workflow_dispatch:
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -13,12 +14,8 @@ jobs:
       id-token: write
     steps:
       - uses: actions/checkout@v4
-      # Setup .npmrc file to publish to npm
       - uses: actions/setup-node@v6
         with:
-          node-version: '22.x'
-          registry-url: 'https://registry.npmjs.org'
+          node-version: '24'
       - run: npm ci
-      - run: npm run publish
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - run: npm run publish --workspaces --if-present -- --provenance --access public

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -153,11 +153,11 @@ optimizer artifacts, and GEPA.
 
 ## Publishing Shape
 
-Publishing is secret-gated per ecosystem and runs from GitHub Actions after a
-GitHub Release is published:
+Publishing runs from GitHub Actions after a GitHub Release is published, with
+manual dispatch available for retries and verification:
 
-- `.github/workflows/npm-publish.yml` runs `npm run publish` for the npm
-  workspaces with `NODE_AUTH_TOKEN`.
+- `.github/workflows/npm-publish.yml` publishes the npm workspaces through npm
+  trusted publishing with GitHub Actions OIDC and signed provenance.
 - `.github/workflows/package-publish.yml` separately publishes generated
   packages from the same release event.
 - Current generated-package publishing covers Python/PyPI and Rust/crates.io.


### PR DESCRIPTION
## Summary

- move npm publishing from `NPM_TOKEN` to GitHub Actions OIDC trusted publishing
- use Node 24, preserve provenance and public workspace publishing, and add manual dispatch
- update the release documentation to describe the trusted-publishing path

## Verification

- workflow YAML parses successfully
- `git diff --check` passes
- confirmed exactly four public publishable workspaces and no `publishConfig.registry` override
- confirmed the workflow contains no `NPM_TOKEN`, `NODE_AUTH_TOKEN`, or `registry-url`