### PR TITLE
ci: shard AxIR checks by affected target

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       axir: ${{ steps.scope.outputs.run_axir }}
+      axir_targets: ${{ steps.scope.outputs.axir_targets }}
       core: ${{ steps.scope.outputs.run_core }}
     steps:
       - uses: actions/checkout@v4
@@ -115,10 +116,14 @@ jobs:
         run: npm run test:tests
 
   generated-examples:
-    name: Generated Examples
+    name: Generated Examples (${{ matrix.target }})
     needs: changes
     if: needs.changes.outputs.axir == 'true'
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        target: ${{ fromJSON(needs.changes.outputs.axir_targets) }}
     steps:
       - uses: actions/checkout@v4
       - name: Setup Node.js
@@ -128,10 +133,12 @@ jobs:
           cache: npm
           cache-dependency-path: package-lock.json
       - name: Setup Python
+        if: matrix.target == 'python'
         uses: actions/setup-python@v6
         with:
           python-version: '3.x'
       - name: Setup Java
+        if: matrix.target == 'java'
         uses: actions/setup-java@v5
         with:
           distribution: temurin
@@ -152,6 +159,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-axir-go-
       - name: Cache Cargo outputs
+        if: matrix.target == 'rust'
         uses: actions/cache@v4
         with:
           path: |
@@ -163,20 +171,19 @@ jobs:
             ${{ runner.os }}-cargo-generated-
             ${{ runner.os }}-cargo-
       - name: Install C++ QuickJS runtime
+        if: matrix.target == 'cpp'
         run: sudo apt-get update && sudo apt-get install --yes libquickjs
       - name: Install dependencies
         run: npm ci
       - name: Run generated examples
-        run: npm run test:examples:generated
+        run: npm run test:examples:generated -- ${{ matrix.target }}
         env:
           AXIR_QUICKJS_CFLAGS: '-I/usr/include/quickjs'
           AXIR_QUICKJS_LDFLAGS: '/usr/lib/quickjs/libquickjs.a -lm -ldl -pthread'
-      - name: AxIR perturbation gate (expected-mutation, all targets)
-        run: npm run axir:perturb:check
-      - name: AxIR anti-hardcode gate (model-response mutation, all targets)
-        run: npm run axir:gate:response-perturb
-        env:
-          AXIR_PERTURB_ALL: "1"
+      - name: AxIR perturbation gate (expected-mutation)
+        run: npm run axir:perturb:check -- ${{ matrix.target }}
+      - name: AxIR anti-hardcode gate (model-response mutation)
+        run: npm run axir:gate:response-perturb -- ${{ matrix.target }}
 
   axir-packages:
     name: AxIR Package Freshness
@@ -243,7 +250,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        target: [python, java, cpp, go, rust]
+        target: ${{ fromJSON(needs.changes.outputs.axir_targets) }}
     steps:
       - uses: actions/checkout@v4
       - name: Setup Node.js
@@ -297,7 +304,8 @@ jobs:
 
   axir-agent-antidote:
     # Real-engine antidote (see docs/AXIR_GATES.md). Runs the WHOLE ir/conformance/axagent-real
-    # suite, so BOTH RLM actor stages are genuinely executed by a real embedded engine: the executor
+    # suite for each affected target (all targets for shared changes), so BOTH RLM actor stages are
+    # genuinely executed by a real embedded engine: the executor
     # (agent-runtime-real-javascript-final) AND the distiller (agent-runtime-real-distiller-code,
     # which a one-shot distiller that demands a completion cannot pass -- the bug a live model surfaced
     # that scripted fixtures + the executor-only antidote missed). The recorded transcript supplies the
@@ -318,21 +326,26 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Setup Go
+        if: contains(fromJSON(needs.changes.outputs.axir_targets), 'go')
         uses: actions/setup-go@v6
         with:
           go-version: '1.23.x'
           cache: false
       - name: Go in-process engine antidote (goja, bundled)
+        if: contains(fromJSON(needs.changes.outputs.axir_targets), 'go')
         run: cd packages/go && go run ./conformance ../../ir/conformance/axagent-real
       - name: Setup Python
