### PR TITLE
fix(gemini): send the thinking config the port never built

### DIFF
--- a/ir/axcore/provider.axir
+++ b/ir/axcore/provider.axir
@@ -5392,6 +5392,25 @@ module @ax.provider version "0.1" {
       core.call @openai_copy_config_key_impl(%payload, %model_config, "n", "candidateCount")
       core.call @openai_copy_config_key_impl(%payload, %model_config, "stopSequences", "stopSequences")
       core.call @openai_copy_config_key_impl(%payload, %model_config, "stop_sequences", "stopSequences")
+      %thinking_config = core.map
+      %has_thinking = core.let false
+      %budget_snake = core.get %model_config["thinking_token_budget"]
+      %budget = core.get %model_config["thinkingTokenBudget"] default %budget_snake
+      %has_budget = core.call intrinsic.is_not_none(%budget)
+      core.if %has_budget {
+        core.set %thinking_config["thinkingBudget"] = %budget
+        %has_thinking = core.let true
+      }
+      %show_snake = core.get %model_config["show_thoughts"]
+      %show_thoughts = core.get %model_config["showThoughts"] default %show_snake
+      %has_show = core.call intrinsic.is_not_none(%show_thoughts)
+      core.if %has_show {
+        core.set %thinking_config["includeThoughts"] = %show_thoughts
+        %has_thinking = core.let true
+      }
+      core.if %has_thinking {
+        core.set %payload["thinkingConfig"] = %thinking_config
+      }
       core.return
     }
   }

--- a/ir/conformance/axai/gemini-thinking-config-reaches-the-request.json
+++ b/ir/conformance/axai/gemini-thinking-config-reaches-the-request.json
@@ -1,0 +1,48 @@
+{
+  "expected_transport_request": {
+    "json": {
+      "generationConfig": {
+        "thinkingConfig": {
+          "includeThoughts": true,
+          "thinkingBudget": 2048
+        }
+      }
+    }
+  },
+  "kind": "ai_chat",
+  "model": "gemini-3.5-flash",
+  "name": "gemini-thinking-config-reaches-the-request",
+  "provider": "google-gemini",
+  "request": {
+    "chat_prompt": [
+      {
+        "content": "think about this",
+        "role": "user"
+      }
+    ],
+    "model_config": {
+      "showThoughts": true,
+      "stream": false,
+      "thinkingTokenBudget": 2048
+    }
+  },
+  "transport_responses": [
+    {
+      "json": {
+        "candidates": [
+          {
+            "content": {
+              "parts": [
+                {
+                  "text": "ok"
+                }
+              ]
+            },
+            "finishReason": "STOP"
+          }
+        ]
+      },
+      "status": 200
+    }
+  ]
+}

--- a/packages/cpp/axir-provenance.json
+++ b/packages/cpp/axir-provenance.json
@@ -4,8 +4,8 @@
   "emitted_functions": 593,
   "files": {
     "axllm/axllm.cpp": {
-      "emitted_lines": 24527,
-      "total_lines": 31263
+      "emitted_lines": 24546,
+      "total_lines": 31282
     }
   }
 }

