### PR TITLE
fix(go): let hosts read the AxError envelope through errors.As

### DIFF
--- a/packages/go/README.md
+++ b/packages/go/README.md
@@ -38,6 +38,7 @@ func main() {
 - Base package uses the Go standard library for HTTP/process boundaries
 - Optional JavaScript actor execution lives in `runtime/goja` and is opt-in by import
 - An `AIClient` decorator must forward the optional `GetFeatures(model) map[string]Value` method when the wrapped client implements it; otherwise AxGen uses permissive fallback capabilities
+- Failures carry an `AxError` envelope: `ax.AsAxError(err)` or `errors.As(err, &ax.AxError{})` reaches the provider `Status` and `Code`, and `ax.IsRetryable(err)` reports transient failures; `Error()` renders the message alone, so never classify on its wording
 - Network support: available
 
 Shared Ax behavior is Core-owned. The generated target code stays focused on idiomatic wrappers, transports, dynamic value helpers, and host-runtime boundaries. Authentication-required profiles accept a static key or a credential callback; the callback is invoked on every request attempt and its headers override static profile authentication.

--- a/packages/go/axir-provenance.json
+++ b/packages/go/axir-provenance.json
@@ -5,7 +5,7 @@
   "files": {
     "axllm.go": {
       "emitted_lines": 51106,
-      "total_lines": 63160
+      "total_lines": 63190
     }
   }
 }