+        if: contains(fromJSON(needs.changes.outputs.axir_targets), 'python')
         uses: actions/setup-python@v6
         with:
           python-version: '3.x'
       - name: Python in-process engine antidote (axllm[runtime-quickjs])
+        if: contains(fromJSON(needs.changes.outputs.axir_targets), 'python')
         run: |
           pip install quickjs
           PYTHONPATH=packages/python python -m axllm.conformance ir/conformance/axagent-real
       - name: Cache Cargo outputs
+        if: contains(fromJSON(needs.changes.outputs.axir_targets), 'rust')
         uses: actions/cache@v4
         with:
           path: |
@@ -343,6 +356,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-cargo-
       - name: Build Rust antidote binary
+        if: contains(fromJSON(needs.changes.outputs.axir_targets), 'rust')
         run: |
           for attempt in 1 2 3; do
             if cargo build --manifest-path packages/rust/Cargo.toml --features runtime-quickjs --bin axllm-conformance; then
@@ -354,13 +368,16 @@ jobs:
             sleep $((attempt * 15))
           done
       - name: Rust in-process engine antidote (rquickjs)
+        if: contains(fromJSON(needs.changes.outputs.axir_targets), 'rust')
         run: cargo run --offline --manifest-path packages/rust/Cargo.toml --features runtime-quickjs --bin axllm-conformance -- ir/conformance/axagent-real
       - name: Setup Java
+        if: contains(fromJSON(needs.changes.outputs.axir_targets), 'java')
         uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: '17'
       - name: Java in-process engine antidote (quickjs4j/Chicory)
+        if: contains(fromJSON(needs.changes.outputs.axir_targets), 'java')
         # quickjs4j is a pure-JVM WASM engine, so the only setup is fetching it (+ deps) from
         # Maven Central, compiling the package against it, and running -- no native toolchain.
         run: |

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "test": "run-s test:contribution-policy test:release-workflow test:axir:tools test:axir test:axir:packages test:mcp-events:generated test:mcp-oauth test:mcp-interop test:examples:generated test:format test:lint test:tests test:spelling",
     "test:contribution-policy": "vitest run scripts/external-contribution-policy.test.js",
     "test:release-workflow": "vitest run scripts/release.test.js",
-    "test:axir:tools": "vitest run scripts/axir-backlog.test.js scripts/axir-conformance-sync.test.js scripts/ci-scope.test.js",
+    "test:axir:tools": "vitest run scripts/axir-backlog.test.js scripts/axir-conformance-sync.test.js scripts/ci-scope.test.js scripts/test-generated-examples.test.js",
     "test:axir": "node scripts/test-axir.mjs",
     "test:axir:packages": "npm run axir:check-packages",
     "test:examples:generated": "node scripts/test-generated-examples.mjs",

--- a/scripts/ci-scope.mjs
+++ b/scripts/ci-scope.mjs
@@ -12,6 +12,8 @@ const defaultRepoRoot = path.resolve(scriptDir, '..');
 const gitMaxBuffer = 512 * 1024 * 1024;
 const fullScopeSentinel = '.github/workflows/ci.yml';
 