--- a/packages/cpp/axllm/axllm.cpp
+++ b/packages/cpp/axllm/axllm.cpp
@@ -9493,6 +9493,25 @@ Value Core::_gemini_apply_model_config_impl(Value payload, Value model_config, V
   Core::_openai_copy_config_key_impl(payload, model_config, Value("n"), Value("candidateCount"));
   Core::_openai_copy_config_key_impl(payload, model_config, Value("stopSequences"), Value("stopSequences"));
   Core::_openai_copy_config_key_impl(payload, model_config, Value("stop_sequences"), Value("stopSequences"));
+  Value thinking_config = Value::object();
+  Value has_thinking = Value(false);
+  Value budget_snake = Core::get(model_config, Value("thinking_token_budget"), Value());
+  Value budget = Core::get(model_config, Value("thinkingTokenBudget"), budget_snake);
+  Value has_budget = Core::is_not_none(budget);
+  if (Core::truthy(has_budget)) {
+    Core::set(thinking_config, Value("thinkingBudget"), budget);
+    has_thinking = Value(true);
+  }
+  Value show_snake = Core::get(model_config, Value("show_thoughts"), Value());
+  Value show_thoughts = Core::get(model_config, Value("showThoughts"), show_snake);
+  Value has_show = Core::is_not_none(show_thoughts);
+  if (Core::truthy(has_show)) {
+    Core::set(thinking_config, Value("includeThoughts"), show_thoughts);
+    has_thinking = Value(true);
+  }
+  if (Core::truthy(has_thinking)) {
+    Core::set(payload, Value("thinkingConfig"), thinking_config);
+  }
   return Value();
 }
 

--- a/packages/go/axir-provenance.json
+++ b/packages/go/axir-provenance.json
@@ -4,8 +4,8 @@
   "emitted_functions": 593,
   "files": {
     "axllm.go": {
-      "emitted_lines": 51227,
-      "total_lines": 63785
+      "emitted_lines": 51268,
+      "total_lines": 63826
     }
   }
 }

--- a/packages/go/axllm.go
+++ b/packages/go/axllm.go
@@ -17304,14 +17304,30 @@ func _gemini_apply_model_config_impl(args ...Value) (Value, error) {
 	var v_payload Value
 	var v_model_config Value
 	var v_server_managed_sampling Value
+	var v_budget Value
+	var v_budget_snake Value
 	var v_client_managed_sampling Value
+	var v_has_budget Value
+	var v_has_show Value
+	var v_has_thinking Value
+	var v_show_snake Value
+	var v_show_thoughts Value
+	var v_thinking_config Value
 	if len(args) > 0 { v_payload = args[0] }
 	_ = v_payload
 	if len(args) > 1 { v_model_config = args[1] }
 	_ = v_model_config
 	if len(args) > 2 { v_server_managed_sampling = args[2] }
 	_ = v_server_managed_sampling
+	_ = v_budget
+	_ = v_budget_snake
 	_ = v_client_managed_sampling
+	_ = v_has_budget
+	_ = v_has_show
+	_ = v_has_thinking
+	_ = v_show_snake
+	_ = v_show_thoughts
+	_ = v_thinking_config
 	if _, err := _openai_copy_config_key_impl(v_payload, v_model_config, "maxTokens", "maxOutputTokens"); err != nil { return nil, err }
 	if _, err := _openai_copy_config_key_impl(v_payload, v_model_config, "max_tokens", "maxOutputTokens"); err != nil { return nil, err }
 	v_client_managed_sampling = _core_not(v_server_managed_sampling)
@@ -17329,6 +17345,31 @@ func _gemini_apply_model_config_impl(args ...Value) (Value, error) {
 	if _, err := _openai_copy_config_key_impl(v_payload, v_model_config, "n", "candidateCount"); err != nil { return nil, err }
 	if _, err := _openai_copy_config_key_impl(v_payload, v_model_config, "stopSequences", "stopSequences"); err != nil { return nil, err }
 	if _, err := _openai_copy_config_key_impl(v_payload, v_model_config, "stop_sequences", "stopSequences"); err != nil { return nil, err }
+	v_thinking_config = Object()
+	v_has_thinking = false
+	v_budget_snake = coreGet(v_model_config, "thinking_token_budget", nil)
+	v_budget = coreGet(v_model_config, "thinkingTokenBudget", v_budget_snake)
+	v_has_budget = _core_is_not_none(v_budget)
+	if coreTruthy(v_has_budget) {
+		if err := coreSet(v_thinking_config, "thinkingBudget", v_budget); err != nil { return nil, err }
+		v_has_thinking = true
+	} else {
+	// empty
+	}
+	v_show_snake = coreGet(v_model_config, "show_thoughts", nil)
+	v_show_thoughts = coreGet(v_model_config, "showThoughts", v_show_snake)
+	v_has_show = _core_is_not_none(v_show_thoughts)
+	if coreTruthy(v_has_show) {
+		if err := coreSet(v_thinking_config, "includeThoughts", v_show_thoughts); err != nil { return nil, err }
+		v_has_thinking = true
+	} else {
+	// empty
+	}
+	if coreTruthy(v_has_thinking) {
+		if err := coreSet(v_payload, "thinkingConfig", v_thinking_config); err != nil { return nil, err }
+	} else {
+	// empty
+	}
 	return nil, nil
 }
 

--- a/packages/java/axir-provenance.json
+++ b/packages/java/axir-provenance.json
@@ -4,8 +4,8 @@
   "emitted_functions": 593,
   "files": {
     "dev/axllm/ax/Core.java": {
-      "emitted_lines": 24556,
-      "total_lines": 25866
+      "emitted_lines": 24575,
+      "total_lines": 25885
     }
   }
 }

