### PR TITLE
fix(ci): honor AxIR non-portable exemptions

### DIFF
--- a/scripts/axir-backlog.mjs
+++ b/scripts/axir-backlog.mjs
@@ -866,7 +866,7 @@ function fileContentFor(readFile, changedPath) {
   }
 }
 
-function coveredByNonPortableExemption(
+export function coveredByNonPortableExemption(
   changedPath,
   exemptions,
   { changedLineRanges, readFile } = {}

--- a/scripts/external-contribution-policy.mjs
+++ b/scripts/external-contribution-policy.mjs
@@ -1,6 +1,7 @@
 import { isDeepStrictEqual } from 'node:util';
 
 import {
+  coveredByNonPortableExemption,
   isPortableTsPath,
   portableSurfaceForPath,
   validateLedger,
@@ -226,6 +227,65 @@ export function evaluateChangedFiles({ files, changedFilesCount }) {
   };
 }
 
+function changedLineRangesFromFiles(files) {
+  const ranges = {};
+  for (const file of files.filter(hasCompletePatch)) {
+    const fileRanges = [];
+    let newLine = null;
+    for (const line of file.patch.split(/\r?\n/)) {
+      if (line.startsWith('@@')) {
+        const match = /\+(\d+)(?:,(\d+))?/.exec(line);
+        newLine = match ? Number(match[1]) : null;
+        continue;
+      }
+      if (newLine === null || line.startsWith('\\')) continue;
+      if (line.startsWith('+')) {
+        const previous = fileRanges.at(-1);
+        if (previous?.end === newLine - 1) previous.end = newLine;
+        else fileRanges.push({ start: newLine, end: newLine });
+        newLine++;
+      } else if (!line.startsWith('-')) {
+        newLine++;
+      }
+    }
+    if (fileRanges.length > 0) {
+      ranges[normalizePath(file.filename)] = fileRanges;
+    }
+  }
+  return ranges;
+}
+
+function hasCompletePatch(file) {
+  if (
+    typeof file?.filename !== 'string' ||
+    typeof file?.patch !== 'string' ||
+    !Number.isInteger(file.additions) ||
+    !Number.isInteger(file.deletions)
+  ) {
+    return false;
+  }
+  let additions = 0;
+  let deletions = 0;
+  for (const line of file.patch.split(/\r?\n/)) {
+    if (line.startsWith('+')) additions++;
+    else if (line.startsWith('-')) deletions++;
+  }
+  return additions === file.additions && deletions === file.deletions;
+}
+
+function scopedExemptionPaths(portablePaths, exemptions) {
+  const portablePathSet = new Set(portablePaths.map(normalizePath));
+  return [
+    ...new Set(
+      exemptions.flatMap((exemption) =>
+        exemption.scopedFiles
+          .map(normalizePath)
+          .filter((filePath) => portablePathSet.has(filePath))
+      )
+    ),
+  ].sort();
+}
+
 export function parseLedgerText(content, label = 'ledger') {
   if (typeof content !== 'string') {
     return { ok: false, error: `${label} content is not text.` };
@@ -389,6 +449,8 @@ export function evaluateExternalContribution({
   prNumber,
   baseLedger,
   headLedger,
+  changedLineRanges,
+  readFile,
 }) {
   if (
     isTrustedAuthor({
@@ -410,6 +472,17 @@ export function evaluateExternalContribution({
   const violations = [...fileResult.violations];
   const backlogPairChanged =
     fileResult.backlogChanged && fileResult.backlogDocChanged;
+  const baseExemptions = baseLedger?.nonPortableExemptions ?? [];
+  const exemptPortablePaths = fileResult.portablePaths.filter((filePath) =>
+    coveredByNonPortableExemption(filePath, baseExemptions, {
+      changedLineRanges,
+      readFile,
+    })
+  );
+  const exemptPortablePathSet = new Set(exemptPortablePaths);
+  const uncoveredPortablePaths = fileResult.portablePaths.filter(
+    (filePath) => !exemptPortablePathSet.has(filePath)
+  );
 
   if (fileResult.backlogChanged !== fileResult.backlogDocChanged) {
     violations.push({
@@ -417,7 +490,7 @@ export function evaluateExternalContribution({
       message: `${BACKLOG_PATH} and ${BACKLOG_DOC_PATH} must change together.`,
     });
   }
-  if (fileResult.portablePaths.length > 0 && !backlogPairChanged) {
+  if (uncoveredPortablePaths.length > 0 && !backlogPairChanged) {
     violations.push({
       code: 'missing-backlog-pair',
       message:
@@ -437,7 +510,7 @@ export function evaluateExternalContribution({
           baseLedger,
           headLedger,
           prNumber,
-          portablePaths: fileResult.portablePaths,
+          portablePaths: uncoveredPortablePaths,
         })
       );
     }
@@ -448,6 +521,7 @@ export function evaluateExternalContribution({
     trusted: false,
     violations,
     portablePaths: fileResult.portablePaths,
+    exemptPortablePaths,
   };
 }
 
@@ -479,7 +553,7 @@ export function buildPolicyComment({ result, prNumber }) {
 
 ## External contribution policy
 
-This PR is blocked because outside contributors may submit only handwritten TypeScript plus a new PR-bound AxIR backlog entry.
+This PR is blocked because outside contributors may submit only handwritten TypeScript. Portable TypeScript must be covered by a base-owned non-portable exemption or a new PR-bound AxIR backlog entry.
 
 ${lines.join('\n')}
 
@@ -488,6 +562,8 @@ For portable TypeScript changes, add exact changed files with:
 \`\`\`bash
 npm run axir:backlog -- add --title "Describe the portable behavior" --surface <surface> --impact "Describe generated-language drift" --paths <exact-ts-files> --pr ${prNumber}
 \`\`\`
+
+Do not add backlog files for paths already covered by a base-owned non-portable exemption.
 
 Do not run AxIR generation or commit Python, Java, C++, Go, Rust, generated TypeScript, generated examples, or generated website files. A maintainer must recreate any needed generated changes on a member-owned branch.`;
 }
@@ -631,10 +707,13 @@ export async function runExternalContributionPolicy({
         });
     let baseLedger;
     let headLedger;
+    let exemptionChangedLineRanges;
+    let exemptionReadFile;
+    const backlogPairChanged =
+      filePreview.backlogChanged && filePreview.backlogDocChanged;
     if (
       !trusted &&
-      filePreview.backlogChanged &&
-      filePreview.backlogDocChanged
+      (filePreview.portablePaths.length > 0 || backlogPairChanged)
     ) {
       const baseText = await readRepositoryFile({
         github,
@@ -647,6 +726,37 @@ export async function runExternalContributionPolicy({
       if (!baseParsed.ok) throw new Error(baseParsed.error);
       baseLedger = baseParsed.ledger;
 
+      const scopedPaths = scopedExemptionPaths(
+        filePreview.portablePaths,
+        baseLedger.nonPortableExemptions
+      );
+      if (scopedPaths.length > 0 && pull.head.repo) {
+        const headFiles = new Map();
+        for (const filePath of scopedPaths) {
+          try {
+            headFiles.set(
+              filePath,
+              await readRepositoryFile({
+                github,
+                owner: pull.head.repo.owner.login,
+                repo: pull.head.repo.name,
+                filePath,
+                ref: headSha,
+              })
+            );
+          } catch (error) {
+            core.info(
+              `Unable to read scoped exemption file ${filePath}: ${error instanceof Error ? error.message : String(error)}`
+            );
+          }
+        }
+        exemptionChangedLineRanges = changedLineRangesFromFiles(files);
+        exemptionReadFile = (filePath) =>
+          headFiles.get(normalizePath(filePath));
+      }
+    }
+
+    if (!trusted && backlogPairChanged) {
       if (!pull.head.repo) {
         throw new Error('The PR head repository is unavailable.');
       }
@@ -677,6 +787,8 @@ export async function runExternalContributionPolicy({
       prNumber: number,
       baseLedger,
       headLedger,
+      changedLineRanges: exemptionChangedLineRanges,
+      readFile: exemptionReadFile,
     });
     await publishStatus({
       github,

--- a/scripts/external-contribution-policy.test.js
+++ b/scripts/external-contribution-policy.test.js
@@ -39,6 +39,19 @@ function ledger(entries = [], nonPortableExemptions = []) {
   return { schemaVersion: 2, entries, nonPortableExemptions };
 }
 
+function exemption(overrides = {}) {
+  return {
+    id: 'webllm-browser-only',
+    surface: 'axai',
+    reason: 'Browser-only host runtime',
+    paths: ['src/ax/ai/webllm'],
+    scopedFiles: [],
+    tags: ['webllm', 'browser-only'],
+    createdAt: '2026-08-20',
+    ...overrides,
+  };
+}
+
 function file(filename, previousFilename) {
   return {
     filename,
@@ -328,6 +341,140 @@ describe('external backlog integrity', () => {
     );
   });
 
+  it('accepts portable paths covered by a base-owned directory exemption', () => {
+    const result = evaluateExternalContribution({
+      association: 'CONTRIBUTOR',
+      files: [
+        file('src/ax/ai/webllm/api.ts'),
+        file('src/ax/ai/webllm/api.test.ts'),
+      ],
+      changedFilesCount: 2,
+      prNumber: 700,
+      baseLedger: ledger([], [exemption()]),
+    });
+    expect(result).toEqual(
+      expect.objectContaining({
+        ok: true,
+        exemptPortablePaths: [
+          'src/ax/ai/webllm/api.test.ts',
+          'src/ax/ai/webllm/api.ts',
+        ],
+      })
+    );
+  });
+
+  it('does not trust an exemption supplied only by the contributor head', () => {
+    const result = evaluateExternalContribution({
+      association: 'CONTRIBUTOR',
+      files: [file('src/ax/ai/webllm/api.ts')],
+      changedFilesCount: 1,
+      prNumber: 700,
+      baseLedger: ledger(),
+      headLedger: ledger([], [exemption()]),
+    });
+    expect(result.ok).toBe(false);
+    expect(result.violations).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ code: 'missing-backlog-pair' }),
+      ])
+    );
+  });
+
+  it('keeps marker-scoped exemptions fail-closed without line evidence', () => {
+    const result = evaluateExternalContribution({
+      association: 'CONTRIBUTOR',
+      files: [file('src/ax/ai/wrap.ts')],
+      changedFilesCount: 1,
+      prNumber: 700,
+      baseLedger: ledger(
+        [],
+        [
+          exemption({
+            paths: [],
+            scopedFiles: ['src/ax/ai/wrap.ts'],
+          }),
+        ]
+      ),
+    });
+    expect(result.ok).toBe(false);
+    expect(result.violations).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ code: 'missing-backlog-pair' }),
+      ])
+    );
+  });
+
+  it('accepts marker-scoped exemptions with matching line evidence', () => {
+    const filePath = 'src/ax/ai/wrap.ts';
+    const result = evaluateExternalContribution({
+      association: 'CONTRIBUTOR',
+      files: [file(filePath)],
+      changedFilesCount: 1,
+      prNumber: 700,
+      baseLedger: ledger(
+        [],
+        [
+          exemption({
+            paths: [],
+            scopedFiles: [filePath],
+          }),
+        ]
+      ),
+      changedLineRanges: { [filePath]: [{ start: 2, end: 2 }] },
+      readFile: () =>
+        [
+          '// axir-nonportable:start browser-only',
+          'const browserOnly = true;',
+          '// axir-nonportable:end browser-only',
+        ].join('\n'),
+    });
+    expect(result.ok).toBe(true);
+    expect(result.exemptPortablePaths).toEqual([filePath]);
+  });
+
+  it('requires backlog coverage only for non-exempt portable paths', () => {
+    const baseExemption = exemption();
+    const result = evaluateExternalContribution({
+      association: 'CONTRIBUTOR',
+      files: [
+        file('src/ax/ai/webllm/api.ts'),
+        file(changedPath),
+        file(BACKLOG_PATH),
+        file(BACKLOG_DOC_PATH),
+      ],
+      changedFilesCount: 4,
+      prNumber: 700,
+      baseLedger: ledger([], [baseExemption]),
+      headLedger: ledger([openEntry()], [baseExemption]),
+    });
+    expect(result.ok).toBe(true);
+  });
+
+  it('rejects workaround backlog entries for already exempt paths', () => {
+    const baseExemption = exemption();
+    const result = evaluateExternalContribution({
+      association: 'CONTRIBUTOR',
+      files: [
+        file('src/ax/ai/webllm/api.ts'),
+        file(BACKLOG_PATH),
+        file(BACKLOG_DOC_PATH),
+      ],
+      changedFilesCount: 3,
+      prNumber: 700,
+      baseLedger: ledger([], [baseExemption]),
+      headLedger: ledger(
+        [openEntry({ tsPaths: ['src/ax/ai/webllm/api.ts'] })],
+        [baseExemption]
+      ),
+    });
+    expect(result.ok).toBe(false);
+    expect(result.violations).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ code: 'backlog-without-portable-ts' }),
+      ])
+    );
+  });
+
   it('rejects malformed and oversized ledgers without executing them', () => {
     expect(parseLedgerText('{', 'head backlog')).toEqual(
       expect.objectContaining({ ok: false })
@@ -382,6 +529,108 @@ describe('policy comments and runner', () => {
       expect.objectContaining({ comment_id: 41 })
     );
     expect(createComment).not.toHaveBeenCalled();
+  });
+
+  it('reads trusted base exemptions for portable external changes', async () => {
+    const mocks = githubMock({
+      pull: pullFixture(),
+      files: [file('src/ax/ai/webllm/api.ts')],
+      comments: [],
+      contents: [JSON.stringify(ledger([], [exemption()]))],
+    });
+    const result = await runExternalContributionPolicy({
+      github: mocks.github,
+      context: contextFixture(),
+      core: { info: vi.fn() },
+      prNumber: 700,
+    });
+    expect(result).toEqual(
+      expect.objectContaining({ ok: true, trusted: false })
+    );
+    expect(mocks.getContent).toHaveBeenCalledOnce();
+    expect(mocks.statusCalls.map((call) => call.state)).toEqual([
+      'pending',
+      'success',
+    ]);
+  });
+
+  it('verifies marker-scoped exemptions from the head patch and file', async () => {
+    const filePath = 'src/ax/ai/wrap.ts';
+    const scopedExemption = exemption({
+      paths: [],
+      scopedFiles: [filePath],
+    });
+    const mocks = githubMock({
+      pull: pullFixture(),
+      files: [
+        {
+          ...file(filePath),
+          additions: 1,
+          deletions: 1,
+          patch:
+            '@@ -1,3 +1,3 @@\n // axir-nonportable:start browser-only\n-const browserOnly = false;\n+const browserOnly = true;\n // axir-nonportable:end browser-only',
+        },
+      ],
+      comments: [],
+      contents: [
+        JSON.stringify(ledger([], [scopedExemption])),
+        [
+          '// axir-nonportable:start browser-only',
+          'const browserOnly = true;',
+          '// axir-nonportable:end browser-only',
+        ].join('\n'),
+      ],
+    });
+    const result = await runExternalContributionPolicy({
+      github: mocks.github,
+      context: contextFixture(),
+      core: { info: vi.fn() },
+      prNumber: 700,
+    });
+    expect(result.ok).toBe(true);
+    expect(result.exemptPortablePaths).toEqual([filePath]);
+    expect(mocks.getContent).toHaveBeenCalledTimes(2);
+  });
+
+  it('fails scoped exemptions closed when GitHub truncates the patch', async () => {
+    const filePath = 'src/ax/ai/wrap.ts';
+    const scopedExemption = exemption({
+      paths: [],
+      scopedFiles: [filePath],
+    });
+    const mocks = githubMock({
+      pull: pullFixture(),
+      files: [
+        {
+          ...file(filePath),
+          additions: 2,
+          deletions: 2,
+          patch:
+            '@@ -1,3 +1,3 @@\n // axir-nonportable:start browser-only\n-const browserOnly = false;\n+const browserOnly = true;\n // axir-nonportable:end browser-only',
+        },
+      ],
+      comments: [],
+      contents: [
+        JSON.stringify(ledger([], [scopedExemption])),
+        [
+          '// axir-nonportable:start browser-only',
+          'const browserOnly = true;',
+          '// axir-nonportable:end browser-only',
+        ].join('\n'),
+      ],
+    });
+    const result = await runExternalContributionPolicy({
+      github: mocks.github,
+      context: contextFixture(),
+      core: { info: vi.fn() },
+      prNumber: 700,
+    });
+    expect(result.ok).toBe(false);
+    expect(result.violations).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ code: 'missing-backlog-pair' }),
+      ])
+    );
   });
 
   it('creates one explanatory comment and a failure status for violations', async () => {
@@ -676,6 +925,7 @@ function githubMock({ pull, files, comments, contents = [] }) {
     updateComment,
     createComment,
     paginate,
+    getContent,
     github: {
       paginate,
       rest: {


### PR DESCRIPTION
## Summary
- read non-portable exemptions from the trusted base ledger
- apply directory and marker-scoped exemptions before requiring PR-bound backlog entries
- fail marker-scoped evaluation closed when GitHub patch evidence is missing or truncated
- reject workaround backlog entries for already exempt paths

## Verification
- npm run test:contribution-policy
- npm run test:format
- npm run test:lint
- npm run axir:backlog:validate
- real-ledger simulation for PR #591 WebLLM paths