+export const AXIR_TARGETS = ['python', 'java', 'cpp', 'go', 'rust'];
+
 const generatedLanguageRoots = [
   'packages/python/',
   'packages/java/',
@@ -24,6 +26,51 @@ const generatedLanguageRoots = [
   'src/examples/go/',
   'src/examples/rust/',
 ];
+
+const targetOwnedRoots = new Map([
+  [
+    'python',
+    [
+      'packages/python/',
+      'src/examples/python/',
+      'tools/axir/internal/axir/templates/python/',
+    ],
+  ],
+  [
+    'java',
+    [
+      'packages/java/',
+      'src/examples/java/',
+      'tools/axir/internal/axir/templates/java/',
+    ],
+  ],
+  [
+    'cpp',
+    [
+      'packages/cpp/',
+      'src/examples/cpp/',
+      'tools/axir/internal/axir/templates/cpp/',
+    ],
+  ],
+  [
+    'go',
+    [
+      'packages/go/',
+      'src/examples/go/',
+      'tools/axir/internal/axir/templates/go/',
+      'tools/axir/internal/axir/templates/goja/',
+    ],
+  ],
+  [
+    'rust',
+    [
+      'packages/rust/',
+      'src/examples/rust/',
+      'tools/axir/internal/axir/templates/rust/',
+      'tools/axir/internal/axir/templates/rust_quickjs/',
+    ],
+  ],
+]);
 
 const axirMatrixFiles = new Set([
   // Not currently tracked, but adding it can change every npm ci result.
@@ -115,6 +162,29 @@ export function axirMatrixPaths(changedFiles) {
   return changedFiles.map(normalizePath).filter(isAxirMatrixPath);
 }
 
+function targetForAxirPath(filePath) {
+  const normalized = normalizePath(filePath);
+  for (const [target, roots] of targetOwnedRoots) {
+    if (roots.some((root) => normalized.startsWith(root))) return target;
+  }
+  return null;
+}
+
+export function axirTargets(changedFiles) {
+  const paths = axirMatrixPaths(changedFiles);
+  if (paths.length === 0) return [];
+
+  const selected = new Set();
+  for (const filePath of paths) {
+    const target = targetForAxirPath(filePath);
+    // Shared compiler/IR inputs and any unclassified AxIR path fail open to the
+    // complete target matrix. Only clearly target-owned roots may narrow CI.
+    if (!target) return [...AXIR_TARGETS];
+    selected.add(target);
+  }
+  return AXIR_TARGETS.filter((target) => selected.has(target));
+}
+
 export function isCoreTestPath(filePath) {
   const normalized = normalizePath(filePath);
   return !isDocumentationOnlyPath(normalized);
@@ -186,10 +256,14 @@ function main(argv = process.argv.slice(2)) {
   const githubOutput = option(argv, 'github-output');
   const changedFiles = changedFilesFromGit(base, head, root);
   const axirPaths = axirMatrixPaths(changedFiles);
+  const targets = axirTargets(changedFiles);
   const corePaths = coreTestPaths(changedFiles);
-  const runAxir = axirPaths.length > 0;
+  const runAxir = targets.length > 0;
   const runCore = corePaths.length > 0;
 
+  console.log(
+    runAxir ? `AxIR targets: ${targets.join(', ')}` : 'AxIR targets: none'
+  );
   console.log(
     runAxir
       ? `AxIR/language matrix required by:\n${axirPaths.map((file) => `- ${file}`).join('\n')}`
@@ -203,6 +277,7 @@ function main(argv = process.argv.slice(2)) {
 
   if (githubOutput) {
     appendFileSync(githubOutput, `run_axir=${runAxir}\n`);
+    appendFileSync(githubOutput, `axir_targets=${JSON.stringify(targets)}\n`);
     appendFileSync(githubOutput, `run_core=${runCore}\n`);
   }
 }

--- a/scripts/ci-scope.test.js
+++ b/scripts/ci-scope.test.js
@@ -7,7 +7,9 @@ import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
 
 import {
+  AXIR_TARGETS,
   axirMatrixPaths,
+  axirTargets,
   changedFilesFromGit,
   coreTestPaths,
   isAxirMatrixPath,
@@ -78,6 +80,68 @@ describe('AxIR CI scope', () => {
     'README.md',
   ])('does not run the generated-language matrix for %s', (filePath) => {
     expect(isAxirMatrixPath(filePath)).toBe(false);
+  });
+
+  it.each([
+    ['python', 'packages/python/axllm/agent.py'],
+    ['java', 'src/examples/java/generation/AxGenOpenAIExample.java'],
+    ['cpp', 'tools/axir/internal/axir/templates/cpp/cppHeader.hpp'],
+    ['go', 'tools/axir/internal/axir/templates/goja/goGojaRuntime.go.txt'],
+    [
+      'rust',
+      'tools/axir/internal/axir/templates/rust_quickjs/rustQuickJSRuntime.rs',
+    ],
+  ])('narrows a target-owned %s path to its language', (target, filePath) => {
+    expect(axirTargets([filePath])).toEqual([target]);
+  });
+
+  it('narrows the complete PR 604 path set to Go', () => {
+    expect(
+      axirTargets([
+        'packages/go/runtime/goja/goja.go',
+        'packages/go/runtime/goja/goja_test.go',
+        'tools/axir/internal/axir/templates/goja/goGojaRuntime.go.txt',
+        'tools/axir/internal/axir/templates/goja/goGojaRuntimeTest.go.txt',
+      ])
+    ).toEqual(['go']);
+  });
+
+  it('unions mixed target-owned paths in canonical matrix order', () => {
+    expect(
+      axirTargets([
+        'packages/rust/src/lib.rs',
+        'packages/go/axllm.go',
+        'packages/python/axllm/agent.py',
+      ])
+    ).toEqual(['python', 'go', 'rust']);
+  });
+
+  it.each([
+    'ir/axcore/agent.axir',
+    'ir/conformance/axagent/basic.json',
+    'tools/axir/internal/axir/codegen.go',
+    'tools/axir/internal/axir/templates/mcp/goMCP.go.txt',
+    'scripts/run-example.mjs',
+    'scripts/test-generated-examples.mjs',
+    'package-lock.json',
+    '.github/workflows/ci.yml',
+  ])(
+    'fails open to every target for shared or ambiguous input %s',
+    (filePath) => {
+      expect(axirTargets([filePath])).toEqual(AXIR_TARGETS);
+    }
+  );
+
+  it('lets a shared input override otherwise target-owned paths', () => {
+    expect(
+      axirTargets(['packages/go/axllm.go', 'ir/axcore/agent.axir'])
+    ).toEqual(AXIR_TARGETS);
+  });
+
+  it('returns no targets for documentation-only or unrelated changes', () => {
+    expect(
+      axirTargets(['docs/ARCHITECTURE.md', 'src/ax/agent/agent.ts'])
+    ).toEqual([]);
   });
 
   it.each([
@@ -187,7 +251,7 @@ describe('AxIR CI scope', () => {
         { cwd: repoRoot, stdio: 'pipe' }
       );
       expect(readFileSync(noChangesOutput, 'utf8')).toBe(
-        'run_axir=false\nrun_core=false\n'
+        'run_axir=false\naxir_targets=[]\nrun_core=false\n'
       );
 
       execFileSync(
@@ -204,7 +268,7 @@ describe('AxIR CI scope', () => {
         { cwd: repoRoot, stdio: 'pipe' }
       );
       expect(readFileSync(failOpenOutput, 'utf8')).toBe(
-        'run_axir=true\nrun_core=true\n'
+        'run_axir=true\naxir_targets=["python","java","cpp","go","rust"]\nrun_core=true\n'
       );
     } finally {
       rmSync(tempRoot, { force: true, recursive: true });

--- a/scripts/run-example.mjs
+++ b/scripts/run-example.mjs
@@ -306,46 +306,65 @@ async function runCpp(examplePath, rest) {
   const qjs = wantsRuntime ? resolveQuickjsCppFlags() : null;
 
   if (cmake) {
-    const buildDir = path.join(generatedRoot, 'cpp-cmake-build', stem);
-    const installDir = path.join(generatedRoot, 'cpp-install', stem);
+    // The generated-example harness invokes this script once per example. Its
+    // opt-in lets those child processes share one package build per profile;
+    // standalone runs keep their existing clean-build behavior.
+    const reusePackageBuild = env.AXIR_CPP_REUSE_PACKAGE_BUILD === '1';
+    const packageBuildKey = wantsRuntime ? 'quickjs' : 'base';
+    const buildDir = path.join(
+      generatedRoot,
+      reusePackageBuild ? 'cpp-package-build' : 'cpp-cmake-build',
+      reusePackageBuild ? packageBuildKey : stem
+    );
+    const installDir = path.join(
+      generatedRoot,
+      reusePackageBuild ? 'cpp-package-install' : 'cpp-install',
+      reusePackageBuild ? packageBuildKey : stem
+    );
     const scratchDir = path.join(generatedRoot, 'cpp-run', stem);
     const scratchBuildDir = path.join(generatedRoot, 'cpp-run-build', stem);
-    await rm(buildDir, { recursive: true, force: true });
-    await rm(installDir, { recursive: true, force: true });
+    if (!reusePackageBuild) {
+      await rm(buildDir, { recursive: true, force: true });
+      await rm(installDir, { recursive: true, force: true });
+    }
     await rm(scratchDir, { recursive: true, force: true });
     await rm(scratchBuildDir, { recursive: true, force: true });
     await mkdir(scratchDir, { recursive: true });
 
-    const configureArgs = [
-      '-S',
-      outDir,
-      '-B',
-      buildDir,
-      '-DAX_BUILD_EXAMPLES=OFF',
-      '-DAX_BUILD_CONFORMANCE=OFF',
-    ];
-    if (wantsRuntime) {
-      configureArgs.push(
-        '-DAX_BUILD_QUICKJS_PROFILE=ON',
-        `-DAX_QUICKJS_CFLAGS=${qjs.cflags}`,
-        `-DAX_QUICKJS_LDFLAGS=${qjs.ldflags}`
-      );
-    }
-    run(cmake, configureArgs, { cwd: repoRoot, env });
-    run(cmake, ['--build', buildDir, '--target', 'axllm'], {
-      cwd: repoRoot,
-      env,
-    });
-    if (wantsRuntime) {
-      run(cmake, ['--build', buildDir, '--target', 'axllm_quickjs'], {
+    const packageReady = path.join(installDir, '.axir-example-package-ready');
+    if (!reusePackageBuild || !existsSync(packageReady)) {
+      const configureArgs = [
+        '-S',
+        outDir,
+        '-B',
+        buildDir,
+        '-DAX_BUILD_EXAMPLES=OFF',
+        '-DAX_BUILD_CONFORMANCE=OFF',
+      ];
+      if (wantsRuntime) {
+        configureArgs.push(
+          '-DAX_BUILD_QUICKJS_PROFILE=ON',
+          `-DAX_QUICKJS_CFLAGS=${qjs.cflags}`,
+          `-DAX_QUICKJS_LDFLAGS=${qjs.ldflags}`
+        );
+      }
+      run(cmake, configureArgs, { cwd: repoRoot, env });
+      run(cmake, ['--build', buildDir, '--target', 'axllm'], {
         cwd: repoRoot,
         env,
       });
+      if (wantsRuntime) {
+        run(cmake, ['--build', buildDir, '--target', 'axllm_quickjs'], {
+          cwd: repoRoot,
+          env,
+        });
+      }
+      run(cmake, ['--install', buildDir, '--prefix', installDir], {
+        cwd: repoRoot,
+        env,
+      });
+      if (reusePackageBuild) await writeFile(packageReady, '');
     }
-    run(cmake, ['--install', buildDir, '--prefix', installDir], {
-      cwd: repoRoot,
-      env,
-    });
 
     await writeFile(
       path.join(scratchDir, 'CMakeLists.txt'),

--- a/scripts/test-generated-examples.mjs
+++ b/scripts/test-generated-examples.mjs
@@ -9,7 +9,15 @@ const scriptDir = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(scriptDir, '..');
 const runner = path.join(repoRoot, 'scripts', 'run-example.mjs');
 
-const examples = [
+export const GENERATED_EXAMPLE_TARGETS = [
+  'python',
+  'java',
+  'cpp',
+  'go',
+  'rust',
+];
+
+export const generatedExamples = [
   ['python', 'signature_schema.py'],
   ['python', 'provider_mapping_no_key.py'],
   ['python', 'provider_stream_no_key.py'],
@@ -69,19 +77,59 @@ const examples = [
   ['rust', 'mcp_scripted_tools.rs'],
 ];
 
-run(process.execPath, [runner, 'list']);
-for (const [language, file] of examples) {
-  run(process.execPath, [runner, language, file]);
+export function selectGeneratedExampleTargets(args = []) {
+  const requested = args.length > 0 ? args : GENERATED_EXAMPLE_TARGETS;
+  const unknown = requested.filter(
+    (target) => !GENERATED_EXAMPLE_TARGETS.includes(target)
+  );
+  if (unknown.length > 0) {
+    throw new Error(
+      `Unsupported generated-example target(s): ${[...new Set(unknown)].join(', ')}. Expected one or more of: ${GENERATED_EXAMPLE_TARGETS.join(', ')}.`
+    );
+  }
+  const selected = new Set(requested);
+  return GENERATED_EXAMPLE_TARGETS.filter((target) => selected.has(target));
 }
 
-const catalog = await readPublicExampleCatalog({ repoRoot });
-for (const example of catalog.all.filter((value) => value.group === 'mcp')) {
-  run(process.execPath, [
-    runner,
-    example.language.runner,
-    example.sourcePath,
-    '--compile-only',
-  ]);
+export function generatedExamplesForTargets(
+  targets,
+  values = generatedExamples
+) {
+  const selected = new Set(targets);
+  return values.filter(([language]) => selected.has(language));
+}
+
+export function generatedMcpExamplesForTargets(catalog, targets) {
+  const selected = new Set(targets);
+  return catalog.all.filter(
+    (value) => value.group === 'mcp' && selected.has(value.language.runner)
+  );
+}
+
+async function main(args = process.argv.slice(2)) {
+  const targets = selectGeneratedExampleTargets(args);
+  console.log(`Generated example targets: ${targets.join(', ')}`);
+
+  // Preserve the existing all-target catalog smoke without printing the entire
+  // catalog once per CI shard. Targeted runs still parse the same catalog below.
+  if (args.length === 0) run(process.execPath, [runner, 'list']);
+  for (const [language, file] of generatedExamplesForTargets(targets)) {
+    console.log(`[example] ${language}: ${file}`);
+    run(process.execPath, [runner, language, file]);
+  }
+
+  const catalog = await readPublicExampleCatalog({ repoRoot });
+  for (const example of generatedMcpExamplesForTargets(catalog, targets)) {
+    console.log(
+      `[mcp compile] ${example.language.runner}: ${example.sourcePath}`
+    );
+    run(process.execPath, [
+      runner,
+      example.language.runner,
+      example.sourcePath,
+      '--compile-only',
+    ]);
+  }
 }
 
 function run(command, args) {
@@ -93,4 +141,16 @@ function run(command, args) {
   });
   if (result.error) throw result.error;
   if (result.status !== 0) process.exit(result.status ?? 1);
+}
+
+const isMain =
+  process.argv[1] &&
+  path.resolve(process.argv[1]) ===
+    path.resolve(fileURLToPath(import.meta.url));
+
+if (isMain) {
+  main().catch((error) => {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(1);
+  });
 }

--- a/scripts/test-generated-examples.mjs
+++ b/scripts/test-generated-examples.mjs
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 import { spawnSync } from 'node:child_process';
+import { rm } from 'node:fs/promises';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { readPublicExampleCatalog } from './example-catalog.mjs';
@@ -110,12 +111,21 @@ async function main(args = process.argv.slice(2)) {
   const targets = selectGeneratedExampleTargets(args);
   console.log(`Generated example targets: ${targets.join(', ')}`);
 
+  if (targets.includes('cpp')) {
+    const generatedRoot = path.join(repoRoot, 'src', 'examples', '.generated');
+    await Promise.all(
+      ['cpp-package-build', 'cpp-package-install'].map((name) =>
+        rm(path.join(generatedRoot, name), { force: true, recursive: true })
+      )
+    );
+  }
+
   // Preserve the existing all-target catalog smoke without printing the entire
   // catalog once per CI shard. Targeted runs still parse the same catalog below.
   if (args.length === 0) run(process.execPath, [runner, 'list']);
   for (const [language, file] of generatedExamplesForTargets(targets)) {
     console.log(`[example] ${language}: ${file}`);
-    run(process.execPath, [runner, language, file]);
+    run(process.execPath, [runner, language, file], language);
   }
 
   const catalog = await readPublicExampleCatalog({ repoRoot });
@@ -123,19 +133,21 @@ async function main(args = process.argv.slice(2)) {
     console.log(
       `[mcp compile] ${example.language.runner}: ${example.sourcePath}`
     );
-    run(process.execPath, [
-      runner,
-      example.language.runner,
-      example.sourcePath,
-      '--compile-only',
-    ]);
+    run(
+      process.execPath,
+      [runner, example.language.runner, example.sourcePath, '--compile-only'],
+      example.language.runner
+    );
   }
 }
 
-function run(command, args) {
+function run(command, args, language) {
   const result = spawnSync(command, args, {
     cwd: repoRoot,
-    env: process.env,
+    env: {
+      ...process.env,
+      ...(language === 'cpp' ? { AXIR_CPP_REUSE_PACKAGE_BUILD: '1' } : {}),
+    },
     stdio: 'inherit',
     shell: false,
   });

--- a/scripts/test-generated-examples.test.js
+++ b/scripts/test-generated-examples.test.js
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  GENERATED_EXAMPLE_TARGETS,
+  generatedExamples,
+  generatedExamplesForTargets,
+  generatedMcpExamplesForTargets,
+  selectGeneratedExampleTargets,
+} from './test-generated-examples.mjs';
+
+describe('generated example target selection', () => {
+  it('keeps all targets when no target is supplied', () => {
+    expect(selectGeneratedExampleTargets()).toEqual(GENERATED_EXAMPLE_TARGETS);
+    expect(generatedExamplesForTargets(GENERATED_EXAMPLE_TARGETS)).toEqual(
+      generatedExamples
+    );
+  });
+
+  it('selects one target and preserves canonical order for mixed targets', () => {
+    expect(selectGeneratedExampleTargets(['go'])).toEqual(['go']);
+    expect(selectGeneratedExampleTargets(['rust', 'go', 'rust'])).toEqual([
+      'go',
+      'rust',
+    ]);
+    expect(
+      generatedExamplesForTargets(['go']).every(
+        ([language]) => language === 'go'
+      )
+    ).toBe(true);
+  });
+
+  it('rejects unsupported targets', () => {
+    expect(() => selectGeneratedExampleTargets(['typescript'])).toThrow(
+      'Unsupported generated-example target(s): typescript'
+    );
+  });
+
+  it('filters MCP compilation by target', () => {
+    const catalog = {
+      all: [
+        { group: 'mcp', language: { runner: 'go' }, sourcePath: 'go-mcp' },
+        {
+          group: 'mcp',
+          language: { runner: 'rust' },
+          sourcePath: 'rust-mcp',
+        },
+        {
+          group: 'generation',
+          language: { runner: 'go' },
+          sourcePath: 'go-generation',
+        },
+      ],
+    };
+
+    expect(generatedMcpExamplesForTargets(catalog, ['go'])).toEqual([
+      catalog.all[0],
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary

- emit target-aware AxIR scope from the CI scope detector, failing open to all five languages for shared or ambiguous changes
- shard generated examples and both perturbation gates by affected language, and reuse the same target list for AxIR verification and real-engine antidotes
- preserve no-argument generated-example behavior while supporting validated positional target filters
- reuse each C++ package/profile build across its example slice while keeping standalone example runs as clean builds

The baseline Generated Examples job on PR #604 took 20m25s even though that change was Go/goja-only. With this change, those paths select only the Go shard; this optimization PR selects all five shards because it changes shared workflow and script inputs.

## Live CI timing

Exact head: `5422a2616279be28eaeb43584b97ae36de72429f`
Run: https://github.com/ax-llm/ax/actions/runs/32829211937

- Go: 1m42s
- Python: 2m41s
- Java: 3m41s
- Rust: 4m15s
- C++: 5m31s
- CI Summary passed 5m57s after the workflow began

All five Generated Examples shards, all five AxIR Verify shards, package freshness, the real-engine antidote, and CI Summary passed.

## Validation

- npm run test:axir:tools
- npm run test:format
- targeted Biome lint for changed scripts
- workflow parse and matrix/CI Summary structure assertions
- npm run build
- npm run axir:check-packages
- generated examples for Python, Java, C++, Go, and Rust, including target-specific MCP compilation
- expectation and response perturbation gates for all five targets
- npm run axir:backlog:check -- --base origin/main --head HEAD

This PR is intentionally left unmerged.