### PR TITLE
fix(go): surface HTTP errors from embed, transcribe and speak

### DIFF
--- a/ir/conformance/axai/gemini-embed-rate-limit-surfaces-error.json
+++ b/ir/conformance/axai/gemini-embed-rate-limit-surfaces-error.json
@@ -1,0 +1,23 @@
+{
+  "embed_model": "gemini-embedding-2",
+  "expected_error_contains": "prepayment credits are depleted",
+  "expected_status": 429,
+  "kind": "ai_error",
+  "method": "embed",
+  "name": "gemini-embed-rate-limit-surfaces-error",
+  "provider": "google-gemini",
+  "request": {
+    "texts": ["one"]
+  },
+  "transport_responses": [
+    {
+      "json": {
+        "error": {
+          "message": "Your prepayment credits are depleted",
+          "status": "RESOURCE_EXHAUSTED"
+        }
+      },
+      "status": 429
+    }
+  ]
+}

--- a/ir/conformance/axai/openai-speak-error-surfaces-error.json
+++ b/ir/conformance/axai/openai-speak-error-surfaces-error.json
@@ -1,0 +1,22 @@
+{
+  "expected_error_contains": "voice synthesis unavailable",
+  "expected_status": 503,
+  "kind": "ai_error",
+  "method": "speak",
+  "name": "openai-speak-error-surfaces-error",
+  "request": {
+    "format": "mp3",
+    "text": "hello",
+    "voice": "alloy"
+  },
+  "transport_responses": [
+    {
+      "json": {
+        "error": {
+          "message": "voice synthesis unavailable"
+        }
+      },
+      "status": 503
+    }
+  ]
+}

--- a/ir/conformance/axai/openai-transcribe-error-surfaces-error.json
+++ b/ir/conformance/axai/openai-transcribe-error-surfaces-error.json
@@ -1,0 +1,23 @@
+{
+  "expected_error_contains": "transcription backend unavailable",
+  "expected_status": 500,
+  "kind": "ai_error",
+  "method": "transcribe",
+  "name": "openai-transcribe-error-surfaces-error",
+  "request": {
+    "audio": "base64-audio",
+    "format": "json",
+    "language": "en",
+    "model": "whisper-1"
+  },
+  "transport_responses": [
+    {
+      "json": {
+        "error": {
+          "message": "transcription backend unavailable"
+        }
+      },
+      "status": 500
+    }
+  ]
+}

--- a/packages/go/axllm.go
+++ b/packages/go/axllm.go
@@ -53298,7 +53298,7 @@ func (c *OpenAICompatibleClient) Embed(ctx context.Context, request map[string]V
 		if err != nil {
 			panic(AxError{Category: "network", Message: err.Error()})
 		}
-		return mustCore(provider_normalize_embed_response(c.Profile, coreGet(raw, "json", raw), c.Name, model))
+		return mustCore(provider_normalize_embed_response(c.Profile, normalizeTransportPayload(raw), c.Name, model))
 	})
 	if err == nil {
 		emitUsageEvent("embed", response, mergedOptions, false)
@@ -53484,7 +53484,7 @@ func (c *OpenAICompatibleClient) Transcribe(ctx context.Context, request map[str
 		if err != nil {
 			panic(AxError{Category: "network", Message: err.Error()})
 		}
-		return mustCore(provider_normalize_transcribe_response(c.Profile, coreGet(raw, "json", raw)))
+		return mustCore(provider_normalize_transcribe_response(c.Profile, normalizeTransportPayload(raw)))
 	})
 }
 func (c *OpenAICompatibleClient) Speak(ctx context.Context, request map[string]Value, options map[string]Value) (Value, error) {
@@ -53494,7 +53494,7 @@ func (c *OpenAICompatibleClient) Speak(ctx context.Context, request map[string]V
 		if err != nil {
 			panic(AxError{Category: "network", Message: err.Error()})
 		}
-		return mustCore(provider_normalize_speak_response(c.Profile, coreGet(raw, "json", raw), request))
+		return mustCore(provider_normalize_speak_response(c.Profile, normalizeTransportPayload(raw), request))
 	})
 }
 func (c *OpenAICompatibleClient) RealtimeAudioSetup(request map[string]Value, options map[string]Value) Value {

--- a/tools/axir/extractors/axai-goldens.ts
+++ b/tools/axir/extractors/axai-goldens.ts
@@ -4866,6 +4866,64 @@ writeFixture('gemini-embeddings-output-dimensionality', {
   },
 });
 
