### PR TITLE
fix(release): publish merged releases automatically

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -1,0 +1,38 @@
+name: Publish merged release
+
+on:
+  workflow_run:
+    workflows: ['Build and Test']
+    types: [completed]
+    branches: [main]
+
+permissions:
+  actions: write
+  checks: read
+  contents: write
+  pull-requests: read
+  statuses: read
+
+jobs:
+  publish:
+    if: >-
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'push'
+    runs-on: ubuntu-latest
+    concurrency:
+      group: publish-merged-release-${{ github.event.workflow_run.head_sha }}
+      cancel-in-progress: false
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
+          fetch-depth: 0
+      - name: Configure release tag identity
+        run: |
+          git config user.name github-actions[bot]
+          git config user.email 41898282+github-actions[bot]@users.noreply.github.com
+      - name: Publish merged release commit
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_SHA: ${{ github.event.workflow_run.head_sha }}
+        run: node scripts/release.mjs publish-merged "$RELEASE_SHA"

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -36,15 +36,21 @@ the generated packages, creates the release commit, validates it, pushes the
 branch, and opens a pull request. It intentionally does not tag, push directly
 to `main`, or create a GitHub Release.
 
-After the release pull request passes the required checks and is merged, run
-`npm run release:publish -- <version>` from the synchronized `main` branch.
-The publish phase checks the requested tag directly on the remote; unrelated
+After the release pull request passes the required checks and is merged, the
+`Publish merged release` workflow waits for the merge commit's main-branch
+`Build and Test` run to succeed. It then verifies that the commit is a merged,
+version-aligned release, pushes an annotated tag, creates the GitHub Release,
+and explicitly dispatches the npm and generated-package publication workflows
+at that exact tag. Explicit dispatch is required because GitHub does not start
+new workflows for ordinary events created with a workflow's `GITHUB_TOKEN`.
+
+`npm run release:publish -- <version>` remains the guarded recovery path. Run it
+from a clean, synchronized `main` branch if the automatic workflow needs manual
+recovery. It checks the requested tag directly on the remote, resolves the
+matching release commit from protected `main` history even if newer commits have
+landed, verifies its merged pull request and required checks, replaces any stale
+local tag, pushes the annotated tag, and creates the GitHub Release. Unrelated
 historical local tags do not need to be cleaned up first.
-The publish phase verifies that the release reached `main` through a merged
-pull request with passing required checks, replaces any stale local tag left by
-an older failed release attempt, pushes an annotated tag for the merged commit,
-and creates the GitHub Release. Publishing workflows then upload the registry
-packages from that exact tag.
 
 Generated package source is checked in under `packages/<language>`. Built
 registry artifacts, such as Python wheels, source distributions, Rust cargo
