### PR TITLE
fix(axai): forward the requested embedding size to Gemini

### DIFF
--- a/ir/axcore/provider.axir
+++ b/ir/axcore/provider.axir
@@ -5599,6 +5599,11 @@ module @ax.provider version "0.1" {
         %model_name = core.call intrinsic.string.format("models/{}", %model)
         core.set %item["model"] = %model_name
         core.set %item["content"] = %content
+        %dimensions = core.get %request["dimensions"]
+        %has_dimensions = core.call intrinsic.is_not_none(%dimensions)
+        core.if %has_dimensions {
+          core.set %item["outputDimensionality"] = %dimensions
+        }
         core.append %requests, %item
       }
       core.set %payload["requests"] = %requests

--- a/ir/conformance/axai/gemini-embeddings-output-dimensionality.json
+++ b/ir/conformance/axai/gemini-embeddings-output-dimensionality.json
@@ -1,0 +1,43 @@
+{
+  "embed_model": "gemini-embedding-2",
+  "expected_output": {
+    "embeddings": [[0.1, 0.2]]
+  },
+  "expected_transport_request": {
+    "json": {
+      "requests": [
+        {
+          "content": {
+            "parts": [
+              {
+                "text": "one"
+              }
+            ]
+          },
+          "model": "models/gemini-embedding-2",
+          "outputDimensionality": 512
+        }
+      ]
+    },
+    "url": "https://generativelanguage.googleapis.com/v1beta/models/gemini-embedding-2:batchEmbedContents?key=test-key"
+  },
+  "kind": "ai_embed",
+  "name": "gemini-embeddings-output-dimensionality",
+  "provider": "google-gemini",
+  "request": {
+    "dimensions": 512,
+    "texts": ["one"]
+  },
+  "transport_responses": [
+    {
+      "json": {
+        "embeddings": [
+          {
+            "values": [0.1, 0.2]
+          }
+        ]
+      },
+      "status": 200
+    }
+  ]
+}

--- a/packages/cpp/axir-provenance.json
+++ b/packages/cpp/axir-provenance.json
@@ -4,8 +4,8 @@
   "emitted_functions": 592,
   "files": {
     "axllm/axllm.cpp": {
-      "emitted_lines": 24477,
-      "total_lines": 30868
+      "emitted_lines": 24482,
+      "total_lines": 30873
     }
   }
 }

--- a/packages/cpp/axllm/axllm.cpp
+++ b/packages/cpp/axllm/axllm.cpp
@@ -9667,6 +9667,11 @@ Value Core::_gemini_build_embed_request(Value request) {
     Value model_name = Core::string_format(Value("models/{}"), model);
     Core::set(item, Value("model"), model_name);
     Core::set(item, Value("content"), content);
+    Value dimensions = Core::get(request, Value("dimensions"), Value());
+    Value has_dimensions = Core::is_not_none(dimensions);
+    if (Core::truthy(has_dimensions)) {
+      Core::set(item, Value("outputDimensionality"), dimensions);
+    }
     Core::append(requests, item);
   }
   Core::set(payload, Value("requests"), requests);

--- a/packages/go/axir-provenance.json
+++ b/packages/go/axir-provenance.json
@@ -4,8 +4,8 @@
   "emitted_functions": 592,
   "files": {
     "axllm.go": {
-      "emitted_lines": 51106,
-      "total_lines": 63190
+      "emitted_lines": 51117,
+      "total_lines": 63201
     }
   }
 }