--- a/packages/java/dev/axllm/ax/Core.java
+++ b/packages/java/dev/axllm/ax/Core.java
@@ -8423,6 +8423,25 @@ final class Core {
     Core._openai_copy_config_key_impl(payload, model_config, "n", "candidateCount");
     Core._openai_copy_config_key_impl(payload, model_config, "stopSequences", "stopSequences");
     Core._openai_copy_config_key_impl(payload, model_config, "stop_sequences", "stopSequences");
+    Object thinking_config = new java.util.LinkedHashMap<String, Object>();
+    Object has_thinking = Boolean.FALSE;
+    Object budget_snake = Core.get(model_config, "thinking_token_budget", null);
+    Object budget = Core.get(model_config, "thinkingTokenBudget", budget_snake);
+    Object has_budget = Core.isNotNone(budget);
+    if (Core.truthy(has_budget)) {
+      Core.set(thinking_config, "thinkingBudget", budget);
+      has_thinking = Boolean.TRUE;
+    }
+    Object show_snake = Core.get(model_config, "show_thoughts", null);
+    Object show_thoughts = Core.get(model_config, "showThoughts", show_snake);
+    Object has_show = Core.isNotNone(show_thoughts);
+    if (Core.truthy(has_show)) {
+      Core.set(thinking_config, "includeThoughts", show_thoughts);
+      has_thinking = Boolean.TRUE;
+    }
+    if (Core.truthy(has_thinking)) {
+      Core.set(payload, "thinkingConfig", thinking_config);
+    }
     return null;
   }
 

--- a/packages/java/pom.xml
+++ b/packages/java/pom.xml
@@ -146,6 +146,8 @@
               <publishingServerId>central</publishingServerId>
               <autoPublish>true</autoPublish>
               <waitUntil>published</waitUntil>
+              <!-- Central can exceed the plugin's 30-minute default under load. -->
+              <waitMaxTime>7200</waitMaxTime>
             </configuration>
           </plugin>
         </plugins>

