### PR TITLE
fix(util): parse SSE frames in the browser path the way the Node path does

### DIFF
--- a/src/ax/util/apicall.test.ts
+++ b/src/ax/util/apicall.test.ts
@@ -568,13 +568,26 @@ describe('apiCall', () => {
       vi.unstubAllGlobals();
     });
 
-    const sseResponse = (events: string): Response =>
-      new Response(events, {
+    const sseResponse = (events: string | string[]): Response => {
+      const body = Array.isArray(events)
+        ? new ReadableStream<Uint8Array>({
+            start(controller) {
+              const encoder = new TextEncoder();
+              for (const event of events) {
+                controller.enqueue(encoder.encode(event));
+              }
+              controller.close();
+            },
+          })
+        : events;
+
+      return new Response(body, {
         status: 200,
         headers: { 'content-type': 'text/event-stream' },
       });
+    };
 
-    const collectStream = async (events: string) => {
+    const collectStream = async (events: string | string[]) => {
       const mockFetch = vi.fn().mockResolvedValue(sseResponse(events));
 
       const stream = (await apiCall<{ test: string }, { index: number }>(
@@ -634,6 +647,28 @@ describe('apiCall', () => {
 
       await expect(
         collectStream('data: {"index":0}\r\n\r\ndata: {"index":1}\r\n\r\n')
+      ).resolves.toEqual([{ index: 0 }, { index: 1 }]);
+    });
+
+    it('keeps CRLF boundaries whole when split across chunks', async () => {
+      stubBrowserGlobals();
+
+      await expect(
+        collectStream([
+          'data: {"index":0}\r',
+          '\n\r',
+          '\ndata: {"index":1}\r',
+          '\n\r',
+          '\n',
+        ])
+      ).resolves.toEqual([{ index: 0 }, { index: 1 }]);
+    });
+
+    it('splits events on bare \\r boundaries', async () => {
+      stubBrowserGlobals();
+
+      await expect(
+        collectStream('data: {"index":0}\r\rdata: {"index":1}\r')
       ).resolves.toEqual([{ index: 0 }, { index: 1 }]);
     });
 

--- a/src/ax/util/apicall.test.ts
+++ b/src/ax/util/apicall.test.ts
@@ -624,5 +624,45 @@ describe('apiCall', () => {
         collectStream(`data: {"index":0}\n\ndata: {"index":1}\n\n${sentinel}`)
       ).resolves.toEqual([{ index: 0 }, { index: 1 }]);
     });
+
+    // The SSE spec allows \r\n line endings, and the Node SSEParser path in
+    // this same file normalizes them. Without normalization here the event
+    // boundary is never found, the buffer grows for the whole response, and
+    // only the last data: line of that one giant event survives.
+    it('splits events on \\r\\n\\r\\n boundaries', async () => {
+      stubBrowserGlobals();
+
+      await expect(
+        collectStream('data: {"index":0}\r\n\r\ndata: {"index":1}\r\n\r\n')
+      ).resolves.toEqual([{ index: 0 }, { index: 1 }]);
+    });
+
+    // The spec concatenates repeated data: fields with \n, which is how the
+    // Node SSEParser path already behaves.
+    it('concatenates multi-line data fields', async () => {
+      stubBrowserGlobals();
+
+      await expect(
+        collectStream('data: {"index":\ndata: 0}\n\n')
+      ).resolves.toEqual([{ index: 0 }]);
+    });
+
+    // The space after the colon is optional in the SSE spec, and the Node
+    // SSEParser path accepts either form.
+    it('accepts data fields with no space after the colon', async () => {
+      stubBrowserGlobals();
+
+      await expect(
+        collectStream('data:{"index":0}\n\ndata:{"index":1}\n\n')
+      ).resolves.toEqual([{ index: 0 }, { index: 1 }]);
+    });
+
+    it('stops at a [DONE] sentinel sent with \\r\\n line endings', async () => {
+      stubBrowserGlobals();
+
+      await expect(
+        collectStream('data: {"index":0}\r\n\r\ndata: [DONE]\r\n\r\n')
+      ).resolves.toEqual([{ index: 0 }]);
+    });
   });
 });

--- a/src/ax/util/apicall.ts
+++ b/src/ax/util/apicall.ts
@@ -945,25 +945,56 @@ export const apiCall = async <TRequest = unknown, TResponse = unknown>(
             const decoder = new TextDecoder();
             let buffer = '';
 
+            // The SSE spec allows \r\n and \r line endings; the Node
+            // SSEParser path in this file normalizes them, so this one must
+            // too or a \r\n\r\n frame boundary is never found and the buffer
+            // grows for the whole response. A trailing \r may be the first
+            // half of a \r\n split across chunk boundaries, so hold it back
+            // until the next chunk shows what follows it; at end of stream
+            // nothing follows, so it is a terminator in its own right.
+            const normalizeBuffer = (isFinal: boolean): void => {
+              let pendingCarriageReturn = '';
+              if (!isFinal && buffer.endsWith('\r')) {
+                buffer = buffer.slice(0, -1);
+                pendingCarriageReturn = '\r';
+              }
+              buffer = buffer.replace(/\r\n|\r/g, '\n') + pendingCarriageReturn;
+            };
+
             // Returns true if the caller should stop reading (e.g. saw [DONE]).
             const processEvent = (event: string): boolean => {
               if (!event.trim()) return false;
 
               const lines = event.split('\n');
-              let data = '';
+              const dataLines: string[] = [];
               let eventType = 'message';
 
               for (const line of lines) {
-                if (line.startsWith('data: ')) {
-                  data = line.slice(6);
-                } else if (line.startsWith('event: ')) {
-                  eventType = line.slice(7);
+                // Comment line.
+                if (line.startsWith(':')) continue;
+
+                const colonIndex = line.indexOf(':');
+                if (colonIndex === -1) continue;
+
+                const field = line.slice(0, colonIndex);
+                let value = line.slice(colonIndex + 1);
+                // A single space after the colon is part of the delimiter,
+                // and `data:{...}` with no space at all is valid.
+                if (value.startsWith(' ')) value = value.slice(1);
+
+                if (field === 'data') {
+                  // Repeated data fields are one payload joined with \n, the
+                  // same way the Node SSEParser path assembles them.
+                  dataLines.push(value);
+                } else if (field === 'event') {
+                  eventType = value;
                 }
               }
 
+              const data = dataLines.join('\n');
               if (!data) return false;
 
-              if (data === '[DONE]') {
+              if (data.trim() === '[DONE]') {
                 controller.close();
                 return true;
               }
@@ -996,6 +1027,7 @@ export const apiCall = async <TRequest = unknown, TResponse = unknown>(
                 while (true) {
                   const { done, value } = await reader.read();
                   if (done) {
+                    normalizeBuffer(true);
                     // Flush any trailing event that wasn't terminated by \n\n.
                     // Providers are allowed to end the stream without a final
                     // blank line; the Node SSEParser path handles this via
@@ -1014,6 +1046,7 @@ export const apiCall = async <TRequest = unknown, TResponse = unknown>(
                   }
 
                   buffer += decoder.decode(value, { stream: true });
+                  normalizeBuffer(false);
 
                   const events = buffer.split('\n\n');
                   buffer = events.pop() || '';


### PR DESCRIPTION
The `isBrowser` branch of `apiCall` hand-rolls its own SSE parser. The Node branch of the *same function* uses `SSEParser` from `src/ax/util/sse.ts`. They disagree on three points, and in each case the browser one is the one that loses data — so this is an internal asymmetry in the package, not a style preference.

## 1. Frame boundaries are `\n\n` only

`src/ax/util/apicall.ts:1018`:

```ts
const events = buffer.split('\n\n');
```

The SSE spec allows `\r\n` line endings, and `SSEParser` normalizes them (`sse.ts:53`). Against a provider that sends `\r\n\r\n` frames this split never matches: no event is ever dispatched, `buffer` grows for the length of the whole response, and only at `done` does the trailing-event flush hand the entire body to `processEvent` as one event.

## 2. `data:` overwrites instead of accumulating

`apicall.ts:957-958`:

```ts
if (line.startsWith('data: ')) {
  data = line.slice(6);
}
```

The spec joins repeated `data:` fields with `\n`, which is what `SSEParser.parseLine` does. Here each line clobbers the previous one, so a multi-line `data:` field keeps only its last line.

Combined with (1), a whole CRLF response collapses into one event of which only the final `data:` line survives:

```
'data: {"index":0}\r\n\r\ndata: {"index":1}\r\n\r\n'
  -> [{ index: 1 }]        // expected [{ index: 0 }, { index: 1 }]
```

## 3. The space after `data:` is required

`startsWith('data: ')` drops `data:{"index":0}`, which is legal SSE and which `SSEParser` accepts. Line 966 also compares the raw `data` against `'[DONE]'` without trimming, so a sentinel that arrives with any surrounding whitespace is parsed as JSON instead of ending the stream.

## The fix

- Normalize `\r\n`/`\r` to `\n` before scanning for frame boundaries. A trailing `\r` may be the first half of a `\r\n` split across a chunk boundary, so it is held back until the next chunk shows what follows it — otherwise it would be misread as a blank line. At `done` nothing follows, so it is normalized as a terminator.
- Accumulate repeated `data:` fields and join with `\n`.
- Parse `field:value` per the spec: skip `:` comments, strip a single optional leading space from the value, and trim before the `[DONE]` comparison.

## Tests

Four tests added to the existing `browser SSE streaming` harness in `src/ax/util/apicall.test.ts` (the one that stubs `window`/`EventSource` to reach this branch). All four fail on `main`:

```
   ✗ browser SSE streaming > splits events on \r\n\r\n boundaries
     → expected [ { index: 1 } ] to deeply equal [ { index: +0 }, { index: 1 } ]
   ✗ browser SSE streaming > concatenates multi-line data fields
     → expected [] to deeply equal [ { index: +0 } ]
   ✗ browser SSE streaming > accepts data fields with no space after the colon
     → expected [] to deeply equal [ { index: +0 }, { index: 1 } ]
   ✗ browser SSE streaming > stops at a [DONE] sentinel sent with \r\n line endings
     → expected [] to deeply equal [ { index: +0 } ]

 Test Files  1 failed (1)
      Tests  4 failed | 25 passed (29)
```

and pass with the change (29 passed). Full `@ax-llm/ax` suite: **210 files, 2949 passed, 4 skipped**, `biome lint` and `biome format` clean (exit 0). The four pre-existing browser-streaming tests are untouched.

TypeScript only, under `src/ax/util/`, so no AxIR backlog entry is required per `.github/CONTRIBUTING.md`.

---

Filed separately from #622, which fixes the mirror-image chunk-boundary bug on the Node `SSEParser` path. The two touch different files and are independently revertable; this one is three behavioral changes and wants closer review than that one-place fix.