--- a/packages/go/axllm.go
+++ b/packages/go/axllm.go
@@ -17380,7 +17380,9 @@ func _gemini_build_embed_request(args ...Value) (Value, error) {
 	axirCoverageMark("_gemini_build_embed_request")
 	var v_request Value
 	var v_content Value
+	var v_dimensions Value
 	var v_empty_texts Value
+	var v_has_dimensions Value
 	var v_item Value
 	var v_model Value
 	var v_model_name Value
@@ -17393,7 +17395,9 @@ func _gemini_build_embed_request(args ...Value) (Value, error) {
 	if len(args) > 0 { v_request = args[0] }
 	_ = v_request
 	_ = v_content
+	_ = v_dimensions
 	_ = v_empty_texts
+	_ = v_has_dimensions
 	_ = v_item
 	_ = v_model
 	_ = v_model_name
@@ -17419,6 +17423,13 @@ func _gemini_build_embed_request(args ...Value) (Value, error) {
 		v_model_name = _core_string_format("models/{}", v_model)
 		if err := coreSet(v_item, "model", v_model_name); err != nil { return nil, err }
 		if err := coreSet(v_item, "content", v_content); err != nil { return nil, err }
+		v_dimensions = coreGet(v_request, "dimensions", nil)
+		v_has_dimensions = _core_is_not_none(v_dimensions)
+		if coreTruthy(v_has_dimensions) {
+			if err := coreSet(v_item, "outputDimensionality", v_dimensions); err != nil { return nil, err }
+		} else {
+		// empty
+		}
 		v_requests = coreAppend(v_requests, v_item)
 	}
 	if err := coreSet(v_payload, "requests", v_requests); err != nil { return nil, err }

--- a/packages/java/axir-provenance.json
+++ b/packages/java/axir-provenance.json
@@ -4,8 +4,8 @@
   "emitted_functions": 592,
   "files": {
     "dev/axllm/ax/Core.java": {
-      "emitted_lines": 24506,
-      "total_lines": 25803
+      "emitted_lines": 24511,
+      "total_lines": 25808
     }
   }
 }

--- a/packages/java/dev/axllm/ax/Core.java
+++ b/packages/java/dev/axllm/ax/Core.java
@@ -8601,6 +8601,11 @@ final class Core {
       Object model_name = Core.stringFormat("models/{}", model);
       Core.set(item, "model", model_name);
       Core.set(item, "content", content);
+      Object dimensions = Core.get(request, "dimensions", null);
+      Object has_dimensions = Core.isNotNone(dimensions);
+      if (Core.truthy(has_dimensions)) {
+        Core.set(item, "outputDimensionality", dimensions);
+      }
       Core.append(requests, item);
     }
     Core.set(payload, "requests", requests);

--- a/packages/python/axir-provenance.json
+++ b/packages/python/axir-provenance.json
@@ -8,8 +8,8 @@
       "total_lines": 10680
     },
     "axllm/ai.py": {
-      "emitted_lines": 6970,
-      "total_lines": 9170
+      "emitted_lines": 6976,
+      "total_lines": 9176
     },
     "axllm/flow.py": {
       "emitted_lines": 2287,

--- a/packages/python/axllm/ai.py
+++ b/packages/python/axllm/ai.py
@@ -7718,6 +7718,12 @@ def _gemini_build_embed_request(request: AxEmbedRequest) -> Any:
         model_name = _core_string_format("models/{}", model)
         item["model"] = model_name
         item["content"] = content
+        dimensions = _core_get(request, "dimensions", None)
+        has_dimensions = _core_is_not_none(dimensions)
+        if has_dimensions:
+            item["outputDimensionality"] = dimensions
+        else:
+            pass
         requests.append(item)
     payload["requests"] = requests
     return payload

--- a/packages/rust/axir-provenance.json
+++ b/packages/rust/axir-provenance.json
@@ -4,8 +4,8 @@
   "emitted_functions": 592,
   "files": {
     "src/lib.rs": {
-      "emitted_lines": 56424,
-      "total_lines": 79503
+      "emitted_lines": 56435,
+      "total_lines": 79514
     }
   }
 }

--- a/packages/rust/src/lib.rs
+++ b/packages/rust/src/lib.rs
@@ -40209,7 +40209,9 @@ fn _gemini_build_embed_request(args: &[CoreValue]) -> Result<CoreValue, AxError>
     axir_coverage_mark("_gemini_build_embed_request");
     let mut v_request = core_arg(args, 0);
     let mut v_content = CoreValue::Null;
