### PR TITLE
fix(util): keep SSE events whole when \r\n is split across chunks

### DIFF
--- a/src/ax/util/sse.test.ts
+++ b/src/ax/util/sse.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest';
+
+import { SSEParser } from './sse.js';
+
+const parse = async (chunks: string[]) => {
+  const source = new ReadableStream<string>({
+    start(controller) {
+      for (const chunk of chunks) {
+        controller.enqueue(chunk);
+      }
+      controller.close();
+    },
+  });
+
+  const dropped: string[] = [];
+  const reader = source
+    .pipeThrough(
+      new SSEParser<unknown>({
+        onError: (_error, rawData) => {
+          dropped.push(rawData);
+        },
+      })
+    )
+    .getReader();
+
+  const events: unknown[] = [];
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) {
+      break;
+    }
+    events.push(value);
+  }
+
+  return { events, dropped };
+};
+
+describe('SSEParser', () => {
+  it('joins multi-line data fields in a CRLF stream', async () => {
+    await expect(
+      parse(['data: {"index":\r\ndata: 0}\r\n\r\n'])
+    ).resolves.toEqual({ events: [{ index: 0 }], dropped: [] });
+  });
+
+  // A \r\n line terminator can land on either side of a chunk boundary: the
+  // transport, not the provider, decides where the stream is split. Both
+  // framings carry the same bytes and must produce the same events.
+  it('joins multi-line data fields when \\r\\n is split across chunks', async () => {
+    await expect(
+      parse(['data: {"index":\r', '\ndata: 0}\r\n\r\n'])
+    ).resolves.toEqual({ events: [{ index: 0 }], dropped: [] });
+  });
+
+  // Guards the flush path: at end of stream there is no following \n, so a
+  // bare trailing \r is a real line terminator and must still be parsed.
+  it('emits a trailing event terminated only by a bare \\r', async () => {
+    await expect(parse(['data: {"index":0}\r'])).resolves.toEqual({
+      events: [{ index: 0 }],
+      dropped: [],
+    });
+  });
+});

--- a/src/ax/util/sse.ts
+++ b/src/ax/util/sse.ts
@@ -42,17 +42,34 @@ export class SSEParser<T = unknown> extends TransformStream<string, T> {
   }
 
   private handleFlush(controller: TransformStreamDefaultController<T>): void {
-    this.processBuffer(controller);
+    this.processBuffer(controller, true);
     if (this.currentEvent.rawData) {
       this.processEvent(controller);
     }
   }
 
-  private processBuffer(controller: TransformStreamDefaultController<T>): void {
+  private processBuffer(
+    controller: TransformStreamDefaultController<T>,
+    isFinal = false
+  ): void {
+    // A \r\n line terminator can straddle a chunk boundary. Normalizing the
+    // buffer while it still ends in \r would turn that half into a \n and
+    // consume it as a line terminator, and the \n arriving in the next chunk
+    // would then read as a blank line -- dispatching the event early and
+    // splitting multi-line data fields in two. Hold a trailing \r back until
+    // the next chunk shows what follows it. At the end of the stream nothing
+    // follows, so the \r is a terminator in its own right.
+    let pendingBuffer = this.buffer;
+    let pendingCarriageReturn = '';
+    if (!isFinal && pendingBuffer.endsWith('\r')) {
+      pendingBuffer = pendingBuffer.slice(0, -1);
+      pendingCarriageReturn = '\r';
+    }
+
     // Normalize newlines to \n
-    const normalizedBuffer = this.buffer.replace(/\r\n|\r/g, '\n');
+    const normalizedBuffer = pendingBuffer.replace(/\r\n|\r/g, '\n');
     const lines = normalizedBuffer.split('\n');
-    this.buffer = lines.pop() || '';
+    this.buffer = (lines.pop() || '') + pendingCarriageReturn;
 
     for (const line of lines) {
       if (line === '') {


### PR DESCRIPTION
## The bug

`SSEParser.processBuffer` (`src/ax/util/sse.ts:53`) normalizes line endings on `this.buffer` — a buffer that has *already* been chunked by the transport:

```ts
const normalizedBuffer = this.buffer.replace(/\r\n|\r/g, '\n');
const lines = normalizedBuffer.split('\n');
this.buffer = lines.pop() || '';
```

When a `\r\n` terminator straddles a chunk boundary, the buffer ends in a lone `\r`. That `\r` is normalized to `\n` and consumed as a line terminator, and the `\n` that arrives at the head of the next chunk then reads as a **blank line** — which dispatches the current event.

Where the split lands is decided by TCP segmentation, not by the provider, so this is nondeterministic: the same bytes parse differently depending on how the network happened to slice them.

## Impact

The event is dispatched one line early, so an event carrying a multi-line `data:` field (legal SSE — the spec concatenates them with `\n`) is torn into two events. With JSON payloads both halves fail `JSON.parse` and are discarded silently via `onError`, whose default only `console.warn`s. The stream keeps going, minus data.

This is the Node/server path: `apicall.ts:1102` wires it up with `.pipeThrough(new SSEParser<TResponse>())`.

Same bytes, two framings, on `main`:

```
whole   ['data: {"index":\r\ndata: 0}\r\n\r\n']   -> events [{ index: 0 }]
split   ['data: {"index":\r', '\ndata: 0}\r\n\r\n'] -> events [], dropped ['{"index":', '0}']
```

## The fix

Hold a trailing `\r` back until the next chunk shows what follows it, instead of normalizing it eagerly. At end of stream nothing follows, so `handleFlush` passes `isFinal` and the bare `\r` is normalized as a terminator — preserving today's behavior on that path (covered by the third test).

Single-line `data:` events are unaffected either way: the early dispatch simply lands where the real blank line would have, and the extra blank line is a no-op. So this is a fix for torn multi-line events, not a change to the common path.

## Tests

New `src/ax/util/sse.test.ts` (there was no unit test file for `SSEParser`). The middle test fails on `main`:

```
 ❯ util/sse.test.ts (3 tests | 1 failed)
   ✓ SSEParser > joins multi-line data fields in a CRLF stream
   × SSEParser > joins multi-line data fields when \r\n is split across chunks
     → expected { events: [], dropped: [ …(2) ] } to deeply equal { events: [ { index: +0 } ], …(1) }
   ✓ SSEParser > emits a trailing event terminated only by a bare \r
```

and passes with the change. Full `@ax-llm/ax` suite: **211 files, 2948 passed, 4 skipped**, plus `biome lint` and `biome format` clean (exit 0).

TypeScript only, under `src/ax/util/`, so no AxIR backlog entry is required per `.github/CONTRIBUTING.md`.