### PR TITLE
fix(java): allow slower Maven Central publishes

### DIFF
--- a/packages/java/pom.xml
+++ b/packages/java/pom.xml
@@ -146,6 +146,8 @@
               <publishingServerId>central</publishingServerId>
               <autoPublish>true</autoPublish>
               <waitUntil>published</waitUntil>
+              <!-- Central can exceed the plugin's 30-minute default under load. -->
+              <waitMaxTime>7200</waitMaxTime>
             </configuration>
           </plugin>
         </plugins>

--- a/tools/axir/internal/axir/templates/package/javaPomXML.xml
+++ b/tools/axir/internal/axir/templates/package/javaPomXML.xml
@@ -146,6 +146,8 @@
               <publishingServerId>central</publishingServerId>
               <autoPublish>true</autoPublish>
               <waitUntil>published</waitUntil>
+              <!-- Central can exceed the plugin's 30-minute default under load. -->
+              <waitMaxTime>7200</waitMaxTime>
             </configuration>
           </plugin>
         </plugins>


### PR DESCRIPTION
## Summary

- allow Maven Central publishing to wait up to two hours for the published state
- keep the checked-in Java POM synchronized with its AxIR generator template
- avoid false release failures when Sonatype exceeds the plugin's 30-minute default

## Verification

- npm run axir:check-packages
- mvn -B -ntp -Prelease -DskipTests validate
- xmllint --noout packages/java/pom.xml tools/axir/internal/axir/templates/package/javaPomXML.xml
- git diff --check

The 24.0.11 deployment uploaded successfully and later became available on Maven Central after the original workflow timed out.