--- a/packages/python/axir-provenance.json
+++ b/packages/python/axir-provenance.json
@@ -8,8 +8,8 @@
       "total_lines": 10722
     },
     "axllm/ai.py": {
-      "emitted_lines": 7026,
-      "total_lines": 9611
+      "emitted_lines": 7048,
+      "total_lines": 9633
     },
     "axllm/flow.py": {
       "emitted_lines": 2287,

--- a/packages/python/axllm/ai.py
+++ b/packages/python/axllm/ai.py
@@ -7918,6 +7918,28 @@ def _gemini_apply_model_config_impl(payload: Any, model_config: Any, server_mana
     _openai_copy_config_key_impl(payload, model_config, "n", "candidateCount")
     _openai_copy_config_key_impl(payload, model_config, "stopSequences", "stopSequences")
     _openai_copy_config_key_impl(payload, model_config, "stop_sequences", "stopSequences")
+    thinking_config = {}
+    has_thinking = False
+    budget_snake = _core_get(model_config, "thinking_token_budget", None)
+    budget = _core_get(model_config, "thinkingTokenBudget", budget_snake)
+    has_budget = _core_is_not_none(budget)
+    if has_budget:
+        thinking_config["thinkingBudget"] = budget
+        has_thinking = True
+    else:
+        pass
+    show_snake = _core_get(model_config, "show_thoughts", None)
+    show_thoughts = _core_get(model_config, "showThoughts", show_snake)
+    has_show = _core_is_not_none(show_thoughts)
+    if has_show:
+        thinking_config["includeThoughts"] = show_thoughts
+        has_thinking = True
+    else:
+        pass
+    if has_thinking:
+        payload["thinkingConfig"] = thinking_config
+    else:
+        pass
     return None
 
 

--- a/packages/rust/axir-provenance.json
+++ b/packages/rust/axir-provenance.json
@@ -4,8 +4,8 @@
   "emitted_functions": 593,
   "files": {
     "src/lib.rs": {
-      "emitted_lines": 56573,
-      "total_lines": 80656
+      "emitted_lines": 56628,
+      "total_lines": 80711
     }
   }
 }

--- a/packages/rust/src/lib.rs
+++ b/packages/rust/src/lib.rs
@@ -40835,7 +40835,15 @@ fn _gemini_apply_model_config_impl(args: &[CoreValue]) -> Result<CoreValue, AxEr
     let mut v_payload = core_arg(args, 0);
     let mut v_model_config = core_arg(args, 1);
     let mut v_server_managed_sampling = core_arg(args, 2);
+    let mut v_budget = CoreValue::Null;
+    let mut v_budget_snake = CoreValue::Null;
     let mut v_client_managed_sampling = CoreValue::Null;
+    let mut v_has_budget = CoreValue::Null;
+    let mut v_has_show = CoreValue::Null;
+    let mut v_has_thinking = CoreValue::Null;
+    let mut v_show_snake = CoreValue::Null;
+    let mut v_show_thoughts = CoreValue::Null;
+    let mut v_thinking_config = CoreValue::Null;
     _openai_copy_config_key_impl(&[
         v_payload.clone(),
         v_model_config.clone(),
@@ -40911,6 +40919,53 @@ fn _gemini_apply_model_config_impl(args: &[CoreValue]) -> Result<CoreValue, AxEr
         CoreValue::from("stop_sequences"),
         CoreValue::from("stopSequences"),
     ])?;
+    v_thinking_config = CoreValue::new_map();
+    v_has_thinking = CoreValue::Bool(false);
+    v_budget_snake = core_get(
+        &v_model_config,
+        &CoreValue::from("thinking_token_budget"),
+        CoreValue::Null,
+    );
+    v_budget = core_get(
+        &v_model_config,
+        &CoreValue::from("thinkingTokenBudget"),
+        v_budget_snake.clone(),
+    );
+    v_has_budget = core_is_not_none(&[v_budget.clone()])?;
+    if core_truthy(&v_has_budget) {
+        core_set(
+            &v_thinking_config,
+            CoreValue::from("thinkingBudget"),
+            v_budget.clone(),
+        )?;
+        v_has_thinking = CoreValue::Bool(true);
+    }
+    v_show_snake = core_get(
+        &v_model_config,
+        &CoreValue::from("show_thoughts"),
+        CoreValue::Null,
+    );
+    v_show_thoughts = core_get(
+        &v_model_config,
+        &CoreValue::from("showThoughts"),
+        v_show_snake.clone(),
+    );
+    v_has_show = core_is_not_none(&[v_show_thoughts.clone()])?;
+    if core_truthy(&v_has_show) {
+        core_set(
+            &v_thinking_config,
+            CoreValue::from("includeThoughts"),
+            v_show_thoughts.clone(),
+        )?;
+        v_has_thinking = CoreValue::Bool(true);
+    }
+    if core_truthy(&v_has_thinking) {
+        core_set(
+            &v_payload,
+            CoreValue::from("thinkingConfig"),
+            v_thinking_config.clone(),
+        )?;
+    }
     return Ok(CoreValue::Null);
 }
 

