### PR TITLE
fix(release): ignore unrelated local tags

### DIFF
--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -38,6 +38,8 @@ to `main`, or create a GitHub Release.
 
 After the release pull request passes the required checks and is merged, run
 `npm run release:publish -- <version>` from the synchronized `main` branch.
+The publish phase checks the requested tag directly on the remote; unrelated
+historical local tags do not need to be cleaned up first.
 The publish phase verifies that the release reached `main` through a merged
 pull request with passing required checks, replaces any stale local tag left by
 an older failed release attempt, pushes an annotated tag for the merged commit,

--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -242,6 +242,10 @@ export function parseReleaseArguments(argv) {
   return { mode, value };
 }
 
+export function publishFetchArguments() {
+  return ['fetch', '--prune', 'origin', mainBranch];
+}
+
 function prepare(increment = 'patch') {
   assertClean();
   assertBranch(mainBranch);
@@ -330,7 +334,9 @@ function recreateLocalTag(version, head) {
 function publish(requestedVersion) {
   assertClean();
   assertBranch(mainBranch);
-  run('git', ['fetch', '--prune', '--tags', 'origin', mainBranch]);
+  // Remote tag identity is checked with ls-remote below. Fetching every tag can
+  // fail when a checkout still has a pre-squash tag from an older release.
+  run('git', publishFetchArguments());
   const head = git('rev-parse', 'HEAD');
   const remoteHead = git('rev-parse', `origin/${mainBranch}`);
   if (head !== remoteHead) {

--- a/scripts/release.test.js
+++ b/scripts/release.test.js
@@ -8,6 +8,7 @@ import {
   assertAlignedReleaseVersions,
   parseReleaseArguments,
   parseRemoteTagTarget,
+  publishFetchArguments,
   releaseBranchName,
   resolveReleaseVersion,
 } from './release.mjs';
@@ -73,6 +74,16 @@ describe('protected-main release workflow', () => {
       value: '24.0.6',
     });
     expect(() => parseReleaseArguments(['ship'])).toThrow(/Usage/);
+  });
+
+  it('does not fetch unrelated historical tags before publishing', () => {
+    expect(publishFetchArguments()).toEqual([
+      'fetch',
+      '--prune',
+      'origin',
+      'main',
+    ]);
+    expect(publishFetchArguments()).not.toContain('--tags');
   });
 
   it('cannot tag, push main, or publish from release-it directly', () => {


### PR DESCRIPTION
## Summary
- fetch protected main without fetching every historical tag
- continue checking the requested release tag directly with ls-remote
- add a regression test and document that old local tags need no cleanup

## Why
The first protected-main publish of 24.0.6 safely stopped because this checkout retained a pre-squash 24.0.3 tag. Fetching all tags made that unrelated historical ref a release blocker. The 24.0.6 release was resumed after restoring the local tag from the authoritative remote; this change prevents the same class of failure in future releases.

## Verification
- npm run test:release-workflow (15 tests)
- npm run test:format
- npm run test:lint (passes with three pre-existing website warnings)
- npm run test:spelling
- git diff --check