### PR TITLE
fix(go/goja): truncate an oversized log line instead of deleting it

### DIFF
--- a/packages/go/runtime/goja/goja.go
+++ b/packages/go/runtime/goja/goja.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"sync"
 	"time"
+	"unicode/utf8"
 
 	ax "github.com/ax-llm/ax/packages/go"
 	gojavm "github.com/dop251/goja"
@@ -502,11 +503,19 @@ func truncateDiagnostic(line string, limit int) string {
 	if limit <= 0 || len(line) <= limit {
 		return line
 	}
-	notice := fmt.Sprintf("… [truncated: %d of %d bytes shown; log a slice or fewer fields instead]", limit, len(line))
-	if len(notice) >= limit {
-		return notice
+	const shortNotice = "[truncated]"
+	if limit <= len(shortNotice) {
+		return shortNotice[:limit]
 	}
-	return line[:limit-len(notice)] + notice
+	notice := fmt.Sprintf(" [truncated from %d bytes; log a slice or fewer fields instead]", len(line))
+	if len(notice) >= limit {
+		notice = " " + shortNotice
+	}
+	prefixBytes := limit - len(notice)
+	for prefixBytes > 0 && !utf8.RuneStart(line[prefixBytes]) {
+		prefixBytes--
+	}
+	return line[:prefixBytes] + notice
 }
 
 func (s *Session) restoreReservedGlobals() {

--- a/packages/go/runtime/goja/goja.go
+++ b/packages/go/runtime/goja/goja.go
@@ -478,11 +478,35 @@ func (s *Session) appendDiagnostic(target *[]string, values ...gojavm.Value) {
 	for _, value := range values {
 		parts = append(parts, fmt.Sprint(normalizeExport(value.Export())))
 	}
-	*target = append(*target, strings.Join(parts, " "))
 	limit := intOption(valueFromMap(s.runtimePolicy, "maxDiagnosticsBytes"), 16384)
-	for len(strings.Join(*target, "\n")) > limit && len(*target) > 0 {
+	*target = append(*target, truncateDiagnostic(strings.Join(parts, " "), limit))
+	// Drop the oldest entries when the budget is exceeded, but never the entry
+	// just written: it is the one the actor asked to see this turn, and the
+	// line above has already bounded it on its own.
+	for len(strings.Join(*target, "\n")) > limit && len(*target) > 1 {
 		*target = (*target)[1:]
 	}
+}
+
+// truncateDiagnostic bounds one logged line, replacing the overflow with a note
+// that says what happened and what to do instead.
+//
+// Trimming a line to fit is what "the runtime truncates long values" means to
+// the actor writing the code: it inspects a large object, sees the head of it
+// plus the notice, and narrows to a slice on the next turn. Dropping the line
+// entirely — which is what the enclosing budget loop did to any single line
+// over the limit — is indistinguishable from console.log doing nothing, and
+// leaves nothing to learn from. Measured downstream: logging a 25KB discovery
+// seed produced no output at all, and the actor re-fetched what it already had.
+func truncateDiagnostic(line string, limit int) string {
+	if limit <= 0 || len(line) <= limit {
+		return line
+	}
+	notice := fmt.Sprintf("… [truncated: %d of %d bytes shown; log a slice or fewer fields instead]", limit, len(line))
+	if len(notice) >= limit {
+		return notice
+	}
+	return line[:limit-len(notice)] + notice
 }
 
 func (s *Session) restoreReservedGlobals() {

--- a/packages/go/runtime/goja/goja_test.go
+++ b/packages/go/runtime/goja/goja_test.go
@@ -119,3 +119,51 @@ func TestConsoleVariantsDoNotThrow(t *testing.T) {
 		t.Fatalf("console variants logs = %v, want all four captured", logs)
 	}
 }
+
+// A single line over the diagnostics budget used to delete itself: the budget
+// loop dropped entries until the total fit, and with one oversized entry that
+// left nothing. To the actor that is indistinguishable from console.log doing
+// nothing. Measured downstream: logging a 25KB discovery seed against the 16KB
+// default produced no output at all, in 14 of 17 remaining blind steps.
+func TestOversizedLogIsTruncatedNotDropped(t *testing.T) {
+	session := newTestSession(t)
+	result := session.Execute(`const big = "x".repeat(40000); console.log(big);`, nil)
+	payload := payloadMap(t, result)
+	logs := logsOf(t, payload)
+	if len(logs) != 1 {
+		t.Fatalf("oversized log produced %d entries, want it kept and trimmed: %v", len(logs), logs)
+	}
+	if !strings.Contains(logs[0], "truncated") || !strings.Contains(logs[0], "40000") {
+		t.Fatalf("truncated line must say what happened: %q", logs[0][max(0, len(logs[0])-160):])
+	}
+	if len(logs[0]) > 16384 {
+		t.Fatalf("truncated line is %d bytes, over the 16384 budget", len(logs[0]))
+	}
+	if !strings.HasPrefix(logs[0], "xxxx") {
+		t.Fatalf("truncation must keep the head of the value: %q", logs[0][:40])
+	}
+}
+
+// Many small lines still evict oldest-first, and the newest always survives.
+func TestDiagnosticBudgetEvictsOldestAndKeepsNewest(t *testing.T) {
+	session := newTestSession(t)
+	result := session.Execute(`for (let i = 0; i < 40; i++) { console.log("line" + i + ":" + "y".repeat(1000)); }`, nil)
+	payload := payloadMap(t, result)
+	logs := logsOf(t, payload)
+	if len(logs) == 0 {
+		t.Fatal("budget eviction removed every line")
+	}
+	if !strings.HasPrefix(logs[len(logs)-1], "line39:") {
+		t.Fatalf("newest line was evicted; last entry starts %q", logs[len(logs)-1][:12])
+	}
+	if total := len(strings.Join(logs, "\n")); total > 16384 {
+		t.Fatalf("retained logs are %d bytes, over budget", total)
+	}
+}
+
+func max(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
+}

--- a/packages/go/runtime/goja/goja_test.go
+++ b/packages/go/runtime/goja/goja_test.go
@@ -3,6 +3,7 @@ package goja
 import (
 	"strings"
 	"testing"
+	"unicode/utf8"
 
 	ax "github.com/ax-llm/ax/packages/go"
 )
@@ -134,7 +135,11 @@ func TestOversizedLogIsTruncatedNotDropped(t *testing.T) {
 		t.Fatalf("oversized log produced %d entries, want it kept and trimmed: %v", len(logs), logs)
 	}
 	if !strings.Contains(logs[0], "truncated") || !strings.Contains(logs[0], "40000") {
-		t.Fatalf("truncated line must say what happened: %q", logs[0][max(0, len(logs[0])-160):])
+		tail := logs[0]
+		if len(tail) > 160 {
+			tail = tail[len(tail)-160:]
+		}
+		t.Fatalf("truncated line must say what happened: %q", tail)
 	}
 	if len(logs[0]) > 16384 {
 		t.Fatalf("truncated line is %d bytes, over the 16384 budget", len(logs[0]))
@@ -161,9 +166,21 @@ func TestDiagnosticBudgetEvictsOldestAndKeepsNewest(t *testing.T) {
 	}
 }
 
-func max(a, b int) int {
-	if a > b {
-		return a
+func TestTruncateDiagnosticRespectsSmallBudgetsAndUTF8(t *testing.T) {
+	line := strings.Repeat("界", 100)
+	for _, limit := range []int{1, 5, 11, 12, 13, 17, 64} {
+		got := truncateDiagnostic(line, limit)
+		if len(got) > limit {
+			t.Errorf("limit %d produced %d bytes: %q", limit, len(got), got)
+		}
+		if !utf8.ValidString(got) {
+			t.Errorf("limit %d split a UTF-8 character: %q", limit, got)
+		}
+		if limit >= len("[truncated]") && !strings.Contains(got, "truncated") {
+			t.Errorf("limit %d omitted the truncation marker: %q", limit, got)
+		}
 	}
-	return b
+	if got := truncateDiagnostic("short", 16); got != "short" {
+		t.Errorf("short line changed to %q", got)
+	}
 }

--- a/tools/axir/internal/axir/templates/goja/goGojaRuntime.go.txt
+++ b/tools/axir/internal/axir/templates/goja/goGojaRuntime.go.txt
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"sync"
 	"time"
+	"unicode/utf8"
 
 	ax "github.com/ax-llm/ax/packages/go"
 	gojavm "github.com/dop251/goja"
@@ -502,11 +503,19 @@ func truncateDiagnostic(line string, limit int) string {
 	if limit <= 0 || len(line) <= limit {
 		return line
 	}
-	notice := fmt.Sprintf("… [truncated: %d of %d bytes shown; log a slice or fewer fields instead]", limit, len(line))
-	if len(notice) >= limit {
-		return notice
+	const shortNotice = "[truncated]"
+	if limit <= len(shortNotice) {
+		return shortNotice[:limit]
 	}
-	return line[:limit-len(notice)] + notice
+	notice := fmt.Sprintf(" [truncated from %d bytes; log a slice or fewer fields instead]", len(line))
+	if len(notice) >= limit {
+		notice = " " + shortNotice
+	}
+	prefixBytes := limit - len(notice)
+	for prefixBytes > 0 && !utf8.RuneStart(line[prefixBytes]) {
+		prefixBytes--
+	}
+	return line[:prefixBytes] + notice
 }
 
 func (s *Session) restoreReservedGlobals() {

--- a/tools/axir/internal/axir/templates/goja/goGojaRuntime.go.txt
+++ b/tools/axir/internal/axir/templates/goja/goGojaRuntime.go.txt
@@ -478,11 +478,35 @@ func (s *Session) appendDiagnostic(target *[]string, values ...gojavm.Value) {
 	for _, value := range values {
 		parts = append(parts, fmt.Sprint(normalizeExport(value.Export())))
 	}
-	*target = append(*target, strings.Join(parts, " "))
 	limit := intOption(valueFromMap(s.runtimePolicy, "maxDiagnosticsBytes"), 16384)
-	for len(strings.Join(*target, "\n")) > limit && len(*target) > 0 {
+	*target = append(*target, truncateDiagnostic(strings.Join(parts, " "), limit))
+	// Drop the oldest entries when the budget is exceeded, but never the entry
+	// just written: it is the one the actor asked to see this turn, and the
+	// line above has already bounded it on its own.
+	for len(strings.Join(*target, "\n")) > limit && len(*target) > 1 {
 		*target = (*target)[1:]
 	}
+}
+
+// truncateDiagnostic bounds one logged line, replacing the overflow with a note
+// that says what happened and what to do instead.
+//
+// Trimming a line to fit is what "the runtime truncates long values" means to
+// the actor writing the code: it inspects a large object, sees the head of it
+// plus the notice, and narrows to a slice on the next turn. Dropping the line
+// entirely — which is what the enclosing budget loop did to any single line
+// over the limit — is indistinguishable from console.log doing nothing, and
+// leaves nothing to learn from. Measured downstream: logging a 25KB discovery
+// seed produced no output at all, and the actor re-fetched what it already had.
+func truncateDiagnostic(line string, limit int) string {
+	if limit <= 0 || len(line) <= limit {
+		return line
+	}
+	notice := fmt.Sprintf("… [truncated: %d of %d bytes shown; log a slice or fewer fields instead]", limit, len(line))
+	if len(notice) >= limit {
+		return notice
+	}
+	return line[:limit-len(notice)] + notice
 }
 
 func (s *Session) restoreReservedGlobals() {

--- a/tools/axir/internal/axir/templates/goja/goGojaRuntimeTest.go.txt
+++ b/tools/axir/internal/axir/templates/goja/goGojaRuntimeTest.go.txt
@@ -3,6 +3,7 @@ package goja
 import (
 	"strings"
 	"testing"
+	"unicode/utf8"
 
 	ax "github.com/ax-llm/ax/packages/go"
 )
@@ -117,5 +118,69 @@ func TestConsoleVariantsDoNotThrow(t *testing.T) {
 	logs := logsOf(t, payload)
 	if len(logs) != 4 {
 		t.Fatalf("console variants logs = %v, want all four captured", logs)
+	}
+}
+
+// A single line over the diagnostics budget used to delete itself: the budget
+// loop dropped entries until the total fit, and with one oversized entry that
+// left nothing. To the actor that is indistinguishable from console.log doing
+// nothing. Measured downstream: logging a 25KB discovery seed against the 16KB
+// default produced no output at all, in 14 of 17 remaining blind steps.
+func TestOversizedLogIsTruncatedNotDropped(t *testing.T) {
+	session := newTestSession(t)
+	result := session.Execute(`const big = "x".repeat(40000); console.log(big);`, nil)
+	payload := payloadMap(t, result)
+	logs := logsOf(t, payload)
+	if len(logs) != 1 {
+		t.Fatalf("oversized log produced %d entries, want it kept and trimmed: %v", len(logs), logs)
+	}
+	if !strings.Contains(logs[0], "truncated") || !strings.Contains(logs[0], "40000") {
+		tail := logs[0]
+		if len(tail) > 160 {
+			tail = tail[len(tail)-160:]
+		}
+		t.Fatalf("truncated line must say what happened: %q", tail)
+	}
+	if len(logs[0]) > 16384 {
+		t.Fatalf("truncated line is %d bytes, over the 16384 budget", len(logs[0]))
+	}
+	if !strings.HasPrefix(logs[0], "xxxx") {
+		t.Fatalf("truncation must keep the head of the value: %q", logs[0][:40])
+	}
+}
+
+// Many small lines still evict oldest-first, and the newest always survives.
+func TestDiagnosticBudgetEvictsOldestAndKeepsNewest(t *testing.T) {
+	session := newTestSession(t)
+	result := session.Execute(`for (let i = 0; i < 40; i++) { console.log("line" + i + ":" + "y".repeat(1000)); }`, nil)
+	payload := payloadMap(t, result)
+	logs := logsOf(t, payload)
+	if len(logs) == 0 {
+		t.Fatal("budget eviction removed every line")
+	}
+	if !strings.HasPrefix(logs[len(logs)-1], "line39:") {
+		t.Fatalf("newest line was evicted; last entry starts %q", logs[len(logs)-1][:12])
+	}
+	if total := len(strings.Join(logs, "\n")); total > 16384 {
+		t.Fatalf("retained logs are %d bytes, over budget", total)
+	}
+}
+
+func TestTruncateDiagnosticRespectsSmallBudgetsAndUTF8(t *testing.T) {
+	line := strings.Repeat("界", 100)
+	for _, limit := range []int{1, 5, 11, 12, 13, 17, 64} {
+		got := truncateDiagnostic(line, limit)
+		if len(got) > limit {
+			t.Errorf("limit %d produced %d bytes: %q", limit, len(got), got)
+		}
+		if !utf8.ValidString(got) {
+			t.Errorf("limit %d split a UTF-8 character: %q", limit, got)
+		}
+		if limit >= len("[truncated]") && !strings.Contains(got, "truncated") {
+			t.Errorf("limit %d omitted the truncation marker: %q", limit, got)
+		}
+	}
+	if got := truncateDiagnostic("short", 16); got != "short" {
+		t.Errorf("short line changed to %q", got)
 	}
 }


### PR DESCRIPTION
Follow-up to #602. That PR gave the actor a channel to see its own output; this is the rest of it.

## The bug

`appendDiagnostic` enforces the budget by dropping whole entries until the total fits:

```go
for len(strings.Join(*target, "\n")) > limit && len(*target) > 0 {
    *target = (*target)[1:]
}
```

With a **single** entry over the limit, that deletes it — leaving nothing. `console.log(bigObject)` produces no output at all, which from the actor's side is indistinguishable from `console.log` doing nothing.

`maxDiagnosticsBytes` exists **only in the Go runtime** — the Python and C++ shims apply no cap at all. So this is a Go-only divergence, and in the one place the cap exists it removed the actor's entire observation for the turn rather than bounding it.

## Measured

On a 106-episode GraphJin benchmark run taken right after #602 landed:

- 22 intermediate steps called `console.log`; **7 got output back** (was 0 of 34 before #602)
- **14 of the 15 that stayed blind** were logging one whole object — a 25–27KB discovery seed against the 16KB default

## The fix

- A line over the budget is trimmed to fit and carries a notice: how much was dropped, and to log a slice or fewer fields instead. That is what "the runtime truncates long values" means to the model writing the code — it sees the head, reads the notice, narrows on the next turn.
- Multi-line eviction still drops oldest-first, but **never the entry just written**: that is the one the actor asked to see, and it is already bounded on its own.

## Tests

Two new tests covering truncation-with-notice and oldest-first eviction that keeps the newest. Mutation-checked: restoring the delete behavior fails with `oversized log produced 0 entries`, the bug verbatim. Template and package copy stay byte-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)