--- a/tools/axir/extractors/axai-goldens.ts
+++ b/tools/axir/extractors/axai-goldens.ts
@@ -5067,6 +5067,42 @@ writeFixture('openai-speak-error-surfaces-error', {
   expected_status: 503,
 });
 
+// The ported Gemini path built no thinkingConfig at all, so a caller that set a
+// thinking budget got a model that did not think, and one that asked for the
+// reasoning text back got a chat log with no thought in it. TypeScript maps both
+// (src/ax/ai/google-gemini/api.ts:1043 and :1148); the port dropped them between
+// merge_model_config, which accepts them, and the request, which never read them.
+writeFixture('gemini-thinking-config-reaches-the-request', {
+  kind: 'ai_chat',
+  provider: 'google-gemini',
+  model: 'gemini-3.5-flash',
+  request: {
+    chat_prompt: [{ role: 'user', content: 'think about this' }],
+    model_config: {
+      stream: false,
+      thinkingTokenBudget: 2048,
+      showThoughts: true,
+    },
+  },
+  transport_responses: [
+    {
+      status: 200,
+      json: {
+        candidates: [
+          { content: { parts: [{ text: 'ok' }] }, finishReason: 'STOP' },
+        ],
+      },
+    },
+  ],
+  expected_transport_request: {
+    json: {
+      generationConfig: {
+        thinkingConfig: { thinkingBudget: 2048, includeThoughts: true },
+      },
+    },
+  },
+});
+
 writeFixture('context-cache-rejection', {
   kind: 'ai_context_cache',
   operation: 'rejection',

--- a/tools/axir/internal/axir/templates/package/javaPomXML.xml
+++ b/tools/axir/internal/axir/templates/package/javaPomXML.xml
@@ -146,6 +146,8 @@
               <publishingServerId>central</publishingServerId>
               <autoPublish>true</autoPublish>
               <waitUntil>published</waitUntil>
+              <!-- Central can exceed the plugin's 30-minute default under load. -->
+              <waitMaxTime>7200</waitMaxTime>
             </configuration>
           </plugin>
         </plugins>


### PR DESCRIPTION
`merge_model_config` accepts `thinkingTokenBudget` and `showThoughts`, and the provider catalog advertises `thinkingBudget` and `showThoughts` as supported capabilities for the Gemini models. The ported request builder then read neither — `gemini_apply_model_config_impl` copied maxTokens, sampling, penalties and stop sequences, and no `thinkingConfig` was ever attached.

On the generated runtimes that means:

- a caller that sets a thinking budget gets a model that **does not think**
- a caller that asks for the reasoning text back gets a chat log with **no thought in it**

Silently, in both cases, because the keys are accepted upstream and dropped before the wire.

Found from the second symptom: across 80 recorded GraphJin benchmark episodes every one carried a `chat_log` and not one carried a thought, which left "why did the model do that?" answerable only by inference from the code the model emitted.

TypeScript maps both — `src/ax/ai/google-gemini/api.ts:1043` (thinkingBudget) and `:1148` (includeThoughts). This mirrors that, guarded so a request carrying neither key is byte-identical to before: the same shape as #612 (outputDimensionality) and #615 (embed status).

## Coverage

`gemini-thinking-config-reaches-the-request` asserts both fields land in `generationConfig.thinkingConfig`. Validated against the unfixed builder first:

```
panic: gemini-thinking-config-reaches-the-request: transport request subset mismatch
```

`npm run test:axir` is green and the fixture runs in all five languages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)