### PR TITLE
ci: trust dosco contribution policy identity

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -2,9 +2,10 @@
 
 ## External pull requests
 
-Pull requests authored by anyone other than a GitHub organization `OWNER` or
-`MEMBER` are limited to handwritten TypeScript. Allowed file extensions are
-`.ts`, `.tsx`, `.mts`, and `.cts`.
+Pull requests authored by anyone other than a GitHub organization `OWNER`,
+`MEMBER`, or explicitly allowlisted maintainer identity are limited to
+handwritten TypeScript. Allowed file extensions are `.ts`, `.tsx`, `.mts`, and
+`.cts`.
 
 Do not run AxIR generation or commit changes to AxIR, generated TypeScript,
 Python, Java, C++, Go, Rust, generated examples, generated website files,

--- a/scripts/external-contribution-policy.mjs
+++ b/scripts/external-contribution-policy.mjs
@@ -14,6 +14,9 @@ export const MAX_PR_FILES = 3000;
 export const MAX_LEDGER_BYTES = 1024 * 1024;
 
 const trustedAssociations = new Set(['OWNER', 'MEMBER']);
+const trustedUserIds = new Set([
+  832235, // dosco
+]);
 const typescriptExtensions = ['.ts', '.tsx', '.mts', '.cts'];
 const generatedLanguageRoots = [
   'packages/python/',
@@ -88,10 +91,10 @@ export function isTrustedAssociation(association) {
   return trustedAssociations.has(String(association));
 }
 
-export function isTrustedAuthor({ association, login, type } = {}) {
+export function isTrustedAuthor({ association, id, login, type } = {}) {
   const normalizedLogin = String(login ?? '').toLowerCase();
   if (type === 'Bot' || normalizedLogin.endsWith('[bot]')) return false;
-  return isTrustedAssociation(association);
+  return isTrustedAssociation(association) || trustedUserIds.has(Number(id));
 }
 
 function pullRequestAuthorMetadata({ context, pull, prNumber }) {
@@ -107,6 +110,7 @@ function pullRequestAuthorMetadata({ context, pull, prNumber }) {
   ) {
     return {
       association: eventPull.author_association,
+      id: eventPull.user?.id,
       login: eventPull.user?.login,
       type: eventPull.user?.type,
       source: 'signed pull_request_target event',
@@ -114,6 +118,7 @@ function pullRequestAuthorMetadata({ context, pull, prNumber }) {
   }
   return {
     association: pull.author_association,
+    id: pull.user?.id,
     login: pull.user?.login,
     type: pull.user?.type,
     source: 'pull request API',
@@ -376,6 +381,7 @@ export function evaluateBacklogDelta({
 
 export function evaluateExternalContribution({
   association,
+  authorId,
   authorLogin,
   authorType,
   files = [],
@@ -387,6 +393,7 @@ export function evaluateExternalContribution({
   if (
     isTrustedAuthor({
       association,
+      id: authorId,
       login: authorLogin,
       type: authorType,
     })
@@ -582,7 +589,7 @@ export async function runExternalContributionPolicy({
   const author = pullRequestAuthorMetadata({ context, pull, prNumber: number });
   const trusted = isTrustedAuthor(author);
   core.info(
-    `PR #${number} author metadata (${author.source}): login=${author.login ?? 'unknown'}, type=${author.type ?? 'unknown'}, association=${author.association ?? 'unknown'}, trusted=${trusted}.`
+    `PR #${number} author metadata (${author.source}): login=${author.login ?? 'unknown'}, id=${author.id ?? 'unknown'}, type=${author.type ?? 'unknown'}, association=${author.association ?? 'unknown'}, trusted=${trusted}.`
   );
   const headSha = pull.head.sha;
   const targetUrl = actionsRunUrl(owner, repo);
@@ -662,6 +669,7 @@ export async function runExternalContributionPolicy({
 
     const result = evaluateExternalContribution({
       association: author.association,
+      authorId: author.id,
       authorLogin: author.login,
       authorType: author.type,
       files,
@@ -678,7 +686,7 @@ export async function runExternalContributionPolicy({
       state: result.ok ? 'success' : 'failure',
       description: result.ok
         ? result.trusted
-          ? 'Trusted organization member'
+          ? 'Trusted maintainer identity'
           : 'External contribution policy passed'
         : `${result.violations.length} policy violation${result.violations.length === 1 ? '' : 's'}`,
       targetUrl,

--- a/scripts/external-contribution-policy.test.js
+++ b/scripts/external-contribution-policy.test.js
@@ -61,6 +61,28 @@ describe('external contribution trust boundary', () => {
     expect(isTrustedAssociation(association)).toBe(false);
   });
 
+  it('trusts dosco by immutable GitHub user ID', () => {
+    expect(
+      isTrustedAuthor({
+        association: 'COLLABORATOR',
+        id: 832235,
+        login: 'dosco',
+        type: 'User',
+      })
+    ).toBe(true);
+  });
+
+  it('does not trust the dosco login without its allowlisted user ID', () => {
+    expect(
+      isTrustedAuthor({
+        association: 'COLLABORATOR',
+        id: 123456,
+        login: 'dosco',
+        type: 'User',
+      })
+    ).toBe(false);
+  });
+
   it('does not trust Dependabot or other bots by name', () => {
     expect(
       isTrustedAuthor({
@@ -73,6 +95,14 @@ describe('external contribution trust boundary', () => {
       isTrustedAuthor({
         association: 'OWNER',
         login: 'renovate[bot]',
+        type: 'Bot',
+      })
+    ).toBe(false);
+    expect(
+      isTrustedAuthor({
+        association: 'COLLABORATOR',
+        id: 832235,
+        login: 'dosco[bot]',
         type: 'Bot',
       })
     ).toBe(false);
@@ -418,6 +448,29 @@ describe('policy comments and runner', () => {
     ]);
   });
 
+  it('trusts an allowlisted maintainer without reading contributor files', async () => {
+    const pull = pullFixture({
+      author_association: 'COLLABORATOR',
+      user: { id: 832235, login: 'dosco', type: 'User' },
+      changed_files: 99,
+    });
+    const mocks = githubMock({ pull, files: [], comments: [] });
+    const result = await runExternalContributionPolicy({
+      github: mocks.github,
+      context: contextFixture(),
+      core: { info: vi.fn() },
+      prNumber: 700,
+    });
+    expect(result).toEqual(
+      expect.objectContaining({ ok: true, trusted: true })
+    );
+    expect(mocks.paginate).toHaveBeenCalledOnce();
+    expect(mocks.statusCalls.map((call) => call.state)).toEqual([
+      'pending',
+      'success',
+    ]);
+  });
+
   it('uses matching signed event metadata when the API hides membership', async () => {
     const pull = pullFixture({
       author_association: 'COLLABORATOR',
@@ -431,6 +484,33 @@ describe('policy comments and runner', () => {
       number: 700,
       author_association: 'MEMBER',
       user: { login: 'member', type: 'User' },
+      head: { sha: 'head-sha' },
+    };
+    const result = await runExternalContributionPolicy({
+      github: mocks.github,
+      context,
+      core: { info: vi.fn() },
+      prNumber: 700,
+    });
+    expect(result).toEqual(
+      expect.objectContaining({ ok: true, trusted: true })
+    );
+    expect(mocks.paginate).toHaveBeenCalledOnce();
+  });
+
+  it('uses an allowlisted user ID from matching signed event metadata', async () => {
+    const pull = pullFixture({
+      author_association: 'COLLABORATOR',
+      changed_files: 99,
+    });
+    const mocks = githubMock({ pull, files: [], comments: [] });
+    const context = contextFixture();
+    context.eventName = 'pull_request_target';
+    context.payload.number = 700;
+    context.payload.pull_request = {
+      number: 700,
+      author_association: 'COLLABORATOR',
+      user: { id: 832235, login: 'dosco', type: 'User' },
       head: { sha: 'head-sha' },
     };
     const result = await runExternalContributionPolicy({


### PR DESCRIPTION
## Summary

- trust the maintainer behind `dosco` by immutable GitHub user ID `832235`
- preserve fail-closed bot rejection and organization `OWNER`/`MEMBER` trust
- carry the user ID through signed `pull_request_target` metadata and API fallback paths
- document explicitly allowlisted maintainer identities

## Verification

- `npm run test:contribution-policy` — 75 tests passed
- `npm run test:format` — 716 files checked
- `npm run test:lint` — passed with three unrelated existing website warnings
- `git diff --check`

## Bootstrap note

The policy currently running from `main` classifies `dosco` as `COLLABORATOR`, so this PR is expected to require the existing organization-admin PR bypass once. After this commit reaches `main`, future PRs from GitHub user ID `832235` will be trusted regardless of association visibility.