@@ -73,14 +79,19 @@ npm run release -- minor
 npm run release -- 25.0.0
 ```
 
-Once the release pull request is merged and `main` is synchronized, publish the
-same version:
+Once the release pull request is merged, wait for `Publish merged release` and
+both package publication workflows to pass. For manual recovery only, synchronize
+`main` and publish the missed version:
 
 ```bash
 git switch main
 git pull --ff-only origin main
 npm run release:publish -- 24.0.6
 ```
+
+The recovery command also works after `main` has advanced to a newer release;
+it finds the unique matching release commit in protected `main` history rather
+than tagging the newer tip.
 
 Never rerun `npm run release` to recover a rejected push. The preparation
 command refuses to run from an unsynchronized or dirty branch, and the root

--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -16,6 +16,15 @@ const releaseManifests = [
   'src/tools/package.json',
 ];
 const stableVersionPattern = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/;
+const releaseSubjectPattern =
+  /^chore: release v((?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*))(?: \(#\d+\))?$/;
+const publicationWorkflows = [
+  { file: 'npm-publish.yml', fields: [] },
+  {
+    file: 'package-publish.yml',
+    fields: ['--raw-field', 'dry_run=false'],
+  },
+];
 
 function commandText(command, args) {
   return [command, ...args].join(' ');
@@ -69,6 +78,15 @@ export function readReleaseVersions(root = repoRoot) {
   return Object.fromEntries(
     releaseManifests.map((file) => {
       const manifest = JSON.parse(readFileSync(path.join(root, file), 'utf8'));
+      return [file, manifest.version];
+    })
+  );
+}
+
+function readReleaseVersionsAt(ref) {
+  return Object.fromEntries(
+    releaseManifests.map((file) => {
+      const manifest = JSON.parse(git('show', `${ref}:${file}`));
       return [file, manifest.version];
     })
   );
@@ -133,6 +151,28 @@ export function releaseBranchName(version) {
   return `codex/release-${version.replaceAll('.', '-')}`;
 }
 
+export function releaseVersionFromSubject(subject) {
+  return releaseSubjectPattern.exec(subject)?.[1] || null;
+}
+
+export function selectReleaseCommit(version, commits) {
+  parseStableVersion(version, 'release version');
+  const matches = commits.filter(
+    ({ subject }) => releaseVersionFromSubject(subject) === version
+  );
+  if (matches.length === 0) {
+    fail(`Release ${version} is not present in origin/${mainBranch} history.`);
+  }
+  if (matches.length > 1) {
+    fail(
+      `Release ${version} has multiple commits in origin/${mainBranch} history:\n${matches
+        .map(({ sha }) => `- ${sha}`)
+        .join('\n')}`
+    );
+  }
+  return matches[0].sha;
+}
+
 function localRefExists(ref) {
   return attempt('git', ['show-ref', '--verify', '--quiet', ref]).status === 0;
 }
@@ -163,6 +203,20 @@ function remoteTagTarget(version) {
     remoteRefs(`refs/tags/${version}`, `refs/tags/${version}^{}`),
     version
   );
+}
+
+function releaseCommitOnMain(version) {
+  const commits = git('log', `origin/${mainBranch}`, '--format=%H%x00%s')
+    .split('\n')
+    .filter(Boolean)
+    .map((line) => {
+      const separator = line.indexOf('\0');
+      return {
+        sha: line.slice(0, separator),
+        subject: line.slice(separator + 1),
+      };
+    });
+  return selectReleaseCommit(version, commits);
 }
 
 function assertRefAvailable(version, branch) {
@@ -224,7 +278,8 @@ function releasePullRequestBody(version) {
     '- updates the changelog',
     '- creates no tag or GitHub Release before merge',
     '',
-    'After merge, publish with:',
+    'After merge, successful main-branch CI publishes this release automatically.',
+    'If that automation needs recovery, publish with:',
     '',
     '```sh',
     `npm run release:publish -- ${version}`,
@@ -234,11 +289,16 @@ function releasePullRequestBody(version) {
 
 export function parseReleaseArguments(argv) {
   const [mode = 'prepare', value, ...rest] = argv;
-  if (!['prepare', 'publish'].includes(mode) || rest.length > 0) {
+  if (
+    !['prepare', 'publish', 'publish-merged'].includes(mode) ||
+    rest.length > 0
+  ) {
     fail(
-      'Usage: release.mjs prepare [patch|minor|major|VERSION] | publish [VERSION]'
+      'Usage: release.mjs prepare [patch|minor|major|VERSION] | publish [VERSION] | publish-merged SHA'
     );
   }
+  if (mode === 'publish-merged' && !value)
+    fail('publish-merged requires a SHA.');
   return { mode, value };
 }
 
@@ -283,7 +343,9 @@ function prepare(increment = 'patch') {
     releasePullRequestBody(version),
   ]);
   console.log(`\nRelease ${version} prepared: ${url}`);
-  console.log(`After it merges, run: npm run release:publish -- ${version}`);
+  console.log(
+    `After it merges, successful main-branch CI will publish ${version} automatically.`
+  );
 }
 
 function githubReleaseExists(version) {
@@ -331,31 +393,19 @@ function recreateLocalTag(version, head) {
   ]);
 }
 