+// The Go runtime handed embed/transcribe/speak responses straight to the
+// normalizer without the status check chat performs, so a 4xx/5xx body -- which
+// carries no results -- normalized to an empty success. A depleted-credits 429
+// reached the caller as "no embeddings" with no error at all.
+writeFixture('gemini-embed-rate-limit-surfaces-error', {
+  kind: 'ai_error',
+  method: 'embed',
+  provider: 'google-gemini',
+  embed_model: geminiDefaultEmbedModel,
+  request: { texts: ['one'] },
+  transport_responses: [
+    {
+      status: 429,
+      json: {
+        error: {
+          message: 'Your prepayment credits are depleted',
+          status: 'RESOURCE_EXHAUSTED',
+        },
+      },
+    },
+  ],
+  expected_error_contains: 'prepayment credits are depleted',
+  expected_status: 429,
+});
+
+writeFixture('openai-transcribe-error-surfaces-error', {
+  kind: 'ai_error',
+  method: 'transcribe',
+  request: {
+    audio: 'base64-audio',
+    format: 'json',
+    language: 'en',
+    model: 'whisper-1',
+  },
+  transport_responses: [
+    {
+      status: 500,
+      json: { error: { message: 'transcription backend unavailable' } },
+    },
+  ],
+  expected_error_contains: 'transcription backend unavailable',
+  expected_status: 500,
+});
+
+writeFixture('openai-speak-error-surfaces-error', {
+  kind: 'ai_error',
+  method: 'speak',
+  request: { format: 'mp3', text: 'hello', voice: 'alloy' },
+  transport_responses: [
+    {
+      status: 503,
+      json: { error: { message: 'voice synthesis unavailable' } },
+    },
+  ],
+  expected_error_contains: 'voice synthesis unavailable',
+  expected_status: 503,
+});
+
 writeFixture('context-cache-rejection', {
   kind: 'ai_context_cache',
   operation: 'rejection',

--- a/tools/axir/internal/axir/templates/go/goRuntime.go.txt
+++ b/tools/axir/internal/axir/templates/go/goRuntime.go.txt
@@ -2181,7 +2181,7 @@ func (c *OpenAICompatibleClient) Embed(ctx context.Context, request map[string]V
 		if err != nil {
 			panic(AxError{Category: "network", Message: err.Error()})
 		}
-		return mustCore(provider_normalize_embed_response(c.Profile, coreGet(raw, "json", raw), c.Name, model))
+		return mustCore(provider_normalize_embed_response(c.Profile, normalizeTransportPayload(raw), c.Name, model))
 	})
 	if err == nil {
 		emitUsageEvent("embed", response, mergedOptions, false)
@@ -2367,7 +2367,7 @@ func (c *OpenAICompatibleClient) Transcribe(ctx context.Context, request map[str
 		if err != nil {
 			panic(AxError{Category: "network", Message: err.Error()})
 		}
-		return mustCore(provider_normalize_transcribe_response(c.Profile, coreGet(raw, "json", raw)))
+		return mustCore(provider_normalize_transcribe_response(c.Profile, normalizeTransportPayload(raw)))
 	})
 }
 func (c *OpenAICompatibleClient) Speak(ctx context.Context, request map[string]Value, options map[string]Value) (Value, error) {
@@ -2377,7 +2377,7 @@ func (c *OpenAICompatibleClient) Speak(ctx context.Context, request map[string]V
 		if err != nil {
 			panic(AxError{Category: "network", Message: err.Error()})
 		}
-		return mustCore(provider_normalize_speak_response(c.Profile, coreGet(raw, "json", raw), request))
+		return mustCore(provider_normalize_speak_response(c.Profile, normalizeTransportPayload(raw), request))
 	})
 }
 func (c *OpenAICompatibleClient) RealtimeAudioSetup(request map[string]Value, options map[string]Value) Value {


### PR DESCRIPTION
The Go runtime's `Chat` path runs the transport response through `normalizeTransportPayload`, which raises for `status >= 400`. `Embed`, `Transcribe` and `Speak` instead took `coreGet(raw, "json", raw)` and handed the body straight to the normalizer. An error body carries no results, so the normalizer found nothing to read and returned an **empty success**.

A rate-limited or unpaid account therefore looked like a working call that found nothing. A real 429 reached the caller as `err == nil` with an empty embeddings array:

```
HTTP 429 RESOURCE_EXHAUSTED — "Your prepayment credits are depleted"
  ↓
err=<nil>  value=map["embeddings":(*axllm.AxArray)]   // empty
```

The host then invents a message from what it can see. GraphJin reported `embedding batch returned 0 vectors for 64 documents` — which names nothing an operator can act on, and sent us looking for a bug in our own batching before we thought to curl the endpoint.

## Go-only

Python's `_transport_result`, and the Java, C++ and Rust equivalents, all raise on `status >= 400` for every operation. Regenerating confirms it: **only `packages/go/axllm.go` changes.**

## Coverage

Three cases — 429 on embed, 500 on transcribe, 503 on speak. Each was run against the unfixed builder first:

```
panic: gemini-embed-rate-limit-surfaces-error: expected AI call to fail
panic: openai-transcribe-error-surfaces-error: expected AI call to fail
panic: openai-speak-error-surfaces-error: expected AI call to fail
```

`npm run test:axir` is green, and all three fixtures run and pass in all five languages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)