+    let mut v_dimensions = CoreValue::Null;
     let mut v_empty_texts = CoreValue::Null;
+    let mut v_has_dimensions = CoreValue::Null;
     let mut v_item = CoreValue::Null;
     let mut v_model = CoreValue::Null;
     let mut v_model_name = CoreValue::Null;
@@ -40240,6 +40242,15 @@ fn _gemini_build_embed_request(args: &[CoreValue]) -> Result<CoreValue, AxError>
         v_model_name = core_string_format(&[CoreValue::from("models/{}"), v_model.clone()])?;
         core_set(&v_item, CoreValue::from("model"), v_model_name.clone())?;
         core_set(&v_item, CoreValue::from("content"), v_content.clone())?;
+        v_dimensions = core_get(&v_request, &CoreValue::from("dimensions"), CoreValue::Null);
+        v_has_dimensions = core_is_not_none(&[v_dimensions.clone()])?;
+        if core_truthy(&v_has_dimensions) {
+            core_set(
+                &v_item,
+                CoreValue::from("outputDimensionality"),
+                v_dimensions.clone(),
+            )?;
+        }
         core_append(&v_requests, v_item.clone())?;
     }
     core_set(&v_payload, CoreValue::from("requests"), v_requests.clone())?;

--- a/tools/axir/extractors/axai-goldens.ts
+++ b/tools/axir/extractors/axai-goldens.ts
@@ -4840,6 +4840,32 @@ writeFixture('gemini-embeddings', {
   },
 });
 
+writeFixture('gemini-embeddings-output-dimensionality', {
+  kind: 'ai_embed',
+  provider: 'google-gemini',
+  embed_model: geminiDefaultEmbedModel,
+  request: { texts: ['one'], dimensions: 512 },
+  transport_responses: [
+    {
+      status: 200,
+      json: { embeddings: [{ values: [0.1, 0.2] }] },
+    },
+  ],
+  expected_output: { embeddings: [[0.1, 0.2]] },
+  expected_transport_request: {
+    url: `https://generativelanguage.googleapis.com/v1beta/models/${geminiDefaultEmbedModel}:batchEmbedContents?key=test-key`,
+    json: {
+      requests: [
+        {
+          model: `models/${geminiDefaultEmbedModel}`,
+          content: { parts: [{ text: 'one' }] },
+          outputDimensionality: 512,
+        },
+      ],
+    },
+  },
+});
+
 writeFixture('context-cache-rejection', {
   kind: 'ai_context_cache',
   operation: 'rejection',


### PR DESCRIPTION
`_gemini_build_embed_request` dropped `dimensions`, so every generated language posted `batchEmbedContents` without `outputDimensionality` and the provider answered at its own native width.

The Vertex builder directly beside it already forwards the value, and TypeScript forwards it on **both** paths (`src/ax/ai/google-gemini/api.ts:1264` and `:1278`). Only the ported non-Vertex builder was missed — so python, java, cpp, go and rust all shipped it.

Nothing failed loudly: a caller asking for a smaller vector received a full-width one and no error. Downstream that reads as a setting that silently does nothing — GraphJin's `dimensions: tiny` asked for 128 and indexed at 3072 — and, where the host treats the returned width as a contract, as the feature refusing to start at all.

The guard matches the Vertex builder: send the field only when the request carries one, so payloads without a size are byte-identical to before.

## Coverage

No conformance fixture set `dimensions` for **any** provider, which is how this shipped. `gemini-embeddings-output-dimensionality` covers it, and it was validated against the unfixed builder before being kept:

```
panic: gemini-embeddings-output-dimensionality: transport request subset mismatch
```

`npm run test:axir` is green, and the new fixture runs and passes in all five languages (5/5 `ok gemini-embeddings-output-dimensionality`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)