### PR TITLE
fix(go/goja): surface console output to the actor as per-turn logs

### DIFF
--- a/packages/go/runtime/goja/goja.go
+++ b/packages/go/runtime/goja/goja.go
@@ -35,6 +35,14 @@ type Session struct {
 	closed          bool
 	stdout          []string
 	stderr          []string
+	// turnLogs collects this turn's console output. The axir step normalizer
+	// reads it off the result as `logs` and joins it into the output the model
+	// sees, which is the entire observation loop of the REPL contract: without
+	// it, console.log runs, captures into the session snapshot, and the model
+	// is never shown a byte — measured downstream as blind re-fetching of
+	// results already in hand. Reset each Execute; the TS, Python and C++
+	// runtimes all surface per-turn logs this way.
+	turnLogs []string
 }
 
 func NewRuntime(options ...Option) *Runtime {
@@ -169,6 +177,7 @@ func (s *Session) Execute(code string, options map[string]ax.Value) ax.Value {
 		return runtimeError("session closed", "session_closed")
 	}
 	s.completion = nil
+	s.turnLogs = nil
 	s.installBuiltins()
 	timeoutMs := intOption(valueFromMap(options, "timeoutMs"), intOption(valueFromMap(s.runtimePolicy, "timeoutMs"), 5000))
 	var timer *time.Timer
@@ -219,12 +228,35 @@ func (s *Session) Execute(code string, options map[string]ax.Value) ax.Value {
 	s.restoreReservedGlobals()
 	s.installBuiltins()
 	if s.completion == nil {
-		return map[string]ax.Value{"kind": "result", "result": nil}
+		return s.withTurnLogs(map[string]ax.Value{"kind": "result", "result": nil})
 	}
 	if safe, ok := jsonSafe(s.completion); ok {
-		return safe
+		return s.withTurnLogs(safe)
 	}
 	return runtimeError("goja actor output is not JSON-compatible", "runtime")
+}
+
+// withTurnLogs surfaces this turn's console output as `logs` on the payload,
+// where the axir step normalizer joins it into the output shown to the model.
+// Completion payloads get it too, mirroring the Python runtime; a payload that
+// already carries logs, or is not a map, is returned untouched.
+func (s *Session) withTurnLogs(payload ax.Value) ax.Value {
+	if len(s.turnLogs) == 0 {
+		return payload
+	}
+	m, ok := payload.(map[string]ax.Value)
+	if !ok {
+		return payload
+	}
+	if _, exists := m["logs"]; exists {
+		return payload
+	}
+	logs := make([]ax.Value, 0, len(s.turnLogs))
+	for _, line := range s.turnLogs {
+		logs = append(logs, line)
+	}
+	m["logs"] = logs
+	return m
 }
 
 func (s *Session) Inspect(options map[string]ax.Value) ax.Value {
@@ -299,8 +331,19 @@ func (s *Session) Close() ax.Value {
 func (s *Session) installBuiltins() {
 	s.installFreezeHelper()
 	console := s.vm.NewObject()
-	_ = console.DefineDataProperty("log", s.vm.ToValue(func(values ...gojavm.Value) { s.appendDiagnostic(&s.stdout, values...) }), gojavm.FLAG_FALSE, gojavm.FLAG_FALSE, gojavm.FLAG_TRUE)
-	_ = console.DefineDataProperty("error", s.vm.ToValue(func(values ...gojavm.Value) { s.appendDiagnostic(&s.stderr, values...) }), gojavm.FLAG_FALSE, gojavm.FLAG_FALSE, gojavm.FLAG_TRUE)
+	logTo := func(target *[]string) func(values ...gojavm.Value) {
+		return func(values ...gojavm.Value) {
+			s.appendDiagnostic(target, values...)
+			s.appendDiagnostic(&s.turnLogs, values...)
+		}
+	}
+	// warn/info/debug exist in every sibling runtime's console shim; leaving
+	// them undefined here turned a model's console.info into a TypeError that
+	// failed the whole turn.
+	for _, name := range []string{"log", "warn", "info", "debug"} {
+		_ = console.DefineDataProperty(name, s.vm.ToValue(logTo(&s.stdout)), gojavm.FLAG_FALSE, gojavm.FLAG_FALSE, gojavm.FLAG_TRUE)
+	}
+	_ = console.DefineDataProperty("error", s.vm.ToValue(logTo(&s.stderr)), gojavm.FLAG_FALSE, gojavm.FLAG_FALSE, gojavm.FLAG_TRUE)
 	s.defineProtected("console", console)
 	s.setPrimitive("final", func(args []ax.Value) ax.Value {
 		return map[string]ax.Value{"type": "final", "args": args}

--- a/packages/go/runtime/goja/goja_test.go
+++ b/packages/go/runtime/goja/goja_test.go
@@ -1,0 +1,121 @@
+package goja
+
+import (
+	"strings"
+	"testing"
+
+	ax "github.com/ax-llm/ax/packages/go"
+)
+
+func newTestSession(t *testing.T) *Session {
+	t.Helper()
+	runtime := NewRuntime()
+	runtime.RegisterHostCallable("query_catalog", func(params ax.Value) (ax.Value, error) {
+		return map[string]ax.Value{"cards": []ax.Value{map[string]ax.Value{"id": "table:app:main.accounts"}}}, nil
+	})
+	session, err := runtime.CreateSession(map[string]ax.Value{}, map[string]ax.Value{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return session.(*Session)
+}
+
+func payloadMap(t *testing.T, v ax.Value) map[string]ax.Value {
+	t.Helper()
+	m, ok := v.(map[string]ax.Value)
+	if !ok {
+		t.Fatalf("payload is %T, want map: %v", v, v)
+	}
+	return m
+}
+
+func logsOf(t *testing.T, payload map[string]ax.Value) []string {
+	t.Helper()
+	raw, ok := payload["logs"]
+	if !ok {
+		return nil
+	}
+	list, ok := raw.([]ax.Value)
+	if !ok {
+		t.Fatalf("logs is %T, want list: %v", raw, raw)
+	}
+	out := make([]string, 0, len(list))
+	for _, entry := range list {
+		out = append(out, entry.(string))
+	}
+	return out
+}
+
+// The observation loop of the REPL contract: an intermediate step's console
+// output must come back on the result as `logs`. Measured on 339 recorded
+// episodes before this fix, 34 intermediate steps called console.log and every
+// one received empty output, after which the model re-fetched data it already
+// held.
+func TestExecuteSurfacesConsoleLogsOnIntermediateStep(t *testing.T) {
+	session := newTestSession(t)
+	result := session.Execute(`const detail = await query_catalog({id: "table:app:main.accounts"});
+console.log("cards:", detail.cards.length);`, nil)
+	payload := payloadMap(t, result)
+	logs := logsOf(t, payload)
+	if len(logs) != 1 || !strings.Contains(logs[0], "cards:") || !strings.Contains(logs[0], "1") {
+		t.Fatalf("intermediate step logs = %v, want the printed card count", logs)
+	}
+}
+
+// Completion payloads carry the turn's logs too, mirroring the Python runtime.
+func TestExecuteSurfacesConsoleLogsOnCompletion(t *testing.T) {
+	session := newTestSession(t)
+	result := session.Execute(`console.log("about to finalize");
+await final("done", {ok: true});`, nil)
+	payload := payloadMap(t, result)
+	if logs := logsOf(t, payload); len(logs) != 1 || logs[0] != "about to finalize" {
+		t.Fatalf("completion logs = %v", logs)
+	}
+}
+
+// Logs are per turn: a second Execute must not replay the first turn's output.
+func TestExecuteResetsLogsBetweenTurns(t *testing.T) {
+	session := newTestSession(t)
+	first := payloadMap(t, session.Execute(`console.log("turn one");`, nil))
+	if logs := logsOf(t, first); len(logs) != 1 || logs[0] != "turn one" {
+		t.Fatalf("first turn logs = %v", logs)
+	}
+	second := payloadMap(t, session.Execute(`const x = 1;`, nil))
+	if logs := logsOf(t, second); logs != nil {
+		t.Fatalf("silent second turn leaked logs = %v", logs)
+	}
+	third := payloadMap(t, session.Execute(`console.log("turn three");`, nil))
+	if logs := logsOf(t, third); len(logs) != 1 || logs[0] != "turn three" {
+		t.Fatalf("third turn logs = %v", logs)
+	}
+}
+
+// A failed turn reports its error alone, matching the Python and C++ runtimes.
+func TestExecuteErrorCarriesNoLogs(t *testing.T) {
+	session := newTestSession(t)
+	result := session.Execute(`console.log("before the throw");
+throw new Error("boom");`, nil)
+	payload := payloadMap(t, result)
+	if payload["is_error"] != true {
+		t.Fatalf("expected an error payload: %v", payload)
+	}
+	if _, ok := payload["logs"]; ok {
+		t.Fatalf("error payload must not carry logs: %v", payload)
+	}
+}
+
+// Every sibling runtime's console shim defines warn/info/debug; an undefined
+// method here turned a model's console.info into a TypeError that failed the
+// whole turn.
+func TestConsoleVariantsDoNotThrow(t *testing.T) {
+	session := newTestSession(t)
+	result := session.Execute(`console.warn("w"); console.info("i"); console.debug("d"); console.error("e");`, nil)
+	payload := payloadMap(t, result)
+	if payload["is_error"] == true {
+		t.Fatalf("console variants threw: %v", payload)
+	}
+	logs := logsOf(t, payload)
+	if len(logs) != 4 {
+		t.Fatalf("console variants logs = %v, want all four captured", logs)
+	}
+}

--- a/tools/axir/internal/axir/axir_test.go
+++ b/tools/axir/internal/axir/axir_test.go
@@ -959,6 +959,7 @@ func TestCapabilityManifestsAndGeneratedPackageShape(t *testing.T) {
 				"go.sum",
 				"axllm.go",
 				"runtime/goja/goja.go",
+				"runtime/goja/goja_test.go",
 				"axir-capabilities.json",
 				"axir-api.json",
 				"conformance-coverage.json",
@@ -1213,6 +1214,7 @@ func TestCapabilityManifestsAndGeneratedPackageShape(t *testing.T) {
 				checkGeneratedFileContains(t, dir, "go.mod", "module github.com/ax-llm/ax/packages/go", "go 1.23", "github.com/dop251/goja", "github.com/coder/websocket")
 				checkGeneratedFileContains(t, dir, "axllm.go", "package axllm", "type Value = any", "func NewSignature", "type HTTPTransport struct")
 				checkGeneratedFileContains(t, dir, "runtime/goja/goja.go", "package goja", "func NewRuntime(options ...Option) *Runtime", "func (r *Runtime) RegisterCallable", "gojavm.New")
+				checkGeneratedFileContains(t, dir, "runtime/goja/goja_test.go", "TestExecuteSurfacesConsoleLogsOnIntermediateStep", "TestExecuteResetsLogsBetweenTurns", "TestConsoleVariantsDoNotThrow")
 				checkGeneratedFileContains(t, dir, "examples/runtime_profiles/javascript_goja/main.go", "go-javascript-goja-profile-ok", "ax.NewAgent", "agent.Test(runtime", "while (true) {}")
 			case "rust":
 				checkGeneratedFileContains(t, dir, "Cargo.toml", `name = "axllm"`, "reqwest", "rustls-tls", "rquickjs", "runtime-quickjs", `required-features = ["runtime-quickjs"]`, "tungstenite", `realtime = ["dep:tungstenite"]`)

--- a/tools/axir/internal/axir/codegen.go
+++ b/tools/axir/internal/axir/codegen.go
@@ -374,6 +374,7 @@ func EmitGo(model AxRuntimeModel, outDir string) error {
 		"axllm.go":                          renderPackageTemplate(core, version),
 		"mcp.go":                            goMCP,
 		"runtime/goja/goja.go":              goGojaRuntime,
+		"runtime/goja/goja_test.go":         goGojaRuntimeTest,
 		"axir-capabilities.json":            mustCapabilityManifest(model, "go"),
 		"axir-api.json":                     mustAPIReferenceManifest(model, "go"),
 		"conformance-coverage.json":         mustConformanceCoverageManifest(model, "go"),

--- a/tools/axir/internal/axir/templates/goja/goGojaRuntime.go.txt
+++ b/tools/axir/internal/axir/templates/goja/goGojaRuntime.go.txt
@@ -35,6 +35,14 @@ type Session struct {
 	closed          bool
 	stdout          []string
 	stderr          []string
+	// turnLogs collects this turn's console output. The axir step normalizer
+	// reads it off the result as `logs` and joins it into the output the model
+	// sees, which is the entire observation loop of the REPL contract: without
+	// it, console.log runs, captures into the session snapshot, and the model
+	// is never shown a byte — measured downstream as blind re-fetching of
+	// results already in hand. Reset each Execute; the TS, Python and C++
+	// runtimes all surface per-turn logs this way.
+	turnLogs []string
 }
 
 func NewRuntime(options ...Option) *Runtime {
@@ -169,6 +177,7 @@ func (s *Session) Execute(code string, options map[string]ax.Value) ax.Value {
 		return runtimeError("session closed", "session_closed")
 	}
 	s.completion = nil
+	s.turnLogs = nil
 	s.installBuiltins()
 	timeoutMs := intOption(valueFromMap(options, "timeoutMs"), intOption(valueFromMap(s.runtimePolicy, "timeoutMs"), 5000))
 	var timer *time.Timer
@@ -219,12 +228,35 @@ func (s *Session) Execute(code string, options map[string]ax.Value) ax.Value {
 	s.restoreReservedGlobals()
 	s.installBuiltins()
 	if s.completion == nil {
-		return map[string]ax.Value{"kind": "result", "result": nil}
+		return s.withTurnLogs(map[string]ax.Value{"kind": "result", "result": nil})
 	}
 	if safe, ok := jsonSafe(s.completion); ok {
-		return safe
+		return s.withTurnLogs(safe)
 	}
 	return runtimeError("goja actor output is not JSON-compatible", "runtime")
+}
+
+// withTurnLogs surfaces this turn's console output as `logs` on the payload,
+// where the axir step normalizer joins it into the output shown to the model.
+// Completion payloads get it too, mirroring the Python runtime; a payload that
+// already carries logs, or is not a map, is returned untouched.
+func (s *Session) withTurnLogs(payload ax.Value) ax.Value {
+	if len(s.turnLogs) == 0 {
+		return payload
+	}
+	m, ok := payload.(map[string]ax.Value)
+	if !ok {
+		return payload
+	}
+	if _, exists := m["logs"]; exists {
+		return payload
+	}
+	logs := make([]ax.Value, 0, len(s.turnLogs))
+	for _, line := range s.turnLogs {
+		logs = append(logs, line)
+	}
+	m["logs"] = logs
+	return m
 }
 
 func (s *Session) Inspect(options map[string]ax.Value) ax.Value {
@@ -299,8 +331,19 @@ func (s *Session) Close() ax.Value {
 func (s *Session) installBuiltins() {
 	s.installFreezeHelper()
 	console := s.vm.NewObject()
-	_ = console.DefineDataProperty("log", s.vm.ToValue(func(values ...gojavm.Value) { s.appendDiagnostic(&s.stdout, values...) }), gojavm.FLAG_FALSE, gojavm.FLAG_FALSE, gojavm.FLAG_TRUE)
-	_ = console.DefineDataProperty("error", s.vm.ToValue(func(values ...gojavm.Value) { s.appendDiagnostic(&s.stderr, values...) }), gojavm.FLAG_FALSE, gojavm.FLAG_FALSE, gojavm.FLAG_TRUE)
+	logTo := func(target *[]string) func(values ...gojavm.Value) {
+		return func(values ...gojavm.Value) {
+			s.appendDiagnostic(target, values...)
+			s.appendDiagnostic(&s.turnLogs, values...)
+		}
+	}
+	// warn/info/debug exist in every sibling runtime's console shim; leaving
+	// them undefined here turned a model's console.info into a TypeError that
+	// failed the whole turn.
+	for _, name := range []string{"log", "warn", "info", "debug"} {
+		_ = console.DefineDataProperty(name, s.vm.ToValue(logTo(&s.stdout)), gojavm.FLAG_FALSE, gojavm.FLAG_FALSE, gojavm.FLAG_TRUE)
+	}
+	_ = console.DefineDataProperty("error", s.vm.ToValue(logTo(&s.stderr)), gojavm.FLAG_FALSE, gojavm.FLAG_FALSE, gojavm.FLAG_TRUE)
 	s.defineProtected("console", console)
 	s.setPrimitive("final", func(args []ax.Value) ax.Value {
 		return map[string]ax.Value{"type": "final", "args": args}

--- a/tools/axir/internal/axir/templates/goja/goGojaRuntimeTest.go.txt
+++ b/tools/axir/internal/axir/templates/goja/goGojaRuntimeTest.go.txt
@@ -1,0 +1,121 @@
+package goja
+
+import (
+	"strings"
+	"testing"
+
+	ax "github.com/ax-llm/ax/packages/go"
+)
+
+func newTestSession(t *testing.T) *Session {
+	t.Helper()
+	runtime := NewRuntime()
+	runtime.RegisterHostCallable("query_catalog", func(params ax.Value) (ax.Value, error) {
+		return map[string]ax.Value{"cards": []ax.Value{map[string]ax.Value{"id": "table:app:main.accounts"}}}, nil
+	})
+	session, err := runtime.CreateSession(map[string]ax.Value{}, map[string]ax.Value{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return session.(*Session)
+}
+
+func payloadMap(t *testing.T, v ax.Value) map[string]ax.Value {
+	t.Helper()
+	m, ok := v.(map[string]ax.Value)
+	if !ok {
+		t.Fatalf("payload is %T, want map: %v", v, v)
+	}
+	return m
+}
+
+func logsOf(t *testing.T, payload map[string]ax.Value) []string {
+	t.Helper()
+	raw, ok := payload["logs"]
+	if !ok {
+		return nil
+	}
+	list, ok := raw.([]ax.Value)
+	if !ok {
+		t.Fatalf("logs is %T, want list: %v", raw, raw)
+	}
+	out := make([]string, 0, len(list))
+	for _, entry := range list {
+		out = append(out, entry.(string))
+	}
+	return out
+}
+
+// The observation loop of the REPL contract: an intermediate step's console
+// output must come back on the result as `logs`. Measured on 339 recorded
+// episodes before this fix, 34 intermediate steps called console.log and every
+// one received empty output, after which the model re-fetched data it already
+// held.
+func TestExecuteSurfacesConsoleLogsOnIntermediateStep(t *testing.T) {
+	session := newTestSession(t)
+	result := session.Execute(`const detail = await query_catalog({id: "table:app:main.accounts"});
+console.log("cards:", detail.cards.length);`, nil)
+	payload := payloadMap(t, result)
+	logs := logsOf(t, payload)
+	if len(logs) != 1 || !strings.Contains(logs[0], "cards:") || !strings.Contains(logs[0], "1") {
+		t.Fatalf("intermediate step logs = %v, want the printed card count", logs)
+	}
+}
+
+// Completion payloads carry the turn's logs too, mirroring the Python runtime.
+func TestExecuteSurfacesConsoleLogsOnCompletion(t *testing.T) {
+	session := newTestSession(t)
+	result := session.Execute(`console.log("about to finalize");
+await final("done", {ok: true});`, nil)
+	payload := payloadMap(t, result)
+	if logs := logsOf(t, payload); len(logs) != 1 || logs[0] != "about to finalize" {
+		t.Fatalf("completion logs = %v", logs)
+	}
+}
+
+// Logs are per turn: a second Execute must not replay the first turn's output.
+func TestExecuteResetsLogsBetweenTurns(t *testing.T) {
+	session := newTestSession(t)
+	first := payloadMap(t, session.Execute(`console.log("turn one");`, nil))
+	if logs := logsOf(t, first); len(logs) != 1 || logs[0] != "turn one" {
+		t.Fatalf("first turn logs = %v", logs)
+	}
+	second := payloadMap(t, session.Execute(`const x = 1;`, nil))
+	if logs := logsOf(t, second); logs != nil {
+		t.Fatalf("silent second turn leaked logs = %v", logs)
+	}
+	third := payloadMap(t, session.Execute(`console.log("turn three");`, nil))
+	if logs := logsOf(t, third); len(logs) != 1 || logs[0] != "turn three" {
+		t.Fatalf("third turn logs = %v", logs)
+	}
+}
+
+// A failed turn reports its error alone, matching the Python and C++ runtimes.
+func TestExecuteErrorCarriesNoLogs(t *testing.T) {
+	session := newTestSession(t)
+	result := session.Execute(`console.log("before the throw");
+throw new Error("boom");`, nil)
+	payload := payloadMap(t, result)
+	if payload["is_error"] != true {
+		t.Fatalf("expected an error payload: %v", payload)
+	}
+	if _, ok := payload["logs"]; ok {
+		t.Fatalf("error payload must not carry logs: %v", payload)
+	}
+}
+
+// Every sibling runtime's console shim defines warn/info/debug; an undefined
+// method here turned a model's console.info into a TypeError that failed the
+// whole turn.
+func TestConsoleVariantsDoNotThrow(t *testing.T) {
+	session := newTestSession(t)
+	result := session.Execute(`console.warn("w"); console.info("i"); console.debug("d"); console.error("e");`, nil)
+	payload := payloadMap(t, result)
+	if payload["is_error"] == true {
+		t.Fatalf("console variants threw: %v", payload)
+	}
+	logs := logsOf(t, payload)
+	if len(logs) != 4 {
+		t.Fatalf("console variants logs = %v, want all four captured", logs)
+	}
+}

--- a/tools/axir/internal/axir/templates_embed.go
+++ b/tools/axir/internal/axir/templates_embed.go
@@ -95,6 +95,9 @@ var goSum string
 //go:embed templates/goja/goGojaRuntime.go.txt
 var goGojaRuntime string
 
+//go:embed templates/goja/goGojaRuntimeTest.go.txt
+var goGojaRuntimeTest string
+
 //go:embed templates/goja/goJavaScriptGojaProfileExample.go.txt
 var goJavaScriptGojaProfileExample string
 


### PR DESCRIPTION
## The bug

The RLM prompt promises a REPL: *write code → it executes → you see output.* The axir step normalizer honors that by reading `logs` off the step result and joining it into the output the model sees, and the TS, Python and C++ runtimes supply it. The Go goja runtime captured `console.log` into the session snapshot's `__ax_stdout` and returned a bare `{kind:"result",result:nil}` — the model's `console.log` ran, and the model was never shown a byte.

Same divergence class as the host-callable error envelope fixed in #599: the Go runtime silently dropping a channel its siblings provide, surfacing downstream as "the small model is dumb."

## Measured impact

On 339 recorded GraphJin benchmark episodes (gemini-3.5-flash-lite): **34 intermediate steps called `console.log` and every single one received empty output** — 129 of 129 intermediate steps were blank. Blind, the model re-fetched data it already held, which is the repeat behavior downstream systems then grow guards against.

## The fix

- `Execute` resets a per-turn log buffer; console feeds it alongside the existing stdout/stderr snapshot channels.
- Result **and** completion payloads carry it as `logs` (completions mirror the Python runtime).
- Error payloads carry none, matching Python and C++.
- `console.warn/info/debug` are now defined — every sibling shim has them, and an undefined `console.info` was a TypeError that failed the whole turn.
- Template and package copy receive the identical change and remain byte-identical.

## Tests

Five new tests in `packages/go/runtime/goja/goja_test.go`, including the exact episode scenario (fetch → log → intermediate result). Mutation-checked: reverting the attach fails them with `logs = []`, the pre-fix behavior verbatim.

## Known remaining gap

The Rust and Java QuickJS runtimes have the same divergence (no `__ax_logs` in their templates); this PR fixes the Go target and leaves those to a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)