--- a/packages/go/axllm.go
+++ b/packages/go/axllm.go
@@ -8,6 +8,7 @@ import (
 	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"math"
@@ -80,6 +81,51 @@ func (e AxError) Error() string {
 type SignatureError struct{ AxError }
 type ValidationError struct{ AxError }
 type AIServiceError struct{ AxError }
+
+// Unwrap exposes the embedded envelope so errors.As(err, &AxError{}) reaches
+// Status, Code, and Retryable without the caller having to know which concrete
+// Ax error type carries them. Embedding alone does not satisfy errors.As: the
+// concrete type is SignatureError, not AxError.
+func (e SignatureError) Unwrap() error  { return e.AxError }
+func (e ValidationError) Unwrap() error { return e.AxError }
+func (e AIServiceError) Unwrap() error  { return e.AxError }
+
+// AsAxError returns the structured envelope carried by err, following wrapping.
+// Callers that map Ax failures onto their own error vocabulary should use this
+// rather than matching on Error() text, which renders Message alone and drops
+// the status a provider actually reported.
+func AsAxError(err error) (AxError, bool) {
+	var axErr AxError
+	if errors.As(err, &axErr) {
+		return axErr, true
+	}
+	return AxError{}, false
+}
+
+// IsRetryable reports whether err is a transient failure worth another attempt.
+// Status classification stays Core-owned via is_retryable_status so hosts,
+// balancers, and every generated target agree on the same set.
+func IsRetryable(err error) bool {
+	if err == nil {
+		return false
+	}
+	var serviceErr AIServiceError
+	if errors.As(err, &serviceErr) {
+		switch serviceErr.Type {
+		case "AxAIServiceAuthenticationError":
+			return false
+		case "AxAIServiceStatusError":
+			return coreTruthy(mustCore(is_retryable_status(serviceErr.Status)))
+		case "AxAIServiceNetworkError", "AxAIServiceResponseError", "AxAIServiceStreamTerminatedError", "AxAIServiceTimeoutError":
+			return true
+		}
+		return serviceErr.Retryable
+	}
+	if axErr, ok := AsAxError(err); ok {
+		return axErr.Category == "network" || axErr.Retryable
+	}
+	return false
+}
 
 // coreFlow carries non-local exits (return/break/continue) out of core.try
 // closures in emitted Core functions, mirroring the Rust runtime's CoreFlow
@@ -54356,22 +54402,6 @@ func (b *AxBalancer) canRetryService(service AxAIService) bool {
 }
 func (b *AxBalancer) handleFailure(service AxAIService) { b.serviceFailures[service.GetID()]++ }
 func (b *AxBalancer) handleSuccess(service AxAIService) { delete(b.serviceFailures, service.GetID()) }
-func isRetryableAIError(err error) bool {
-	switch e := err.(type) {
-	case AIServiceError:
-		if e.Type == "AxAIServiceAuthenticationError" {
-			return false
-		}
-		if e.Type == "AxAIServiceStatusError" {
-			return e.Status == 408 || e.Status == 429 || e.Status == 500 || e.Status == 502 || e.Status == 503 || e.Status == 504 || e.Status == 529
-		}
-		return e.Type == "AxAIServiceNetworkError" || e.Type == "AxAIServiceResponseError" || e.Type == "AxAIServiceStreamTerminatedError" || e.Type == "AxAIServiceTimeoutError"
-	case AxError:
-		return e.Category == "network" || e.Retryable
-	default:
-		return false
-	}
-}
 func (b *AxBalancer) candidateServices(request map[string]Value) ([]AxAIService, error) {
 	out := []AxAIService{}
 	model := display(coreGet(request, "model", ""))
@@ -54707,7 +54737,7 @@ func (b *AxBalancer) Chat(ctx context.Context, request map[string]Value, options
 			if ctx.Err() != nil {
 				return nil, err
 			}
-			if !isRetryableAIError(err) {
+			if !IsRetryable(err) {
 				return nil, err
 			}
 			last = err
@@ -54755,7 +54785,7 @@ func (b *AxBalancer) Chat(ctx context.Context, request map[string]Value, options
 			b.handleSuccess(current)
 			return response, nil
 		}
-		if !isRetryableAIError(err) {
+		if !IsRetryable(err) {
 			return nil, err
 		}
 		b.handleFailure(current)
@@ -54797,7 +54827,7 @@ func (b *AxBalancer) Stream(ctx context.Context, request map[string]Value, optio
 			if ctx.Err() != nil {
 				return nil, err
 			}
-			if !isRetryableAIError(err) {
+			if !IsRetryable(err) {
 				return nil, err
 			}
 			last = err

--- a/packages/go/errors_test.go
+++ b/packages/go/errors_test.go
@@ -1,0 +1,74 @@
+package axllm
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+)
+
+// Hosts that map Ax failures onto their own error vocabulary can only see
+// Error(), which renders Message alone and drops the status the provider
+// actually reported. These tests lock the structured path: the envelope stays
+// reachable through every concrete Ax error type and through wrapping, so a
+// host classifies on Status rather than on provider message wording.
+func TestErrorsAsReachesAxErrorThroughServiceError(t *testing.T) {
+	throttled := error(AIServiceError{AxError{
+		Category:  "ai",
+		Type:      "AxAIServiceStatusError",
+		Message:   "Tokens per minute limit exceeded - too many tokens processed.",
+		Status:    429,
+		Code:      "rate_limit_exceeded",
+		Retryable: true,
+	}})
+	cases := map[string]error{
+		"direct":  throttled,
+		"wrapped": fmt.Errorf("chat failed: %w", throttled),
+	}
+	for name, err := range cases {
+		var envelope AxError
+		if !errors.As(err, &envelope) {
+			t.Fatalf("%s: errors.As did not reach the AxError envelope", name)
+		}
+		if envelope.Status != 429 || envelope.Code != "rate_limit_exceeded" || !envelope.Retryable {
+			t.Fatalf("%s: envelope = %+v, want a retryable 429", name, envelope)
+		}
+	}
+}
+
+func TestAsAxErrorReportsEnvelopePresence(t *testing.T) {
+	envelope, ok := AsAxError(ValidationError{AxError{Category: "validation", Message: "bad field"}})
+	if !ok || envelope.Category != "validation" {
+		t.Fatalf("AsAxError(ValidationError) = %+v, %v", envelope, ok)
+	}
+	if envelope, ok := AsAxError(errors.New("plain")); ok {
+		t.Fatalf("AsAxError(plain) = %+v, want no envelope", envelope)
+	}
+	if envelope, ok := AsAxError(nil); ok {
+		t.Fatalf("AsAxError(nil) = %+v, want no envelope", envelope)
+	}
+}
+
+func TestIsRetryableFollowsCoreStatusSet(t *testing.T) {
+	for status, want := range map[int]bool{
+		408: true, 429: true, 500: true, 502: true, 503: true, 504: true, 529: true,
+		400: false, 404: false, 422: false,
+	} {
+		err := error(AIServiceError{AxError{Type: "AxAIServiceStatusError", Status: status}})
+		if got := IsRetryable(err); got != want {
+			t.Fatalf("IsRetryable(status %d) = %v, want %v", status, got, want)
+		}
+	}
+	// Credentials never improve by trying again, whatever status carries them.
+	if IsRetryable(AIServiceError{AxError{Type: "AxAIServiceAuthenticationError", Status: 429}}) {
+		t.Fatal("an authentication failure must not be retryable")
+	}
+	if !IsRetryable(fmt.Errorf("transport: %w", error(AxError{Category: "network"}))) {
+		t.Fatal("a wrapped network failure must be retryable")
+	}
+	if !IsRetryable(AxError{Category: "provider", Retryable: true}) {
+		t.Fatal("an envelope that declares itself retryable must be retryable")
+	}
+	if IsRetryable(nil) || IsRetryable(errors.New("plain")) {
+		t.Fatal("only Ax envelopes classify as retryable")
+	}
+}

--- a/tools/axir/internal/axir/axir_test.go
+++ b/tools/axir/internal/axir/axir_test.go
@@ -958,6 +958,7 @@ func TestCapabilityManifestsAndGeneratedPackageShape(t *testing.T) {
 				"go.mod",
 				"go.sum",
 				"axllm.go",
+				"errors_test.go",
 				"runtime/goja/goja.go",
 				"runtime/goja/goja_test.go",
 				"axir-capabilities.json",
@@ -1213,8 +1214,10 @@ func TestCapabilityManifestsAndGeneratedPackageShape(t *testing.T) {
 			case "go":
 				checkGeneratedFileContains(t, dir, "go.mod", "module github.com/ax-llm/ax/packages/go", "go 1.23", "github.com/dop251/goja", "github.com/coder/websocket")
 				checkGeneratedFileContains(t, dir, "axllm.go", "package axllm", "type Value = any", "func NewSignature", "type HTTPTransport struct")
+				checkGeneratedFileContains(t, dir, "axllm.go", "func AsAxError(err error) (AxError, bool)", "func IsRetryable(err error) bool", "func (e AIServiceError) Unwrap() error")
 				checkGeneratedFileContains(t, dir, "runtime/goja/goja.go", "package goja", "func NewRuntime(options ...Option) *Runtime", "func (r *Runtime) RegisterCallable", "gojavm.New")
 				checkGeneratedFileContains(t, dir, "runtime/goja/goja_test.go", "TestExecuteSurfacesConsoleLogsOnIntermediateStep", "TestExecuteResetsLogsBetweenTurns", "TestConsoleVariantsDoNotThrow")
+				checkGeneratedFileContains(t, dir, "errors_test.go", "TestErrorsAsReachesAxErrorThroughServiceError", "TestAsAxErrorReportsEnvelopePresence", "TestIsRetryableFollowsCoreStatusSet")
 				checkGeneratedFileContains(t, dir, "examples/runtime_profiles/javascript_goja/main.go", "go-javascript-goja-profile-ok", "ax.NewAgent", "agent.Test(runtime", "while (true) {}")
 			case "rust":
 				checkGeneratedFileContains(t, dir, "Cargo.toml", `name = "axllm"`, "reqwest", "rustls-tls", "rquickjs", "runtime-quickjs", `required-features = ["runtime-quickjs"]`, "tungstenite", `realtime = ["dep:tungstenite"]`)

--- a/tools/axir/internal/axir/codegen.go
+++ b/tools/axir/internal/axir/codegen.go
@@ -373,6 +373,7 @@ func EmitGo(model AxRuntimeModel, outDir string) error {
 		"go.sum":                            goSum,
 		"axllm.go":                          renderPackageTemplate(core, version),
 		"mcp.go":                            goMCP,
+		"errors_test.go":                    goErrorBoundaryTest,
 		"runtime/goja/goja.go":              goGojaRuntime,
 		"runtime/goja/goja_test.go":         goGojaRuntimeTest,
 		"axir-capabilities.json":            mustCapabilityManifest(model, "go"),
@@ -2402,6 +2403,7 @@ func packageReadmeConfigForTarget(target string, network string) packageReadmeCo
 				"- Base package uses the Go standard library for HTTP/process boundaries",
 				"- Optional JavaScript actor execution lives in `runtime/goja` and is opt-in by import",
 				"- An `AIClient` decorator must forward the optional `GetFeatures(model) map[string]Value` method when the wrapped client implements it; otherwise AxGen uses permissive fallback capabilities",
+				"- Failures carry an `AxError` envelope: `ax.AsAxError(err)` or `errors.As(err, &ax.AxError{})` reaches the provider `Status` and `Code`, and `ax.IsRetryable(err)` reports transient failures; `Error()` renders the message alone, so never classify on its wording",
 				"- Network support: "+network,
 			),
 			NoKeyExamples: readmeLines(

--- a/tools/axir/internal/axir/templates/go/goErrorBoundaryTest.go.txt
+++ b/tools/axir/internal/axir/templates/go/goErrorBoundaryTest.go.txt
@@ -1,0 +1,74 @@
+package axllm
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+)
+
+// Hosts that map Ax failures onto their own error vocabulary can only see
+// Error(), which renders Message alone and drops the status the provider
+// actually reported. These tests lock the structured path: the envelope stays
+// reachable through every concrete Ax error type and through wrapping, so a
+// host classifies on Status rather than on provider message wording.
+func TestErrorsAsReachesAxErrorThroughServiceError(t *testing.T) {
+	throttled := error(AIServiceError{AxError{
+		Category:  "ai",
+		Type:      "AxAIServiceStatusError",
+		Message:   "Tokens per minute limit exceeded - too many tokens processed.",
+		Status:    429,
+		Code:      "rate_limit_exceeded",
+		Retryable: true,
+	}})
+	cases := map[string]error{
+		"direct":  throttled,
+		"wrapped": fmt.Errorf("chat failed: %w", throttled),
+	}
+	for name, err := range cases {
+		var envelope AxError
+		if !errors.As(err, &envelope) {
+			t.Fatalf("%s: errors.As did not reach the AxError envelope", name)
+		}
+		if envelope.Status != 429 || envelope.Code != "rate_limit_exceeded" || !envelope.Retryable {
+			t.Fatalf("%s: envelope = %+v, want a retryable 429", name, envelope)
+		}
+	}
+}
+
+func TestAsAxErrorReportsEnvelopePresence(t *testing.T) {
+	envelope, ok := AsAxError(ValidationError{AxError{Category: "validation", Message: "bad field"}})
+	if !ok || envelope.Category != "validation" {
+		t.Fatalf("AsAxError(ValidationError) = %+v, %v", envelope, ok)
+	}
+	if envelope, ok := AsAxError(errors.New("plain")); ok {
+		t.Fatalf("AsAxError(plain) = %+v, want no envelope", envelope)
+	}
+	if envelope, ok := AsAxError(nil); ok {
+		t.Fatalf("AsAxError(nil) = %+v, want no envelope", envelope)
+	}
+}
+
+func TestIsRetryableFollowsCoreStatusSet(t *testing.T) {
+	for status, want := range map[int]bool{
+		408: true, 429: true, 500: true, 502: true, 503: true, 504: true, 529: true,
+		400: false, 404: false, 422: false,
+	} {
+		err := error(AIServiceError{AxError{Type: "AxAIServiceStatusError", Status: status}})
+		if got := IsRetryable(err); got != want {
+			t.Fatalf("IsRetryable(status %d) = %v, want %v", status, got, want)
+		}
+	}
+	// Credentials never improve by trying again, whatever status carries them.
+	if IsRetryable(AIServiceError{AxError{Type: "AxAIServiceAuthenticationError", Status: 429}}) {
+		t.Fatal("an authentication failure must not be retryable")
+	}
+	if !IsRetryable(fmt.Errorf("transport: %w", error(AxError{Category: "network"}))) {
+		t.Fatal("a wrapped network failure must be retryable")
+	}
+	if !IsRetryable(AxError{Category: "provider", Retryable: true}) {
+		t.Fatal("an envelope that declares itself retryable must be retryable")
+	}
+	if IsRetryable(nil) || IsRetryable(errors.New("plain")) {
+		t.Fatal("only Ax envelopes classify as retryable")
+	}
+}

--- a/tools/axir/internal/axir/templates/go/goRuntime.go.txt
+++ b/tools/axir/internal/axir/templates/go/goRuntime.go.txt
@@ -8,6 +8,7 @@ import (
 	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"math"
@@ -80,6 +81,51 @@ func (e AxError) Error() string {
 type SignatureError struct{ AxError }
 type ValidationError struct{ AxError }
 type AIServiceError struct{ AxError }
+
+// Unwrap exposes the embedded envelope so errors.As(err, &AxError{}) reaches
+// Status, Code, and Retryable without the caller having to know which concrete
+// Ax error type carries them. Embedding alone does not satisfy errors.As: the
+// concrete type is SignatureError, not AxError.
+func (e SignatureError) Unwrap() error  { return e.AxError }
+func (e ValidationError) Unwrap() error { return e.AxError }
+func (e AIServiceError) Unwrap() error  { return e.AxError }
+
+// AsAxError returns the structured envelope carried by err, following wrapping.
+// Callers that map Ax failures onto their own error vocabulary should use this
+// rather than matching on Error() text, which renders Message alone and drops
+// the status a provider actually reported.
+func AsAxError(err error) (AxError, bool) {
+	var axErr AxError
+	if errors.As(err, &axErr) {
+		return axErr, true
+	}
+	return AxError{}, false
+}
+
+// IsRetryable reports whether err is a transient failure worth another attempt.
+// Status classification stays Core-owned via is_retryable_status so hosts,
+// balancers, and every generated target agree on the same set.
+func IsRetryable(err error) bool {
+	if err == nil {
+		return false
+	}
+	var serviceErr AIServiceError
+	if errors.As(err, &serviceErr) {
+		switch serviceErr.Type {
+		case "AxAIServiceAuthenticationError":
+			return false
+		case "AxAIServiceStatusError":
+			return coreTruthy(mustCore(is_retryable_status(serviceErr.Status)))
+		case "AxAIServiceNetworkError", "AxAIServiceResponseError", "AxAIServiceStreamTerminatedError", "AxAIServiceTimeoutError":
+			return true
+		}
+		return serviceErr.Retryable
+	}
+	if axErr, ok := AsAxError(err); ok {
+		return axErr.Category == "network" || axErr.Retryable
+	}
+	return false
+}
 
 // coreFlow carries non-local exits (return/break/continue) out of core.try
 // closures in emitted Core functions, mirroring the Rust runtime's CoreFlow
@@ -3250,22 +3296,6 @@ func (b *AxBalancer) canRetryService(service AxAIService) bool {
 }
 func (b *AxBalancer) handleFailure(service AxAIService) { b.serviceFailures[service.GetID()]++ }
 func (b *AxBalancer) handleSuccess(service AxAIService) { delete(b.serviceFailures, service.GetID()) }
-func isRetryableAIError(err error) bool {
-	switch e := err.(type) {
-	case AIServiceError:
-		if e.Type == "AxAIServiceAuthenticationError" {
-			return false
-		}
-		if e.Type == "AxAIServiceStatusError" {
-			return e.Status == 408 || e.Status == 429 || e.Status == 500 || e.Status == 502 || e.Status == 503 || e.Status == 504 || e.Status == 529
-		}
-		return e.Type == "AxAIServiceNetworkError" || e.Type == "AxAIServiceResponseError" || e.Type == "AxAIServiceStreamTerminatedError" || e.Type == "AxAIServiceTimeoutError"
-	case AxError:
-		return e.Category == "network" || e.Retryable
-	default:
-		return false
-	}
-}
 func (b *AxBalancer) candidateServices(request map[string]Value) ([]AxAIService, error) {
 	out := []AxAIService{}
 	model := display(coreGet(request, "model", ""))
@@ -3601,7 +3631,7 @@ func (b *AxBalancer) Chat(ctx context.Context, request map[string]Value, options
 			if ctx.Err() != nil {
 				return nil, err
 			}
-			if !isRetryableAIError(err) {
+			if !IsRetryable(err) {
 				return nil, err
 			}
 			last = err
@@ -3649,7 +3679,7 @@ func (b *AxBalancer) Chat(ctx context.Context, request map[string]Value, options
 			b.handleSuccess(current)
 			return response, nil
 		}
-		if !isRetryableAIError(err) {
+		if !IsRetryable(err) {
 			return nil, err
 		}
 		b.handleFailure(current)
@@ -3691,7 +3721,7 @@ func (b *AxBalancer) Stream(ctx context.Context, request map[string]Value, optio
 			if ctx.Err() != nil {
 				return nil, err
 			}
-			if !isRetryableAIError(err) {
+			if !IsRetryable(err) {
 				return nil, err
 			}
 			last = err

--- a/tools/axir/internal/axir/templates_embed.go
+++ b/tools/axir/internal/axir/templates_embed.go
@@ -57,6 +57,9 @@ var goAxGenScriptedClientToolExample string
 //go:embed templates/go/goConformance.go.txt
 var goConformance string
 
+//go:embed templates/go/goErrorBoundaryTest.go.txt
+var goErrorBoundaryTest string
+
 //go:embed templates/go/goMod.mod
 var goMod string
 


### PR DESCRIPTION
## The bug

`AIServiceError` embeds `AxError` rather than wrapping it, so `errors.As(err, &AxError{})` returns **false** for exactly the errors that carry `Status`, `Code`, and `Retryable`:

```
errors.As(AIServiceError, *AxError)        = false   ← the errors with a status in them
errors.As(AIServiceError, *AIServiceError) = true
```

A host holding a fully mapped 429 could still only reach `Error()`, which renders `Message` alone. So hosts classify provider failures by matching message text — and a provider is free to reword its throttle message at any time, at which point a transient rate limit reads as a permanent unrecognized failure. That is not hypothetical: it cost a downstream consumer 236 benchmark episodes, scored as model quality, with a retryable 429 sitting unread in the error the whole time.

`isRetryableAIError` was also unexported, so every consumer reimplements retryability from wording, and its status list was a hardcoded copy of the Core `is_retryable_status` op — free to drift from every other target.

## The fix

In the AxIR Go runtime template (`packages/go/axllm.go` is regenerated from it):

- `Unwrap()` on `SignatureError` / `ValidationError` / `AIServiceError`, so `errors.As(err, &ax.AxError{})` reaches the envelope through any concrete type and through wrapping.
- Exported `AsAxError(err) (AxError, bool)` and `IsRetryable(err) bool`.
- `IsRetryable` takes its status set from the Core `is_retryable_status` op instead of the hardcoded copy; the balancer's three call sites now use the exported helper and the private duplicate is gone.
- The Go README gains one fact: classify on `Status`, never on `Error()` wording.

## Behavior change

An `AIServiceError` whose `Type` is none of the six known strings now honors its own `Retryable` field instead of returning `false`. Unreachable from ax's own constructors today — every one sets a known `Type` — and returning `false` while the struct says `Retryable: true` is the same bug one level down.

## Verification

- new generated test `packages/go/errors_test.go` (from a template, wired into `EmitGo` and the generated-output audits) covering `errors.As` reach, wrapping, the Core status set, and "auth never retries"
- `npm run axir:generate-packages` → only the Go package changes
- `go build` / `go vet` / full `go test ./...` in `packages/go`
- full `go test ./...` in `tools/axir` (~10 min, green)
- `npm run axir:check-packages` → committed packages up to date, verified on this branch's `main` base

🤖 Generated with [Claude Code](https://claude.com/claude-code)