-function publish(requestedVersion) {
-  assertClean();
-  assertBranch(mainBranch);
-  // Remote tag identity is checked with ls-remote below. Fetching every tag can
-  // fail when a checkout still has a pre-squash tag from an older release.
-  run('git', publishFetchArguments());
-  const head = git('rev-parse', 'HEAD');
-  const remoteHead = git('rev-parse', `origin/${mainBranch}`);
-  if (head !== remoteHead) {
-    fail(
-      `Local ${mainBranch} (${head}) must exactly match origin/${mainBranch} (${remoteHead}).`
-    );
+function assertReleaseCommit(version, head) {
+  const subject = git('log', '-1', '--format=%s', head);
+  const subjectVersion = releaseVersionFromSubject(subject);
+  if (subjectVersion !== version) {
+    fail(`Commit ${head} is not the ${version} release commit: ${subject}`);
   }
-
-  const version =
-    requestedVersion || assertAlignedReleaseVersions(readReleaseVersions());
-  parseStableVersion(version, 'release version');
-  const aligned = assertAlignedReleaseVersions(readReleaseVersions());
-  if (aligned !== version)
-    fail(`Package version is ${aligned}; requested ${version}.`);
-  const subject = git('log', '-1', '--format=%s');
-  if (!subject.startsWith(`chore: release v${version}`)) {
-    fail(`HEAD is not the ${version} release commit: ${subject}`);
+  const aligned = assertAlignedReleaseVersions(readReleaseVersionsAt(head));
+  if (aligned !== version) {
+    fail(`Package version at ${head} is ${aligned}; expected ${version}.`);
   }
+}
 
+function ensureRelease(version, head) {
   const existingRemoteTagTarget = remoteTagTarget(version);
   if (existingRemoteTagTarget && existingRemoteTagTarget !== head) {
     fail(
@@ -388,15 +438,111 @@ function publish(requestedVersion) {
     );
   }
   run('gh', ['release', 'view', version]);
+}
+
+function publicationRuns(workflow, head) {
+  return JSON.parse(
+    capture(
+      'gh',
+      [
+        'run',
+        'list',
+        '--workflow',
+        workflow,
+        '--commit',
+        head,
+        '--limit',
+        '20',
+        '--json',
+        'databaseId,status,conclusion,event,url',
+      ],
+      { quiet: true }
+    )
+  );
+}
+
+function dispatchPublicationWorkflows(version, head) {
+  for (const { file, fields } of publicationWorkflows) {
+    const existing = publicationRuns(file, head);
+    if (existing.length > 0) {
+      console.log(
+        `Publication workflow ${file} already has a run for ${head}; skipping duplicate dispatch.`
+      );
+      continue;
+    }
+    run('gh', ['workflow', 'run', file, '--ref', version, ...fields]);
+  }
+}
+
+function publish(requestedVersion) {
+  assertClean();
+  assertBranch(mainBranch);
+  // Remote tag identity is checked with ls-remote below. Fetching every tag can
+  // fail when a checkout still has a pre-squash tag from an older release.
+  run('git', publishFetchArguments());
+  const currentHead = git('rev-parse', 'HEAD');
+  const remoteHead = git('rev-parse', `origin/${mainBranch}`);
+  if (currentHead !== remoteHead) {
+    fail(
+      `Local ${mainBranch} (${currentHead}) must exactly match origin/${mainBranch} (${remoteHead}).`
+    );
+  }
+
+  const version =
+    requestedVersion || assertAlignedReleaseVersions(readReleaseVersions());
+  parseStableVersion(version, 'release version');
+  const currentSubject = git('log', '-1', '--format=%s', currentHead);
+  const head =
+    releaseVersionFromSubject(currentSubject) === version
+      ? currentHead
+      : releaseCommitOnMain(version);
+  assertReleaseCommit(version, head);
+  ensureRelease(version, head);
   console.log(
     `\nRelease ${version} published from protected ${mainBranch} commit ${head}.`
+  );
+}
+
+function publishMerged(head) {
+  if (!/^[0-9a-f]{40}$/.test(head)) fail(`Invalid release commit SHA: ${head}`);
+  const checkoutHead = git('rev-parse', 'HEAD');
+  if (checkoutHead !== head) {
+    fail(
+      `Workflow checkout is ${checkoutHead}; expected release commit ${head}.`
+    );
+  }
+
+  const subject = git('log', '-1', '--format=%s', head);
+  const version = releaseVersionFromSubject(subject);
+  if (!version) {
+    console.log(`Commit ${head} is not a release commit; nothing to publish.`);
+    return;
+  }
+
+  run('git', publishFetchArguments());
+  const ancestry = attempt('git', [
+    'merge-base',
+    '--is-ancestor',
+    head,
+    `origin/${mainBranch}`,
+  ]);
+  if (ancestry.status !== 0) {
+    fail(`Release commit ${head} is not contained in origin/${mainBranch}.`);
+  }
+
+  assertReleaseCommit(version, head);
+  ensureRelease(version, head);
+  dispatchPublicationWorkflows(version, head);
+  console.log(
+    `\nRelease ${version} automatically published from protected ${mainBranch} commit ${head}.`
   );
 }
 
 function main(argv) {
   const { mode, value } = parseReleaseArguments(argv);
   if (mode === 'prepare') prepare(value);
-  else publish(value);
+  else if (mode === 'publish') publish(value);
+  else publishMerged(value);
 }
 
 const invokedPath = process.argv[1] ? path.resolve(process.argv[1]) : '';

--- a/scripts/release.test.js
+++ b/scripts/release.test.js
@@ -10,7 +10,9 @@ import {
   parseRemoteTagTarget,
   publishFetchArguments,
   releaseBranchName,
+  releaseVersionFromSubject,
   resolveReleaseVersion,
+  selectReleaseCommit,
 } from './release.mjs';
 
 const repoRoot = path.resolve(
@@ -48,6 +50,33 @@ describe('protected-main release workflow', () => {
     expect(releaseBranchName('24.0.6')).toBe('codex/release-24-0-6');
   });
 
+  it.each([
+    ['chore: release v24.0.11', '24.0.11'],
+    ['chore: release v24.0.11 (#614)', '24.0.11'],
+    ['fix: release v24.0.11', null],
+    ['chore: release v24.0.11 unexpectedly', null],
+    ['chore: release v24.0.11-rc.1', null],
+  ])('extracts a release version from %j', (subject, expected) => {
+    expect(releaseVersionFromSubject(subject)).toBe(expected);
+  });
+
+  it('resolves a missed historical release commit unambiguously', () => {
+    expect(
+      selectReleaseCommit('24.0.9', [
+        { sha: 'newer', subject: 'chore: release v24.0.10 (#613)' },
+        { sha: 'release', subject: 'chore: release v24.0.9 (#611)' },
+        { sha: 'feature', subject: 'feat: something else' },
+      ])
+    ).toBe('release');
+    expect(() => selectReleaseCommit('24.0.8', [])).toThrow(/not present/);
+    expect(() =>
+      selectReleaseCommit('24.0.9', [
+        { sha: 'one', subject: 'chore: release v24.0.9 (#611)' },
+        { sha: 'two', subject: 'chore: release v24.0.9' },
+      ])
+    ).toThrow(/multiple commits/);
+  });
+
   it('resolves annotated and lightweight remote tags to their release commit', () => {
     expect(
       parseRemoteTagTarget(
@@ -64,7 +93,7 @@ describe('protected-main release workflow', () => {
     expect(parseRemoteTagTarget('', '24.0.6')).toBeNull();
   });
 
-  it('parses only the prepare and publish phases', () => {
+  it('parses only the guarded release phases', () => {
     expect(parseReleaseArguments(['prepare', 'minor'])).toEqual({
       mode: 'prepare',
       value: 'minor',
@@ -73,6 +102,13 @@ describe('protected-main release workflow', () => {
       mode: 'publish',
       value: '24.0.6',
     });
+    expect(parseReleaseArguments(['publish-merged', 'a'.repeat(40)])).toEqual({
+      mode: 'publish-merged',
+      value: 'a'.repeat(40),
+    });
+    expect(() => parseReleaseArguments(['publish-merged'])).toThrow(
+      /requires a SHA/
+    );
     expect(() => parseReleaseArguments(['ship'])).toThrow(/Usage/);
   });
 
@@ -106,6 +142,25 @@ describe('protected-main release workflow', () => {
     expect(manifest.scripts.release).toBe('node scripts/release.mjs prepare');
     expect(manifest.scripts['release:publish']).toBe(
       'node scripts/release.mjs publish'
+    );
+  });
+
+  it('publishes merged release commits after successful main CI', () => {
+    const workflow = readFileSync(
+      path.join(repoRoot, '.github', 'workflows', 'release-publish.yml'),
+      'utf8'
+    );
+    expect(workflow).toContain('workflow_run:');
+    expect(workflow).toContain("workflows: ['Build and Test']");
+    expect(workflow).toContain('branches: [main]');
+    expect(workflow).toContain(
+      "github.event.workflow_run.conclusion == 'success'"
+    );
+    expect(workflow).toContain("github.event.workflow_run.event == 'push'");
+    expect(workflow).toContain('actions: write');
+    expect(workflow).toContain('contents: write');
+    expect(workflow).toContain(
+      'node scripts/release.mjs publish-merged "$RELEASE_SHA"'
     );
   });
 });


### PR DESCRIPTION
## Summary

- publish release commits automatically after their main Build and Test run succeeds
- explicitly dispatch npm and generated-package workflows at the exact tag
- let the manual recovery command resolve missed historical releases after main advances
- keep tag, merged-PR, required-check, and aligned-version safeguards

## Verification

- npm run test:release-workflow
- npm run test:contribution-policy
- npm run axir:backlog:validate
- npm run test:format
- npm run test:lint
- npm run test:spelling
- workflow YAML parse
- git diff --check