### PR TITLE
fix(gemini): route an effort level to thinkingLevel, not thinkingBudget

### DIFF
--- a/docs/AI_PROFILES.md
+++ b/docs/AI_PROFILES.md
@@ -130,6 +130,13 @@ models and maps it to the strongest effort documented by that deployment:
 | `cerebras` | GPT-OSS 120B; Gemma 4 31B | `high` | Rejected for GPT-OSS; supported for Gemma |
 | `deepinfra` | DeepSeek R1 family | `high` | Supported |
 
+The native `google-gemini` profile and its `gemini` / `google_gemini` aliases
+resolve the effective model before mapping an explicit logical budget. Gemini 3
+uses model-supported `thinkingLevel` values, while Gemini 2.5 uses numeric
+`thinkingBudget`; `none` always hides thoughts and clamps to the model's minimum
+when thinking cannot be disabled. The OpenAI-compatible `vertex-ai` profile
+does not inherit this native request shape from Gemini-looking model IDs.
+
 An explicitly unsupported level fails before the request. Hugging Face Router
 stays conservative because its `:fastest`, `:cheapest`, and `:preferred`
 policies can choose different underlying providers for the same model ID; use

--- a/ir/axcore/provider.axir
+++ b/ir/axcore/provider.axir
@@ -5398,7 +5398,47 @@ module @ax.provider version "0.1" {
       %budget = core.get %model_config["thinkingTokenBudget"] default %budget_snake
       %has_budget = core.call intrinsic.is_not_none(%budget)
       core.if %has_budget {
-        core.set %thinking_config["thinkingBudget"] = %budget
+        // thinkingTokenBudget carries either a token count or an effort level,
+        // and Gemini takes them in different fields: thinkingBudget is an int32
+        // and rejects a level outright, while thinkingLevel is what the Gemini 3
+        // family documents. Forwarding a level as the budget produced a hard 400
+        // — "Invalid value at thinking_config.thinking_budget (TYPE_INT32)" — so
+        // a caller asking for high-effort reasoning broke every request instead
+        // of getting it. TypeScript routes the same two shapes the same way
+        // (src/ax/ai/google-gemini/api.ts:1043 and :1065), including its two
+        // remappings: Gemini 3 cannot disable thinking, so none becomes minimal,
+        // and highest is spelled high.
+        %level = core.let ""
+        %is_none = core.call intrinsic.eq(%budget, "none")
+        core.if %is_none {
+          %level = core.let "minimal"
+        }
+        %is_minimal = core.call intrinsic.eq(%budget, "minimal")
+        core.if %is_minimal {
+          %level = core.let "minimal"
+        }
+        %is_low = core.call intrinsic.eq(%budget, "low")
+        core.if %is_low {
+          %level = core.let "low"
+        }
+        %is_medium = core.call intrinsic.eq(%budget, "medium")
+        core.if %is_medium {
+          %level = core.let "medium"
+        }
+        %is_high = core.call intrinsic.eq(%budget, "high")
+        core.if %is_high {
+          %level = core.let "high"
+        }
+        %is_highest = core.call intrinsic.eq(%budget, "highest")
+        core.if %is_highest {
+          %level = core.let "high"
+        }
+        %named_level = core.call intrinsic.eq(%level, "")
+        core.if %named_level {
+          core.set %thinking_config["thinkingBudget"] = %budget
+        } else {
+          core.set %thinking_config["thinkingLevel"] = %level
+        }
         %has_thinking = core.let true
       }
       %show_snake = core.get %model_config["show_thoughts"]

--- a/ir/axcore/provider.axir
+++ b/ir/axcore/provider.axir
@@ -2923,6 +2923,9 @@ module @ax.provider version "0.1" {
       core.set %voice_config["prebuiltVoiceConfig"] = %prebuilt_voice
       core.set %speech_config["voiceConfig"] = %voice_config
       core.set %generation_config["speechConfig"] = %speech_config
+      %empty_model_config = core.map
+      %model_config = core.get %request["model_config"] default %empty_model_config
+      core.call @gemini_apply_thinking_config_impl(%generation_config, %request_model, %model_config)
       core.set %setup["generationConfig"] = %generation_config
       %include_transcript = core.get %request_output_audio["transcript"] default true
       core.if %include_transcript {
@@ -5320,7 +5323,7 @@ module @ax.provider version "0.1" {
       core.set %generation_config["responseMimeType"] = "text/plain"
       %empty_model_config = core.map
       %model_config = core.get %request["model_config"] default %empty_model_config
-      core.call @gemini_apply_model_config_impl(%generation_config, %model_config, %server_managed_sampling)
+      core.call @gemini_apply_model_config_impl(%generation_config, %model, %model_config, %server_managed_sampling)
       %response_format = core.get %request["response_format"]
       %has_response_format = core.call intrinsic.truthy(%response_format)
       core.if %has_response_format {
@@ -5370,13 +5373,238 @@ module @ax.provider version "0.1" {
     }
   }
 
+  op ax.provider.semantic @gemini_clamp_thinking_level_impl {
+    attr core_kind = "func"
+    attr effect = "throws"
+    attr emit_module = "ai"
+    attr private = true
+    tag "gemini-thinking-level-model-clamp"
+    type signature = "(string, string) -> string throws"
+    body @entry(%model: string, %level: string) {
+      %is_minimal = core.call intrinsic.eq(%level, "minimal")
+      %is_low = core.call intrinsic.eq(%level, "low")
+      %is_medium = core.call intrinsic.eq(%level, "medium")
+      %is_high = core.call intrinsic.eq(%level, "high")
+      %is_minimal_or_low = core.call intrinsic.or(%is_minimal, %is_low)
+      %is_medium_or_high = core.call intrinsic.or(%is_medium, %is_high)
+      %is_supported_level = core.call intrinsic.or(%is_minimal_or_low, %is_medium_or_high)
+      core.if %is_supported_level {
+      } else {
+        %message = core.call intrinsic.string.format("unsupported Gemini thinking level: {}", %level)
+        %error = core.call intrinsic.ai.error.unsupported(%message)
+        core.raise %error
+      }
+
+      %is_gemini3 = core.call intrinsic.contains(%model, "gemini-3")
+      %is_image_name = core.call intrinsic.contains(%model, "-image")
+      %is_image = core.call intrinsic.and(%is_gemini3, %is_image_name)
+      core.if %is_image {
+        core.if %is_minimal_or_low {
+          core.return "minimal"
+        }
+        core.return "high"
+      }
+
+      %is_legacy_pro_name = core.call intrinsic.contains(%model, "gemini-3-pro")
+      %is_legacy_pro = core.call intrinsic.and(%is_gemini3, %is_legacy_pro_name)
+      core.if %is_legacy_pro {
+        core.if %is_minimal_or_low {
+          core.return "low"
+        }
+        core.return "high"
+      }
+
+      %is_37_flash = core.call intrinsic.contains(%model, "gemini-3.7-flash")
+      %is_31_pro = core.call intrinsic.contains(%model, "gemini-3.1-pro")
+      %no_minimal_name = core.call intrinsic.or(%is_37_flash, %is_31_pro)
+      %no_minimal = core.call intrinsic.and(%is_gemini3, %no_minimal_name)
+      %clamp_minimal = core.call intrinsic.and(%no_minimal, %is_minimal)
+      core.if %clamp_minimal {
+        core.return "low"
+      }
+      core.return %level
+    }
+  }
+
+  op ax.provider.semantic @gemini_apply_thinking_config_impl {
+    attr core_kind = "func"
+    attr effect = "throws"
+    attr emit_module = "ai"
+    attr private = true
+    tag "gemini-thinking-config-model-aware"
+    type signature = "(json, string, json) -> void throws"
+    body @entry(%payload: json, %model: string, %model_config: json) {
+      %thinking_config = core.map
+      %has_thinking = core.let false
+      %budget_is_none = core.let false
+      %is_gemini3 = core.call intrinsic.contains(%model, "gemini-3")
+      %is_25_pro = core.call intrinsic.contains(%model, "gemini-2.5-pro")
+      %empty_level_mapping = core.map
+      %level_mapping_snake = core.get %model_config["thinking_level_mapping"] default %empty_level_mapping
+      %level_mapping = core.get %model_config["thinkingLevelMapping"] default %level_mapping_snake
+      %empty_budget_levels = core.map
+      %budget_levels_snake = core.get %model_config["thinking_token_budget_levels"] default %empty_budget_levels
+      %budget_levels = core.get %model_config["thinkingTokenBudgetLevels"] default %budget_levels_snake
+      %minimum_budget = core.get %budget_levels["minimal"] default 200
+      %low_budget = core.get %budget_levels["low"] default 800
+      %medium_budget = core.get %budget_levels["medium"] default 5000
+      %high_budget = core.get %budget_levels["high"] default 10000
+      %highest_budget = core.get %budget_levels["highest"] default 24500
+      %budget_snake = core.get %model_config["thinking_token_budget"]
+      %budget = core.get %model_config["thinkingTokenBudget"] default %budget_snake
+      %has_budget = core.call intrinsic.is_not_none(%budget)
+      core.if %has_budget {
+        %budget_is_number = core.type_is %budget type "number"
+        %budget_is_string = core.type_is %budget type "string"
+        core.if %is_gemini3 {
+          core.if %budget_is_number {
+            %message = core.call intrinsic.string.format("Gemini 3 model {} does not support numeric thinkingTokenBudget", %model)
+            %error = core.call intrinsic.ai.error.unsupported(%message)
+            core.raise %error
+          }
+          core.if %budget_is_string {
+          } else {
+            %error = core.call intrinsic.ai.error.unsupported("Gemini thinkingTokenBudget must be a number or logical level")
+            core.raise %error
+          }
+          %level = core.let ""
+          %is_none = core.call intrinsic.eq(%budget, "none")
+          core.if %is_none {
+            %level = core.let "minimal"
+            %budget_is_none = core.let true
+          }
+          %is_minimal = core.call intrinsic.eq(%budget, "minimal")
+          core.if %is_minimal {
+            %level = core.let "minimal"
+          }
+          %is_low = core.call intrinsic.eq(%budget, "low")
+          core.if %is_low {
+            %level = core.let "low"
+          }
+          %is_medium = core.call intrinsic.eq(%budget, "medium")
+          core.if %is_medium {
+            %level = core.let "medium"
+          }
+          %is_high = core.call intrinsic.eq(%budget, "high")
+          core.if %is_high {
+            %level = core.let "high"
+          }
+          %is_highest = core.call intrinsic.eq(%budget, "highest")
+          core.if %is_highest {
+            %level = core.let "high"
+          }
+          %unknown_level = core.call intrinsic.eq(%level, "")
+          core.if %unknown_level {
+            %message = core.call intrinsic.string.format("unsupported Gemini thinkingTokenBudget level: {}", %budget)
+            %error = core.call intrinsic.ai.error.unsupported(%message)
+            core.raise %error
+          }
+          %mapping_key = core.let %budget
+          core.if %is_none {
+            %mapping_key = core.let "minimal"
+          }
+          %mapped_level = core.get %level_mapping[%mapping_key] default %level
+          %clamped_level = core.call @gemini_clamp_thinking_level_impl(%model, %mapped_level)
+          core.set %thinking_config["thinkingLevel"] = %clamped_level
+        } else {
+          core.if %budget_is_number {
+            %numeric_budget = core.let %budget
+            %is_zero = core.call intrinsic.eq(%budget, 0)
+            %clamp_pro_zero = core.call intrinsic.and(%is_25_pro, %is_zero)
+            core.if %clamp_pro_zero {
+              %numeric_budget = core.let %minimum_budget
+            }
+            core.set %thinking_config["thinkingBudget"] = %numeric_budget
+          } else {
+            core.if %budget_is_string {
+            } else {
+              %error = core.call intrinsic.ai.error.unsupported("Gemini thinkingTokenBudget must be a number or logical level")
+              core.raise %error
+            }
+            %numeric_budget = core.let -1
+            %is_none = core.call intrinsic.eq(%budget, "none")
+            core.if %is_none {
+              %numeric_budget = core.let 0
+              core.if %is_25_pro {
+                %numeric_budget = core.let %minimum_budget
+              }
+              %budget_is_none = core.let true
+            }
+            %is_minimal = core.call intrinsic.eq(%budget, "minimal")
+            core.if %is_minimal {
+              %numeric_budget = core.let %minimum_budget
+            }
+            %is_low = core.call intrinsic.eq(%budget, "low")
+            core.if %is_low {
+              %numeric_budget = core.let %low_budget
+            }
+            %is_medium = core.call intrinsic.eq(%budget, "medium")
+            core.if %is_medium {
+              %numeric_budget = core.let %medium_budget
+            }
+            %is_high = core.call intrinsic.eq(%budget, "high")
+            core.if %is_high {
+              %numeric_budget = core.let %high_budget
+            }
+            %is_highest = core.call intrinsic.eq(%budget, "highest")
+            core.if %is_highest {
+              %numeric_budget = core.let %highest_budget
+            }
+            %unknown_level = core.call intrinsic.eq(%numeric_budget, -1)
+            core.if %unknown_level {
+              %message = core.call intrinsic.string.format("unsupported Gemini thinkingTokenBudget level: {}", %budget)
+              %error = core.call intrinsic.ai.error.unsupported(%message)
+              core.raise %error
+            }
+            core.set %thinking_config["thinkingBudget"] = %numeric_budget
+          }
+        }
+        %has_thinking = core.let true
+      }
+
+      %level_snake = core.get %model_config["thinking_level"]
+      %explicit_level = core.get %model_config["thinkingLevel"] default %level_snake
+      %has_explicit_level = core.call intrinsic.is_not_none(%explicit_level)
+      %use_explicit_level = core.call intrinsic.and(%is_gemini3, %has_explicit_level)
+      core.if %use_explicit_level {
+        %level_is_string = core.type_is %explicit_level type "string"
+        core.if %level_is_string {
+        } else {
+          %error = core.call intrinsic.ai.error.unsupported("Gemini thinkingLevel must be a logical level")
+          core.raise %error
+        }
+        %clamped_level = core.call @gemini_clamp_thinking_level_impl(%model, %explicit_level)
+        core.call intrinsic.map.delete(%thinking_config, "thinkingBudget")
+        core.set %thinking_config["thinkingLevel"] = %clamped_level
+        %has_thinking = core.let true
+      }
+
+      %show_snake = core.get %model_config["show_thoughts"]
+      %show_thoughts = core.get %model_config["showThoughts"] default %show_snake
+      %has_show = core.call intrinsic.is_not_none(%show_thoughts)
+      core.if %has_show {
+        core.set %thinking_config["includeThoughts"] = %show_thoughts
+        %has_thinking = core.let true
+      }
+      core.if %budget_is_none {
+        core.set %thinking_config["includeThoughts"] = false
+        %has_thinking = core.let true
+      }
+      core.if %has_thinking {
+        core.set %payload["thinkingConfig"] = %thinking_config
+      }
+      core.return
+    }
+  }
+
   op ax.provider.semantic @gemini_apply_model_config_impl {
     attr core_kind = "func"
+    attr effect = "throws"
     attr emit_module = "ai"
     attr private = true
     tag "gemini-model-config-core-helper"
-    type signature = "(json, json, bool) -> void"
-    body @entry(%payload: json, %model_config: json, %server_managed_sampling: bool) {
+    type signature = "(json, string, json, bool) -> void throws"
+    body @entry(%payload: json, %model: string, %model_config: json, %server_managed_sampling: bool) {
       core.call @openai_copy_config_key_impl(%payload, %model_config, "maxTokens", "maxOutputTokens")
       core.call @openai_copy_config_key_impl(%payload, %model_config, "max_tokens", "maxOutputTokens")
       %client_managed_sampling = core.call intrinsic.not(%server_managed_sampling)
@@ -5392,65 +5620,7 @@ module @ax.provider version "0.1" {
       core.call @openai_copy_config_key_impl(%payload, %model_config, "n", "candidateCount")
       core.call @openai_copy_config_key_impl(%payload, %model_config, "stopSequences", "stopSequences")
       core.call @openai_copy_config_key_impl(%payload, %model_config, "stop_sequences", "stopSequences")
-      %thinking_config = core.map
-      %has_thinking = core.let false
-      %budget_snake = core.get %model_config["thinking_token_budget"]
-      %budget = core.get %model_config["thinkingTokenBudget"] default %budget_snake
-      %has_budget = core.call intrinsic.is_not_none(%budget)
-      core.if %has_budget {
-        // thinkingTokenBudget carries either a token count or an effort level,
-        // and Gemini takes them in different fields: thinkingBudget is an int32
-        // and rejects a level outright, while thinkingLevel is what the Gemini 3
-        // family documents. Forwarding a level as the budget produced a hard 400
-        // — "Invalid value at thinking_config.thinking_budget (TYPE_INT32)" — so
-        // a caller asking for high-effort reasoning broke every request instead
-        // of getting it. TypeScript routes the same two shapes the same way
-        // (src/ax/ai/google-gemini/api.ts:1043 and :1065), including its two
-        // remappings: Gemini 3 cannot disable thinking, so none becomes minimal,
-        // and highest is spelled high.
-        %level = core.let ""
-        %is_none = core.call intrinsic.eq(%budget, "none")
-        core.if %is_none {
-          %level = core.let "minimal"
-        }
-        %is_minimal = core.call intrinsic.eq(%budget, "minimal")
-        core.if %is_minimal {
-          %level = core.let "minimal"
-        }
-        %is_low = core.call intrinsic.eq(%budget, "low")
-        core.if %is_low {
-          %level = core.let "low"
-        }
-        %is_medium = core.call intrinsic.eq(%budget, "medium")
-        core.if %is_medium {
-          %level = core.let "medium"
-        }
-        %is_high = core.call intrinsic.eq(%budget, "high")
-        core.if %is_high {
-          %level = core.let "high"
-        }
-        %is_highest = core.call intrinsic.eq(%budget, "highest")
-        core.if %is_highest {
-          %level = core.let "high"
-        }
-        %named_level = core.call intrinsic.eq(%level, "")
-        core.if %named_level {
-          core.set %thinking_config["thinkingBudget"] = %budget
-        } else {
-          core.set %thinking_config["thinkingLevel"] = %level
-        }
-        %has_thinking = core.let true
-      }
-      %show_snake = core.get %model_config["show_thoughts"]
-      %show_thoughts = core.get %model_config["showThoughts"] default %show_snake
-      %has_show = core.call intrinsic.is_not_none(%show_thoughts)
-      core.if %has_show {
-        core.set %thinking_config["includeThoughts"] = %show_thoughts
-        %has_thinking = core.let true
-      }
-      core.if %has_thinking {
-        core.set %payload["thinkingConfig"] = %thinking_config
-      }
+      core.call @gemini_apply_thinking_config_impl(%payload, %model, %model_config)
       core.return
     }
   }

--- a/ir/conformance/axai/gemini-25-custom-budget-rung-is-preserved.json
+++ b/ir/conformance/axai/gemini-25-custom-budget-rung-is-preserved.json
@@ -1,0 +1,52 @@
+{
+  "expected_transport_json_absent": [
+    "generationConfig.thinkingConfig.thinkingLevel"
+  ],
+  "expected_transport_request": {
+    "json": {
+      "generationConfig": {
+        "thinkingConfig": {
+          "thinkingBudget": 12345
+        }
+      }
+    }
+  },
+  "kind": "ai_chat",
+  "model": "gemini-2.5-flash",
+  "name": "gemini-25-custom-budget-rung-is-preserved",
+  "provider": "google-gemini",
+  "request": {
+    "chat_prompt": [
+      {
+        "content": "think about this",
+        "role": "user"
+      }
+    ],
+    "model_config": {
+      "stream": false,
+      "thinkingTokenBudget": "high",
+      "thinkingTokenBudgetLevels": {
+        "high": 12345
+      }
+    }
+  },
+  "transport_responses": [
+    {
+      "json": {
+        "candidates": [
+          {
+            "content": {
+              "parts": [
+                {
+                  "text": "ok"
+                }
+              ]
+            },
+            "finishReason": "STOP"
+          }
+        ]
+      },
+      "status": 200
+    }
+  ]
+}

--- a/ir/conformance/axai/gemini-25-flash-high-uses-numeric-budget.json
+++ b/ir/conformance/axai/gemini-25-flash-high-uses-numeric-budget.json
@@ -1,0 +1,51 @@
+{
+  "expected_transport_json_absent": [
+    "generationConfig.thinkingConfig.thinkingLevel"
+  ],
+  "expected_transport_request": {
+    "json": {
+      "generationConfig": {
+        "thinkingConfig": {
+          "includeThoughts": true,
+          "thinkingBudget": 10000
+        }
+      }
+    }
+  },
+  "kind": "ai_chat",
+  "model": "gemini-2.5-flash",
+  "name": "gemini-25-flash-high-uses-numeric-budget",
+  "provider": "google-gemini",
+  "request": {
+    "chat_prompt": [
+      {
+        "content": "think about this",
+        "role": "user"
+      }
+    ],
+    "model_config": {
+      "showThoughts": true,
+      "stream": false,
+      "thinkingTokenBudget": "high"
+    }
+  },
+  "transport_responses": [
+    {
+      "json": {
+        "candidates": [
+          {
+            "content": {
+              "parts": [
+                {
+                  "text": "ok"
+                }
+              ]
+            },
+            "finishReason": "STOP"
+          }
+        ]
+      },
+      "status": 200
+    }
+  ]
+}

--- a/ir/conformance/axai/gemini-25-flash-none-disables-thinking.json
+++ b/ir/conformance/axai/gemini-25-flash-none-disables-thinking.json
@@ -1,0 +1,51 @@
+{
+  "expected_transport_json_absent": [
+    "generationConfig.thinkingConfig.thinkingLevel"
+  ],
+  "expected_transport_request": {
+    "json": {
+      "generationConfig": {
+        "thinkingConfig": {
+          "includeThoughts": false,
+          "thinkingBudget": 0
+        }
+      }
+    }
+  },
+  "kind": "ai_chat",
+  "model": "gemini-2.5-flash",
+  "name": "gemini-25-flash-none-disables-thinking",
+  "provider": "google-gemini",
+  "request": {
+    "chat_prompt": [
+      {
+        "content": "think about this",
+        "role": "user"
+      }
+    ],
+    "model_config": {
+      "showThoughts": true,
+      "stream": false,
+      "thinkingTokenBudget": "none"
+    }
+  },
+  "transport_responses": [
+    {
+      "json": {
+        "candidates": [
+          {
+            "content": {
+              "parts": [
+                {
+                  "text": "ok"
+                }
+              ]
+            },
+            "finishReason": "STOP"
+          }
+        ]
+      },
+      "status": 200
+    }
+  ]
+}

--- a/ir/conformance/axai/gemini-25-live-thinking-budget.json
+++ b/ir/conformance/axai/gemini-25-live-thinking-budget.json
@@ -1,0 +1,45 @@
+{
+  "expected_setup": {
+    "setup": {
+      "generationConfig": {
+        "responseModalities": ["AUDIO"],
+        "speechConfig": {
+          "voiceConfig": {
+            "prebuiltVoiceConfig": {
+              "voiceName": "Kore"
+            }
+          }
+        },
+        "thinkingConfig": {
+          "includeThoughts": true,
+          "thinkingBudget": 10000
+        }
+      },
+      "model": "models/gemini-2.5-flash-native-audio-preview-12-2025",
+      "outputAudioTranscription": {}
+    }
+  },
+  "kind": "ai_realtime",
+  "model": "gemini-2.5-flash-native-audio-preview-12-2025",
+  "name": "gemini-25-live-thinking-budget",
+  "provider": "google-gemini",
+  "request": {
+    "audio": {
+      "output": {
+        "transcript": true,
+        "voice": "Kore"
+      }
+    },
+    "chat_prompt": [
+      {
+        "content": "Answer with audio.",
+        "role": "user"
+      }
+    ],
+    "model": "gemini-2.5-flash-native-audio-preview-12-2025",
+    "model_config": {
+      "showThoughts": true,
+      "thinkingTokenBudget": "high"
+    }
+  }
+}

--- a/ir/conformance/axai/gemini-25-pro-none-clamps-to-minimum-budget.json
+++ b/ir/conformance/axai/gemini-25-pro-none-clamps-to-minimum-budget.json
@@ -1,0 +1,51 @@
+{
+  "expected_transport_json_absent": [
+    "generationConfig.thinkingConfig.thinkingLevel"
+  ],
+  "expected_transport_request": {
+    "json": {
+      "generationConfig": {
+        "thinkingConfig": {
+          "includeThoughts": false,
+          "thinkingBudget": 200
+        }
+      }
+    }
+  },
+  "kind": "ai_chat",
+  "model": "gemini-2.5-pro",
+  "name": "gemini-25-pro-none-clamps-to-minimum-budget",
+  "provider": "google-gemini",
+  "request": {
+    "chat_prompt": [
+      {
+        "content": "think about this",
+        "role": "user"
+      }
+    ],
+    "model_config": {
+      "showThoughts": true,
+      "stream": false,
+      "thinkingTokenBudget": "none"
+    }
+  },
+  "transport_responses": [
+    {
+      "json": {
+        "candidates": [
+          {
+            "content": {
+              "parts": [
+                {
+                  "text": "ok"
+                }
+              ]
+            },
+            "finishReason": "STOP"
+          }
+        ]
+      },
+      "status": 200
+    }
+  ]
+}

--- a/ir/conformance/axai/gemini-3-live-numeric-thinking-budget-rejected.json
+++ b/ir/conformance/axai/gemini-3-live-numeric-thinking-budget-rejected.json
@@ -1,0 +1,25 @@
+{
+  "expected_error_contains": "does not support numeric thinkingTokenBudget",
+  "expected_setup": {},
+  "kind": "ai_realtime",
+  "model": "gemini-3.1-flash-live-preview",
+  "name": "gemini-3-live-numeric-thinking-budget-rejected",
+  "provider": "google-gemini",
+  "request": {
+    "audio": {
+      "output": {
+        "voice": "Kore"
+      }
+    },
+    "chat_prompt": [
+      {
+        "content": "Answer with audio.",
+        "role": "user"
+      }
+    ],
+    "model": "gemini-3.1-flash-live-preview",
+    "model_config": {
+      "thinkingTokenBudget": 2048
+    }
+  }
+}

--- a/ir/conformance/axai/gemini-3-numeric-thinking-budget-rejected.json
+++ b/ir/conformance/axai/gemini-3-numeric-thinking-budget-rejected.json
@@ -1,0 +1,19 @@
+{
+  "expected_error_contains": "does not support numeric thinkingTokenBudget",
+  "kind": "ai_chat",
+  "model": "gemini-3.5-flash",
+  "name": "gemini-3-numeric-thinking-budget-rejected",
+  "provider": "google-gemini",
+  "request": {
+    "chat_prompt": [
+      {
+        "content": "think about this",
+        "role": "user"
+      }
+    ],
+    "model_config": {
+      "stream": false,
+      "thinkingTokenBudget": 2048
+    }
+  }
+}

--- a/ir/conformance/axai/gemini-3-unknown-thinking-level-rejected.json
+++ b/ir/conformance/axai/gemini-3-unknown-thinking-level-rejected.json
@@ -1,0 +1,19 @@
+{
+  "expected_error_contains": "unsupported Gemini thinkingTokenBudget level",
+  "kind": "ai_chat",
+  "model": "gemini-3.5-flash",
+  "name": "gemini-3-unknown-thinking-level-rejected",
+  "provider": "google-gemini",
+  "request": {
+    "chat_prompt": [
+      {
+        "content": "think about this",
+        "role": "user"
+      }
+    ],
+    "model_config": {
+      "stream": false,
+      "thinkingTokenBudget": "extreme"
+    }
+  }
+}

--- a/ir/conformance/axai/gemini-31-image-medium-clamps-to-high.json
+++ b/ir/conformance/axai/gemini-31-image-medium-clamps-to-high.json
@@ -1,0 +1,51 @@
+{
+  "expected_transport_json_absent": [
+    "generationConfig.thinkingConfig.thinkingBudget"
+  ],
+  "expected_transport_request": {
+    "json": {
+      "generationConfig": {
+        "thinkingConfig": {
+          "includeThoughts": true,
+          "thinkingLevel": "high"
+        }
+      }
+    }
+  },
+  "kind": "ai_chat",
+  "model": "gemini-3.1-flash-image-preview",
+  "name": "gemini-31-image-medium-clamps-to-high",
+  "provider": "google-gemini",
+  "request": {
+    "chat_prompt": [
+      {
+        "content": "think about this",
+        "role": "user"
+      }
+    ],
+    "model_config": {
+      "showThoughts": true,
+      "stream": false,
+      "thinkingTokenBudget": "medium"
+    }
+  },
+  "transport_responses": [
+    {
+      "json": {
+        "candidates": [
+          {
+            "content": {
+              "parts": [
+                {
+                  "text": "ok"
+                }
+              ]
+            },
+            "finishReason": "STOP"
+          }
+        ]
+      },
+      "status": 200
+    }
+  ]
+}

--- a/ir/conformance/axai/gemini-31-live-thinking-level.json
+++ b/ir/conformance/axai/gemini-31-live-thinking-level.json
@@ -1,0 +1,45 @@
+{
+  "expected_setup": {
+    "setup": {
+      "generationConfig": {
+        "responseModalities": ["AUDIO"],
+        "speechConfig": {
+          "voiceConfig": {
+            "prebuiltVoiceConfig": {
+              "voiceName": "Kore"
+            }
+          }
+        },
+        "thinkingConfig": {
+          "includeThoughts": true,
+          "thinkingLevel": "high"
+        }
+      },
+      "model": "models/gemini-3.1-flash-live-preview",
+      "outputAudioTranscription": {}
+    }
+  },
+  "kind": "ai_realtime",
+  "model": "gemini-3.1-flash-live-preview",
+  "name": "gemini-31-live-thinking-level",
+  "provider": "google-gemini",
+  "request": {
+    "audio": {
+      "output": {
+        "transcript": true,
+        "voice": "Kore"
+      }
+    },
+    "chat_prompt": [
+      {
+        "content": "Answer with audio.",
+        "role": "user"
+      }
+    ],
+    "model": "gemini-3.1-flash-live-preview",
+    "model_config": {
+      "showThoughts": true,
+      "thinkingTokenBudget": "high"
+    }
+  }
+}

--- a/ir/conformance/axai/gemini-31-pro-preserves-medium.json
+++ b/ir/conformance/axai/gemini-31-pro-preserves-medium.json
@@ -1,0 +1,51 @@
+{
+  "expected_transport_json_absent": [
+    "generationConfig.thinkingConfig.thinkingBudget"
+  ],
+  "expected_transport_request": {
+    "json": {
+      "generationConfig": {
+        "thinkingConfig": {
+          "includeThoughts": true,
+          "thinkingLevel": "medium"
+        }
+      }
+    }
+  },
+  "kind": "ai_chat",
+  "model": "gemini-3.1-pro-preview",
+  "name": "gemini-31-pro-preserves-medium",
+  "provider": "google-gemini",
+  "request": {
+    "chat_prompt": [
+      {
+        "content": "think about this",
+        "role": "user"
+      }
+    ],
+    "model_config": {
+      "showThoughts": true,
+      "stream": false,
+      "thinkingTokenBudget": "medium"
+    }
+  },
+  "transport_responses": [
+    {
+      "json": {
+        "candidates": [
+          {
+            "content": {
+              "parts": [
+                {
+                  "text": "ok"
+                }
+              ]
+            },
+            "finishReason": "STOP"
+          }
+        ]
+      },
+      "status": 200
+    }
+  ]
+}

--- a/ir/conformance/axai/gemini-37-custom-level-mapping-is-clamped.json
+++ b/ir/conformance/axai/gemini-37-custom-level-mapping-is-clamped.json
@@ -1,0 +1,52 @@
+{
+  "expected_transport_json_absent": [
+    "generationConfig.thinkingConfig.thinkingBudget"
+  ],
+  "expected_transport_request": {
+    "json": {
+      "generationConfig": {
+        "thinkingConfig": {
+          "thinkingLevel": "low"
+        }
+      }
+    }
+  },
+  "kind": "ai_chat",
+  "model": "gemini-3.7-flash",
+  "name": "gemini-37-custom-level-mapping-is-clamped",
+  "provider": "google-gemini",
+  "request": {
+    "chat_prompt": [
+      {
+        "content": "think about this",
+        "role": "user"
+      }
+    ],
+    "model_config": {
+      "stream": false,
+      "thinkingLevelMapping": {
+        "high": "minimal"
+      },
+      "thinkingTokenBudget": "high"
+    }
+  },
+  "transport_responses": [
+    {
+      "json": {
+        "candidates": [
+          {
+            "content": {
+              "parts": [
+                {
+                  "text": "ok"
+                }
+              ]
+            },
+            "finishReason": "STOP"
+          }
+        ]
+      },
+      "status": 200
+    }
+  ]
+}

--- a/ir/conformance/axai/gemini-37-minimal-clamps-to-low.json
+++ b/ir/conformance/axai/gemini-37-minimal-clamps-to-low.json
@@ -1,0 +1,51 @@
+{
+  "expected_transport_json_absent": [
+    "generationConfig.thinkingConfig.thinkingBudget"
+  ],
+  "expected_transport_request": {
+    "json": {
+      "generationConfig": {
+        "thinkingConfig": {
+          "includeThoughts": true,
+          "thinkingLevel": "low"
+        }
+      }
+    }
+  },
+  "kind": "ai_chat",
+  "model": "gemini-3.7-flash",
+  "name": "gemini-37-minimal-clamps-to-low",
+  "provider": "google-gemini",
+  "request": {
+    "chat_prompt": [
+      {
+        "content": "think about this",
+        "role": "user"
+      }
+    ],
+    "model_config": {
+      "showThoughts": true,
+      "stream": false,
+      "thinkingTokenBudget": "minimal"
+    }
+  },
+  "transport_responses": [
+    {
+      "json": {
+        "candidates": [
+          {
+            "content": {
+              "parts": [
+                {
+                  "text": "ok"
+                }
+              ]
+            },
+            "finishReason": "STOP"
+          }
+        ]
+      },
+      "status": 200
+    }
+  ]
+}

--- a/ir/conformance/axai/gemini-37-none-clamps-to-low-and-hides-thoughts.json
+++ b/ir/conformance/axai/gemini-37-none-clamps-to-low-and-hides-thoughts.json
@@ -1,0 +1,51 @@
+{
+  "expected_transport_json_absent": [
+    "generationConfig.thinkingConfig.thinkingBudget"
+  ],
+  "expected_transport_request": {
+    "json": {
+      "generationConfig": {
+        "thinkingConfig": {
+          "includeThoughts": false,
+          "thinkingLevel": "low"
+        }
+      }
+    }
+  },
+  "kind": "ai_chat",
+  "model": "gemini-3.7-flash",
+  "name": "gemini-37-none-clamps-to-low-and-hides-thoughts",
+  "provider": "google-gemini",
+  "request": {
+    "chat_prompt": [
+      {
+        "content": "think about this",
+        "role": "user"
+      }
+    ],
+    "model_config": {
+      "showThoughts": true,
+      "stream": false,
+      "thinkingTokenBudget": "none"
+    }
+  },
+  "transport_responses": [
+    {
+      "json": {
+        "candidates": [
+          {
+            "content": {
+              "parts": [
+                {
+                  "text": "ok"
+                }
+              ]
+            },
+            "finishReason": "STOP"
+          }
+        ]
+      },
+      "status": 200
+    }
+  ]
+}

--- a/ir/conformance/axai/gemini-legacy-3-pro-medium-clamps-to-high.json
+++ b/ir/conformance/axai/gemini-legacy-3-pro-medium-clamps-to-high.json
@@ -1,0 +1,51 @@
+{
+  "expected_transport_json_absent": [
+    "generationConfig.thinkingConfig.thinkingBudget"
+  ],
+  "expected_transport_request": {
+    "json": {
+      "generationConfig": {
+        "thinkingConfig": {
+          "includeThoughts": true,
+          "thinkingLevel": "high"
+        }
+      }
+    }
+  },
+  "kind": "ai_chat",
+  "model": "gemini-3-pro-preview",
+  "name": "gemini-legacy-3-pro-medium-clamps-to-high",
+  "provider": "google-gemini",
+  "request": {
+    "chat_prompt": [
+      {
+        "content": "think about this",
+        "role": "user"
+      }
+    ],
+    "model_config": {
+      "showThoughts": true,
+      "stream": false,
+      "thinkingTokenBudget": "medium"
+    }
+  },
+  "transport_responses": [
+    {
+      "json": {
+        "candidates": [
+          {
+            "content": {
+              "parts": [
+                {
+                  "text": "ok"
+                }
+              ]
+            },
+            "finishReason": "STOP"
+          }
+        ]
+      },
+      "status": 200
+    }
+  ]
+}

--- a/ir/conformance/axai/gemini-live-thinking-native-vertex-path.json
+++ b/ir/conformance/axai/gemini-live-thinking-native-vertex-path.json
@@ -1,0 +1,47 @@
+{
+  "expected_setup": {
+    "setup": {
+      "generationConfig": {
+        "responseModalities": ["AUDIO"],
+        "speechConfig": {
+          "voiceConfig": {
+            "prebuiltVoiceConfig": {
+              "voiceName": "Kore"
+            }
+          }
+        },
+        "thinkingConfig": {
+          "thinkingLevel": "high"
+        }
+      },
+      "model": "models/gemini-3.1-flash-live-preview",
+      "outputAudioTranscription": {}
+    }
+  },
+  "kind": "ai_realtime",
+  "model": "gemini-3.1-flash-live-preview",
+  "name": "gemini-live-thinking-native-vertex-path",
+  "provider": "google-gemini",
+  "request": {
+    "audio": {
+      "output": {
+        "transcript": true,
+        "voice": "Kore"
+      }
+    },
+    "chat_prompt": [
+      {
+        "content": "Answer with audio.",
+        "role": "user"
+      }
+    ],
+    "model": "gemini-3.1-flash-live-preview",
+    "model_config": {
+      "thinkingTokenBudget": "high"
+    }
+  },
+  "service_options": {
+    "projectId": "demo-project",
+    "region": "us-central1"
+  }
+}

--- a/ir/conformance/axai/gemini-live-thinking-profile-alias-gemini.json
+++ b/ir/conformance/axai/gemini-live-thinking-profile-alias-gemini.json
@@ -1,0 +1,43 @@
+{
+  "expected_setup": {
+    "setup": {
+      "generationConfig": {
+        "responseModalities": ["AUDIO"],
+        "speechConfig": {
+          "voiceConfig": {
+            "prebuiltVoiceConfig": {
+              "voiceName": "Kore"
+            }
+          }
+        },
+        "thinkingConfig": {
+          "thinkingLevel": "high"
+        }
+      },
+      "model": "models/gemini-3.1-flash-live-preview",
+      "outputAudioTranscription": {}
+    }
+  },
+  "kind": "ai_realtime",
+  "model": "gemini-3.1-flash-live-preview",
+  "name": "gemini-live-thinking-profile-alias-gemini",
+  "provider": "gemini",
+  "request": {
+    "audio": {
+      "output": {
+        "transcript": true,
+        "voice": "Kore"
+      }
+    },
+    "chat_prompt": [
+      {
+        "content": "Answer with audio.",
+        "role": "user"
+      }
+    ],
+    "model": "gemini-3.1-flash-live-preview",
+    "model_config": {
+      "thinkingTokenBudget": "high"
+    }
+  }
+}

--- a/ir/conformance/axai/gemini-live-thinking-profile-alias-google-gemini.json
+++ b/ir/conformance/axai/gemini-live-thinking-profile-alias-google-gemini.json
@@ -1,0 +1,43 @@
+{
+  "expected_setup": {
+    "setup": {
+      "generationConfig": {
+        "responseModalities": ["AUDIO"],
+        "speechConfig": {
+          "voiceConfig": {
+            "prebuiltVoiceConfig": {
+              "voiceName": "Kore"
+            }
+          }
+        },
+        "thinkingConfig": {
+          "thinkingLevel": "high"
+        }
+      },
+      "model": "models/gemini-3.1-flash-live-preview",
+      "outputAudioTranscription": {}
+    }
+  },
+  "kind": "ai_realtime",
+  "model": "gemini-3.1-flash-live-preview",
+  "name": "gemini-live-thinking-profile-alias-google-gemini",
+  "provider": "google_gemini",
+  "request": {
+    "audio": {
+      "output": {
+        "transcript": true,
+        "voice": "Kore"
+      }
+    },
+    "chat_prompt": [
+      {
+        "content": "Answer with audio.",
+        "role": "user"
+      }
+    ],
+    "model": "gemini-3.1-flash-live-preview",
+    "model_config": {
+      "thinkingTokenBudget": "high"
+    }
+  }
+}

--- a/ir/conformance/axai/gemini-thinking-config-reaches-the-request.json
+++ b/ir/conformance/axai/gemini-thinking-config-reaches-the-request.json
@@ -10,7 +10,7 @@
     }
   },
   "kind": "ai_chat",
-  "model": "gemini-3.5-flash",
+  "model": "gemini-2.5-flash",
   "name": "gemini-thinking-config-reaches-the-request",
   "provider": "google-gemini",
   "request": {

--- a/ir/conformance/axai/gemini-thinking-level-routes-away-from-the-budget.json
+++ b/ir/conformance/axai/gemini-thinking-level-routes-away-from-the-budget.json
@@ -1,0 +1,48 @@
+{
+  "expected_transport_request": {
+    "json": {
+      "generationConfig": {
+        "thinkingConfig": {
+          "includeThoughts": true,
+          "thinkingLevel": "high"
+        }
+      }
+    }
+  },
+  "kind": "ai_chat",
+  "model": "gemini-3.5-flash",
+  "name": "gemini-thinking-level-routes-away-from-the-budget",
+  "provider": "google-gemini",
+  "request": {
+    "chat_prompt": [
+      {
+        "content": "think hard",
+        "role": "user"
+      }
+    ],
+    "model_config": {
+      "showThoughts": true,
+      "stream": false,
+      "thinkingTokenBudget": "highest"
+    }
+  },
+  "transport_responses": [
+    {
+      "json": {
+        "candidates": [
+          {
+            "content": {
+              "parts": [
+                {
+                  "text": "ok"
+                }
+              ]
+            },
+            "finishReason": "STOP"
+          }
+        ]
+      },
+      "status": 200
+    }
+  ]
+}

--- a/ir/conformance/axai/gemini-thinking-native-vertex-path.json
+++ b/ir/conformance/axai/gemini-thinking-native-vertex-path.json
@@ -1,0 +1,50 @@
+{
+  "expected_transport_request": {
+    "json": {
+      "generationConfig": {
+        "thinkingConfig": {
+          "thinkingLevel": "high"
+        }
+      }
+    }
+  },
+  "kind": "ai_chat",
+  "model": "gemini-3.5-flash",
+  "name": "gemini-thinking-native-vertex-path",
+  "provider": "google-gemini",
+  "request": {
+    "chat_prompt": [
+      {
+        "content": "think hard",
+        "role": "user"
+      }
+    ],
+    "model_config": {
+      "stream": false,
+      "thinkingTokenBudget": "high"
+    }
+  },
+  "service_options": {
+    "projectId": "demo-project",
+    "region": "us-central1"
+  },
+  "transport_responses": [
+    {
+      "json": {
+        "candidates": [
+          {
+            "content": {
+              "parts": [
+                {
+                  "text": "ok"
+                }
+              ]
+            },
+            "finishReason": "STOP"
+          }
+        ]
+      },
+      "status": 200
+    }
+  ]
+}

--- a/ir/conformance/axai/gemini-thinking-profile-alias-gemini.json
+++ b/ir/conformance/axai/gemini-thinking-profile-alias-gemini.json
@@ -1,0 +1,46 @@
+{
+  "expected_transport_request": {
+    "json": {
+      "generationConfig": {
+        "thinkingConfig": {
+          "thinkingLevel": "high"
+        }
+      }
+    }
+  },
+  "kind": "ai_chat",
+  "model": "gemini-3.5-flash",
+  "name": "gemini-thinking-profile-alias-gemini",
+  "provider": "gemini",
+  "request": {
+    "chat_prompt": [
+      {
+        "content": "think hard",
+        "role": "user"
+      }
+    ],
+    "model_config": {
+      "stream": false,
+      "thinkingTokenBudget": "high"
+    }
+  },
+  "transport_responses": [
+    {
+      "json": {
+        "candidates": [
+          {
+            "content": {
+              "parts": [
+                {
+                  "text": "ok"
+                }
+              ]
+            },
+            "finishReason": "STOP"
+          }
+        ]
+      },
+      "status": 200
+    }
+  ]
+}

--- a/ir/conformance/axai/gemini-thinking-profile-alias-google-gemini.json
+++ b/ir/conformance/axai/gemini-thinking-profile-alias-google-gemini.json
@@ -1,0 +1,46 @@
+{
+  "expected_transport_request": {
+    "json": {
+      "generationConfig": {
+        "thinkingConfig": {
+          "thinkingLevel": "high"
+        }
+      }
+    }
+  },
+  "kind": "ai_chat",
+  "model": "gemini-3.5-flash",
+  "name": "gemini-thinking-profile-alias-google-gemini",
+  "provider": "google_gemini",
+  "request": {
+    "chat_prompt": [
+      {
+        "content": "think hard",
+        "role": "user"
+      }
+    ],
+    "model_config": {
+      "stream": false,
+      "thinkingTokenBudget": "high"
+    }
+  },
+  "transport_responses": [
+    {
+      "json": {
+        "candidates": [
+          {
+            "content": {
+              "parts": [
+                {
+                  "text": "ok"
+                }
+              ]
+            },
+            "finishReason": "STOP"
+          }
+        ]
+      },
+      "status": 200
+    }
+  ]
+}

--- a/ir/conformance/axai/vertex-openai-gemini-model-does-not-inherit-native-thinking.json
+++ b/ir/conformance/axai/vertex-openai-gemini-model-does-not-inherit-native-thinking.json
@@ -1,0 +1,44 @@
+{
+  "base_url": "https://vertex.example.test/v1",
+  "expected_transport_json_absent": [
+    "generationConfig",
+    "thinkingConfig",
+    "thinkingLevel",
+    "thinking_level",
+    "thinkingBudget",
+    "thinking_budget"
+  ],
+  "kind": "ai_chat",
+  "model": "gemini-3.5-flash",
+  "name": "vertex-openai-gemini-model-does-not-inherit-native-thinking",
+  "provider": "vertex-ai",
+  "request": {
+    "chat_prompt": [
+      {
+        "content": "think hard",
+        "role": "user"
+      }
+    ],
+    "model_config": {
+      "stream": false,
+      "thinkingTokenBudget": "high"
+    }
+  },
+  "transport_responses": [
+    {
+      "json": {
+        "choices": [
+          {
+            "finish_reason": "stop",
+            "index": 0,
+            "message": {
+              "content": "ok",
+              "role": "assistant"
+            }
+          }
+        ]
+      },
+      "status": 200
+    }
+  ]
+}

--- a/packages/cpp/axir-provenance.json
+++ b/packages/cpp/axir-provenance.json
@@ -1,11 +1,11 @@
 {
   "target": "cpp",
   "enforced": true,
-  "emitted_functions": 593,
+  "emitted_functions": 595,
   "files": {
     "axllm/axllm.cpp": {
-      "emitted_lines": 24577,
-      "total_lines": 31313
+      "emitted_lines": 24746,
+      "total_lines": 31482
     }
   }
 }

--- a/packages/cpp/axir-provenance.json
+++ b/packages/cpp/axir-provenance.json
@@ -4,8 +4,8 @@
   "emitted_functions": 593,
   "files": {
     "axllm/axllm.cpp": {
-      "emitted_lines": 24546,
-      "total_lines": 31282
+      "emitted_lines": 24577,
+      "total_lines": 31313
     }
   }
 }

--- a/packages/cpp/axllm/axllm.cpp
+++ b/packages/cpp/axllm/axllm.cpp
@@ -9499,7 +9499,38 @@ Value Core::_gemini_apply_model_config_impl(Value payload, Value model_config, V
   Value budget = Core::get(model_config, Value("thinkingTokenBudget"), budget_snake);
   Value has_budget = Core::is_not_none(budget);
   if (Core::truthy(has_budget)) {
-    Core::set(thinking_config, Value("thinkingBudget"), budget);
+    Value level = Value("");
+    Value is_none = Core::eq(budget, Value("none"));
+    if (Core::truthy(is_none)) {
+      level = Value("minimal");
+    }
+    Value is_minimal = Core::eq(budget, Value("minimal"));
+    if (Core::truthy(is_minimal)) {
+      level = Value("minimal");
+    }
+    Value is_low = Core::eq(budget, Value("low"));
+    if (Core::truthy(is_low)) {
+      level = Value("low");
+    }
+    Value is_medium = Core::eq(budget, Value("medium"));
+    if (Core::truthy(is_medium)) {
+      level = Value("medium");
+    }
+    Value is_high = Core::eq(budget, Value("high"));
+    if (Core::truthy(is_high)) {
+      level = Value("high");
+    }
+    Value is_highest = Core::eq(budget, Value("highest"));
+    if (Core::truthy(is_highest)) {
+      level = Value("high");
+    }
+    Value named_level = Core::eq(level, Value(""));
+    if (Core::truthy(named_level)) {
+      Core::set(thinking_config, Value("thinkingBudget"), budget);
+    }
+    if (!Core::truthy(named_level)) {
+      Core::set(thinking_config, Value("thinkingLevel"), level);
+    }
     has_thinking = Value(true);
   }
   Value show_snake = Core::get(model_config, Value("show_thoughts"), Value());

--- a/packages/cpp/axllm/axllm.cpp
+++ b/packages/cpp/axllm/axllm.cpp
@@ -7293,6 +7293,9 @@ Value Core::_gemini_live_bidi_build_setup(Value descriptor, Value request) {
   Core::set(voice_config, Value("prebuiltVoiceConfig"), prebuilt_voice);
   Core::set(speech_config, Value("voiceConfig"), voice_config);
   Core::set(generation_config, Value("speechConfig"), speech_config);
+  Value empty_model_config = Value::object();
+  Value model_config = Core::get(request, Value("model_config"), empty_model_config);
+  Core::_gemini_apply_thinking_config_impl(generation_config, request_model, model_config);
   Core::set(setup, Value("generationConfig"), generation_config);
   Value include_transcript = Core::get(request_output_audio, Value("transcript"), Value(true));
   if (Core::truthy(include_transcript)) {
@@ -9426,7 +9429,7 @@ Value Core::_gemini_build_chat_request(Value request, Value options, Value is_ve
   Core::set(generation_config, Value("responseMimeType"), Value("text/plain"));
   Value empty_model_config = Value::object();
   Value model_config = Core::get(request, Value("model_config"), empty_model_config);
-  Core::_gemini_apply_model_config_impl(generation_config, model_config, server_managed_sampling);
+  Core::_gemini_apply_model_config_impl(generation_config, model, model_config, server_managed_sampling);
   Value response_format = Core::get(request, Value("response_format"), Value());
   Value has_response_format = Core::truthy_value(response_format);
   if (Core::truthy(has_response_format)) {
@@ -9476,7 +9479,222 @@ Value Core::_gemini_build_chat_request(Value request, Value options, Value is_ve
   return payload;
 }
 
-Value Core::_gemini_apply_model_config_impl(Value payload, Value model_config, Value server_managed_sampling) {
+Value Core::_gemini_clamp_thinking_level_impl(Value model, Value level) {
+  axir_coverage_mark("_gemini_clamp_thinking_level_impl");
+  Value is_minimal = Core::eq(level, Value("minimal"));
+  Value is_low = Core::eq(level, Value("low"));
+  Value is_medium = Core::eq(level, Value("medium"));
+  Value is_high = Core::eq(level, Value("high"));
+  Value is_minimal_or_low = Core::or_(is_minimal, is_low);
+  Value is_medium_or_high = Core::or_(is_medium, is_high);
+  Value is_supported_level = Core::or_(is_minimal_or_low, is_medium_or_high);
+  if (Core::truthy(is_supported_level)) {
+    // empty
+  }
+  if (!Core::truthy(is_supported_level)) {
+    Value message = Core::string_format(Value("unsupported Gemini thinking level: {}"), level);
+    Value error = Core::ai_error_unsupported(message);
+    throw Core::as_error(error);
+  }
+  Value is_gemini3 = Core::contains(model, Value("gemini-3"));
+  Value is_image_name = Core::contains(model, Value("-image"));
+  Value is_image = Core::and_(is_gemini3, is_image_name);
+  if (Core::truthy(is_image)) {
+    if (Core::truthy(is_minimal_or_low)) {
+      return Value("minimal");
+    }
+    return Value("high");
+  }
+  Value is_legacy_pro_name = Core::contains(model, Value("gemini-3-pro"));
+  Value is_legacy_pro = Core::and_(is_gemini3, is_legacy_pro_name);
+  if (Core::truthy(is_legacy_pro)) {
+    if (Core::truthy(is_minimal_or_low)) {
+      return Value("low");
+    }
+    return Value("high");
+  }
+  Value is_37_flash = Core::contains(model, Value("gemini-3.7-flash"));
+  Value is_31_pro = Core::contains(model, Value("gemini-3.1-pro"));
+  Value no_minimal_name = Core::or_(is_37_flash, is_31_pro);
+  Value no_minimal = Core::and_(is_gemini3, no_minimal_name);
+  Value clamp_minimal = Core::and_(no_minimal, is_minimal);
+  if (Core::truthy(clamp_minimal)) {
+    return Value("low");
+  }
+  return level;
+}
+
+Value Core::_gemini_apply_thinking_config_impl(Value payload, Value model, Value model_config) {
+  axir_coverage_mark("_gemini_apply_thinking_config_impl");
+  Value thinking_config = Value::object();
+  Value has_thinking = Value(false);
+  Value budget_is_none = Value(false);
+  Value is_gemini3 = Core::contains(model, Value("gemini-3"));
+  Value is_25_pro = Core::contains(model, Value("gemini-2.5-pro"));
+  Value empty_level_mapping = Value::object();
+  Value level_mapping_snake = Core::get(model_config, Value("thinking_level_mapping"), empty_level_mapping);
+  Value level_mapping = Core::get(model_config, Value("thinkingLevelMapping"), level_mapping_snake);
+  Value empty_budget_levels = Value::object();
+  Value budget_levels_snake = Core::get(model_config, Value("thinking_token_budget_levels"), empty_budget_levels);
+  Value budget_levels = Core::get(model_config, Value("thinkingTokenBudgetLevels"), budget_levels_snake);
+  Value minimum_budget = Core::get(budget_levels, Value("minimal"), Value(200));
+  Value low_budget = Core::get(budget_levels, Value("low"), Value(800));
+  Value medium_budget = Core::get(budget_levels, Value("medium"), Value(5000));
+  Value high_budget = Core::get(budget_levels, Value("high"), Value(10000));
+  Value highest_budget = Core::get(budget_levels, Value("highest"), Value(24500));
+  Value budget_snake = Core::get(model_config, Value("thinking_token_budget"), Value());
+  Value budget = Core::get(model_config, Value("thinkingTokenBudget"), budget_snake);
+  Value has_budget = Core::is_not_none(budget);
+  if (Core::truthy(has_budget)) {
+    Value budget_is_number = Core::type_is(budget, Value("number"));
+    Value budget_is_string = Core::type_is(budget, Value("string"));
+    if (Core::truthy(is_gemini3)) {
+      if (Core::truthy(budget_is_number)) {
+        Value message = Core::string_format(Value("Gemini 3 model {} does not support numeric thinkingTokenBudget"), model);
+        Value error = Core::ai_error_unsupported(message);
+        throw Core::as_error(error);
+      }
+      if (Core::truthy(budget_is_string)) {
+        // empty
+      }
+      if (!Core::truthy(budget_is_string)) {
+        Value error = Core::ai_error_unsupported(Value("Gemini thinkingTokenBudget must be a number or logical level"));
+        throw Core::as_error(error);
+      }
+      Value level = Value("");
+      Value is_none = Core::eq(budget, Value("none"));
+      if (Core::truthy(is_none)) {
+        level = Value("minimal");
+        budget_is_none = Value(true);
+      }
+      Value is_minimal = Core::eq(budget, Value("minimal"));
+      if (Core::truthy(is_minimal)) {
+        level = Value("minimal");
+      }
+      Value is_low = Core::eq(budget, Value("low"));
+      if (Core::truthy(is_low)) {
+        level = Value("low");
+      }
+      Value is_medium = Core::eq(budget, Value("medium"));
+      if (Core::truthy(is_medium)) {
+        level = Value("medium");
+      }
+      Value is_high = Core::eq(budget, Value("high"));
+      if (Core::truthy(is_high)) {
+        level = Value("high");
+      }
+      Value is_highest = Core::eq(budget, Value("highest"));
+      if (Core::truthy(is_highest)) {
+        level = Value("high");
+      }
+      Value unknown_level = Core::eq(level, Value(""));
+      if (Core::truthy(unknown_level)) {
+        Value message = Core::string_format(Value("unsupported Gemini thinkingTokenBudget level: {}"), budget);
+        Value error = Core::ai_error_unsupported(message);
+        throw Core::as_error(error);
+      }
+      Value mapping_key = budget;
+      if (Core::truthy(is_none)) {
+        mapping_key = Value("minimal");
+      }
+      Value mapped_level = Core::get(level_mapping, mapping_key, level);
+      Value clamped_level = Core::_gemini_clamp_thinking_level_impl(model, mapped_level);
+      Core::set(thinking_config, Value("thinkingLevel"), clamped_level);
+    }
+    if (!Core::truthy(is_gemini3)) {
+      if (Core::truthy(budget_is_number)) {
+        Value numeric_budget = budget;
+        Value is_zero = Core::eq(budget, Value(0));
+        Value clamp_pro_zero = Core::and_(is_25_pro, is_zero);
+        if (Core::truthy(clamp_pro_zero)) {
+          numeric_budget = minimum_budget;
+        }
+        Core::set(thinking_config, Value("thinkingBudget"), numeric_budget);
+      }
+      if (!Core::truthy(budget_is_number)) {
+        if (Core::truthy(budget_is_string)) {
+          // empty
+        }
+        if (!Core::truthy(budget_is_string)) {
+          Value error = Core::ai_error_unsupported(Value("Gemini thinkingTokenBudget must be a number or logical level"));
+          throw Core::as_error(error);
+        }
+        Value numeric_budget = Value(-1);
+        Value is_none = Core::eq(budget, Value("none"));
+        if (Core::truthy(is_none)) {
+          numeric_budget = Value(0);
+          if (Core::truthy(is_25_pro)) {
+            numeric_budget = minimum_budget;
+          }
+          budget_is_none = Value(true);
+        }
+        Value is_minimal = Core::eq(budget, Value("minimal"));
+        if (Core::truthy(is_minimal)) {
+          numeric_budget = minimum_budget;
+        }
+        Value is_low = Core::eq(budget, Value("low"));
+        if (Core::truthy(is_low)) {
+          numeric_budget = low_budget;
+        }
+        Value is_medium = Core::eq(budget, Value("medium"));
+        if (Core::truthy(is_medium)) {
+          numeric_budget = medium_budget;
+        }
+        Value is_high = Core::eq(budget, Value("high"));
+        if (Core::truthy(is_high)) {
+          numeric_budget = high_budget;
+        }
+        Value is_highest = Core::eq(budget, Value("highest"));
+        if (Core::truthy(is_highest)) {
+          numeric_budget = highest_budget;
+        }
+        Value unknown_level = Core::eq(numeric_budget, Value(-1));
+        if (Core::truthy(unknown_level)) {
+          Value message = Core::string_format(Value("unsupported Gemini thinkingTokenBudget level: {}"), budget);
+          Value error = Core::ai_error_unsupported(message);
+          throw Core::as_error(error);
+        }
+        Core::set(thinking_config, Value("thinkingBudget"), numeric_budget);
+      }
+    }
+    has_thinking = Value(true);
+  }
+  Value level_snake = Core::get(model_config, Value("thinking_level"), Value());
+  Value explicit_level = Core::get(model_config, Value("thinkingLevel"), level_snake);
+  Value has_explicit_level = Core::is_not_none(explicit_level);
+  Value use_explicit_level = Core::and_(is_gemini3, has_explicit_level);
+  if (Core::truthy(use_explicit_level)) {
+    Value level_is_string = Core::type_is(explicit_level, Value("string"));
+    if (Core::truthy(level_is_string)) {
+      // empty
+    }
+    if (!Core::truthy(level_is_string)) {
+      Value error = Core::ai_error_unsupported(Value("Gemini thinkingLevel must be a logical level"));
+      throw Core::as_error(error);
+    }
+    Value clamped_level = Core::_gemini_clamp_thinking_level_impl(model, explicit_level);
+    Core::map_delete(thinking_config, Value("thinkingBudget"));
+    Core::set(thinking_config, Value("thinkingLevel"), clamped_level);
+    has_thinking = Value(true);
+  }
+  Value show_snake = Core::get(model_config, Value("show_thoughts"), Value());
+  Value show_thoughts = Core::get(model_config, Value("showThoughts"), show_snake);
+  Value has_show = Core::is_not_none(show_thoughts);
+  if (Core::truthy(has_show)) {
+    Core::set(thinking_config, Value("includeThoughts"), show_thoughts);
+    has_thinking = Value(true);
+  }
+  if (Core::truthy(budget_is_none)) {
+    Core::set(thinking_config, Value("includeThoughts"), Value(false));
+    has_thinking = Value(true);
+  }
+  if (Core::truthy(has_thinking)) {
+    Core::set(payload, Value("thinkingConfig"), thinking_config);
+  }
+  return Value();
+}
+
+Value Core::_gemini_apply_model_config_impl(Value payload, Value model, Value model_config, Value server_managed_sampling) {
   axir_coverage_mark("_gemini_apply_model_config_impl");
   Core::_openai_copy_config_key_impl(payload, model_config, Value("maxTokens"), Value("maxOutputTokens"));
   Core::_openai_copy_config_key_impl(payload, model_config, Value("max_tokens"), Value("maxOutputTokens"));
@@ -9493,56 +9711,7 @@ Value Core::_gemini_apply_model_config_impl(Value payload, Value model_config, V
   Core::_openai_copy_config_key_impl(payload, model_config, Value("n"), Value("candidateCount"));
   Core::_openai_copy_config_key_impl(payload, model_config, Value("stopSequences"), Value("stopSequences"));
   Core::_openai_copy_config_key_impl(payload, model_config, Value("stop_sequences"), Value("stopSequences"));
-  Value thinking_config = Value::object();
-  Value has_thinking = Value(false);
-  Value budget_snake = Core::get(model_config, Value("thinking_token_budget"), Value());
-  Value budget = Core::get(model_config, Value("thinkingTokenBudget"), budget_snake);
-  Value has_budget = Core::is_not_none(budget);
-  if (Core::truthy(has_budget)) {
-    Value level = Value("");
-    Value is_none = Core::eq(budget, Value("none"));
-    if (Core::truthy(is_none)) {
-      level = Value("minimal");
-    }
-    Value is_minimal = Core::eq(budget, Value("minimal"));
-    if (Core::truthy(is_minimal)) {
-      level = Value("minimal");
-    }
-    Value is_low = Core::eq(budget, Value("low"));
-    if (Core::truthy(is_low)) {
-      level = Value("low");
-    }
-    Value is_medium = Core::eq(budget, Value("medium"));
-    if (Core::truthy(is_medium)) {
-      level = Value("medium");
-    }
-    Value is_high = Core::eq(budget, Value("high"));
-    if (Core::truthy(is_high)) {
-      level = Value("high");
-    }
-    Value is_highest = Core::eq(budget, Value("highest"));
-    if (Core::truthy(is_highest)) {
-      level = Value("high");
-    }
-    Value named_level = Core::eq(level, Value(""));
-    if (Core::truthy(named_level)) {
-      Core::set(thinking_config, Value("thinkingBudget"), budget);
-    }
-    if (!Core::truthy(named_level)) {
-      Core::set(thinking_config, Value("thinkingLevel"), level);
-    }
-    has_thinking = Value(true);
-  }
-  Value show_snake = Core::get(model_config, Value("show_thoughts"), Value());
-  Value show_thoughts = Core::get(model_config, Value("showThoughts"), show_snake);
-  Value has_show = Core::is_not_none(show_thoughts);
-  if (Core::truthy(has_show)) {
-    Core::set(thinking_config, Value("includeThoughts"), show_thoughts);
-    has_thinking = Value(true);
-  }
-  if (Core::truthy(has_thinking)) {
-    Core::set(payload, Value("thinkingConfig"), thinking_config);
-  }
+  Core::_gemini_apply_thinking_config_impl(payload, model, model_config);
   return Value();
 }
 

--- a/packages/cpp/axllm/axllm.hpp
+++ b/packages/cpp/axllm/axllm.hpp
@@ -511,7 +511,9 @@ struct Core {
   static Value _gemini_live_bidi_normalize_realtime_event(Value event, Value state, Value ai_name, Value model);
   static Value _gemini_service_tier_impl(Value request, Value options, Value vertex, Value live);
   static Value _gemini_build_chat_request(Value request, Value options, Value is_vertex);
-  static Value _gemini_apply_model_config_impl(Value payload, Value model_config, Value server_managed_sampling);
+  static Value _gemini_clamp_thinking_level_impl(Value model, Value level);
+  static Value _gemini_apply_thinking_config_impl(Value payload, Value model, Value model_config);
+  static Value _gemini_apply_model_config_impl(Value payload, Value model, Value model_config, Value server_managed_sampling);
   static Value _gemini_message_impl(Value message);
   static Value _gemini_content_parts_impl(Value content);
   static Value _gemini_content_part_impl(Value part);

--- a/packages/go/axir-provenance.json
+++ b/packages/go/axir-provenance.json
@@ -4,8 +4,8 @@
   "emitted_functions": 593,
   "files": {
     "axllm.go": {
-      "emitted_lines": 51268,
-      "total_lines": 63826
+      "emitted_lines": 51326,
+      "total_lines": 63884
     }
   }
 }

--- a/packages/go/axir-provenance.json
+++ b/packages/go/axir-provenance.json
@@ -1,11 +1,11 @@
 {
   "target": "go",
   "enforced": true,
-  "emitted_functions": 593,
+  "emitted_functions": 595,
   "files": {
     "axllm.go": {
-      "emitted_lines": 51326,
-      "total_lines": 63884
+      "emitted_lines": 51646,
+      "total_lines": 64204
     }
   }
 }

--- a/packages/go/axllm.go
+++ b/packages/go/axllm.go
@@ -17310,6 +17310,14 @@ func _gemini_apply_model_config_impl(args ...Value) (Value, error) {
 	var v_has_budget Value
 	var v_has_show Value
 	var v_has_thinking Value
+	var v_is_high Value
+	var v_is_highest Value
+	var v_is_low Value
+	var v_is_medium Value
+	var v_is_minimal Value
+	var v_is_none Value
+	var v_level Value
+	var v_named_level Value
 	var v_show_snake Value
 	var v_show_thoughts Value
 	var v_thinking_config Value
@@ -17325,6 +17333,14 @@ func _gemini_apply_model_config_impl(args ...Value) (Value, error) {
 	_ = v_has_budget
 	_ = v_has_show
 	_ = v_has_thinking
+	_ = v_is_high
+	_ = v_is_highest
+	_ = v_is_low
+	_ = v_is_medium
+	_ = v_is_minimal
+	_ = v_is_none
+	_ = v_level
+	_ = v_named_level
 	_ = v_show_snake
 	_ = v_show_thoughts
 	_ = v_thinking_config
@@ -17351,7 +17367,49 @@ func _gemini_apply_model_config_impl(args ...Value) (Value, error) {
 	v_budget = coreGet(v_model_config, "thinkingTokenBudget", v_budget_snake)
 	v_has_budget = _core_is_not_none(v_budget)
 	if coreTruthy(v_has_budget) {
-		if err := coreSet(v_thinking_config, "thinkingBudget", v_budget); err != nil { return nil, err }
+		v_level = ""
+		v_is_none = _core_eq(v_budget, "none")
+		if coreTruthy(v_is_none) {
+			v_level = "minimal"
+		} else {
+		// empty
+		}
+		v_is_minimal = _core_eq(v_budget, "minimal")
+		if coreTruthy(v_is_minimal) {
+			v_level = "minimal"
+		} else {
+		// empty
+		}
+		v_is_low = _core_eq(v_budget, "low")
+		if coreTruthy(v_is_low) {
+			v_level = "low"
+		} else {
+		// empty
+		}
+		v_is_medium = _core_eq(v_budget, "medium")
+		if coreTruthy(v_is_medium) {
+			v_level = "medium"
+		} else {
+		// empty
+		}
+		v_is_high = _core_eq(v_budget, "high")
+		if coreTruthy(v_is_high) {
+			v_level = "high"
+		} else {
+		// empty
+		}
+		v_is_highest = _core_eq(v_budget, "highest")
+		if coreTruthy(v_is_highest) {
+			v_level = "high"
+		} else {
+		// empty
+		}
+		v_named_level = _core_eq(v_level, "")
+		if coreTruthy(v_named_level) {
+			if err := coreSet(v_thinking_config, "thinkingBudget", v_budget); err != nil { return nil, err }
+		} else {
+			if err := coreSet(v_thinking_config, "thinkingLevel", v_level); err != nil { return nil, err }
+		}
 		v_has_thinking = true
 	} else {
 	// empty

--- a/packages/go/axllm.go
+++ b/packages/go/axllm.go
@@ -12608,6 +12608,7 @@ func _gemini_live_bidi_build_setup(args ...Value) (Value, error) {
 	var v_audio_descriptor Value
 	var v_default_model Value
 	var v_default_voice Value
+	var v_empty_model_config Value
 	var v_error Value
 	var v_generation_config Value
 	var v_has_instructions Value
@@ -12616,6 +12617,7 @@ func _gemini_live_bidi_build_setup(args ...Value) (Value, error) {
 	var v_instructions Value
 	var v_modalities Value
 	var v_model Value
+	var v_model_config Value
 	var v_model_prefix Value
 	var v_out Value
 	var v_output_audio_descriptor Value
@@ -12640,6 +12642,7 @@ func _gemini_live_bidi_build_setup(args ...Value) (Value, error) {
 	_ = v_audio_descriptor
 	_ = v_default_model
 	_ = v_default_voice
+	_ = v_empty_model_config
 	_ = v_error
 	_ = v_generation_config
 	_ = v_has_instructions
@@ -12648,6 +12651,7 @@ func _gemini_live_bidi_build_setup(args ...Value) (Value, error) {
 	_ = v_instructions
 	_ = v_modalities
 	_ = v_model
+	_ = v_model_config
 	_ = v_model_prefix
 	_ = v_out
 	_ = v_output_audio_descriptor
@@ -12701,6 +12705,9 @@ func _gemini_live_bidi_build_setup(args ...Value) (Value, error) {
 	if err := coreSet(v_voice_config, "prebuiltVoiceConfig", v_prebuilt_voice); err != nil { return nil, err }
 	if err := coreSet(v_speech_config, "voiceConfig", v_voice_config); err != nil { return nil, err }
 	if err := coreSet(v_generation_config, "speechConfig", v_speech_config); err != nil { return nil, err }
+	v_empty_model_config = Object()
+	v_model_config = coreGet(v_request, "model_config", v_empty_model_config)
+	if _, err := _gemini_apply_thinking_config_impl(v_generation_config, v_request_model, v_model_config); err != nil { return nil, err }
 	if err := coreSet(v_setup, "generationConfig", v_generation_config); err != nil { return nil, err }
 	v_include_transcript = coreGet(v_request_output_audio, "transcript", true)
 	if coreTruthy(v_include_transcript) {
@@ -17240,7 +17247,7 @@ func _gemini_build_chat_request(args ...Value) (Value, error) {
 	if err := coreSet(v_generation_config, "responseMimeType", "text/plain"); err != nil { return nil, err }
 	v_empty_model_config = Object()
 	v_model_config = coreGet(v_request, "model_config", v_empty_model_config)
-	if _, err := _gemini_apply_model_config_impl(v_generation_config, v_model_config, v_server_managed_sampling); err != nil { return nil, err }
+	if _, err := _gemini_apply_model_config_impl(v_generation_config, v_model, v_model_config, v_server_managed_sampling); err != nil { return nil, err }
 	v_response_format = coreGet(v_request, "response_format", nil)
 	v_has_response_format = _core_truthy(v_response_format)
 	if coreTruthy(v_has_response_format) {
@@ -17299,51 +17306,430 @@ func _gemini_build_chat_request(args ...Value) (Value, error) {
 	return v_payload, nil
 }
 
-func _gemini_apply_model_config_impl(args ...Value) (Value, error) {
-	axirCoverageMark("_gemini_apply_model_config_impl")
+func _gemini_clamp_thinking_level_impl(args ...Value) (Value, error) {
+	axirCoverageMark("_gemini_clamp_thinking_level_impl")
+	var v_model Value
+	var v_level Value
+	var v_clamp_minimal Value
+	var v_error Value
+	var v_is_31_pro Value
+	var v_is_37_flash Value
+	var v_is_gemini3 Value
+	var v_is_high Value
+	var v_is_image Value
+	var v_is_image_name Value
+	var v_is_legacy_pro Value
+	var v_is_legacy_pro_name Value
+	var v_is_low Value
+	var v_is_medium Value
+	var v_is_medium_or_high Value
+	var v_is_minimal Value
+	var v_is_minimal_or_low Value
+	var v_is_supported_level Value
+	var v_message Value
+	var v_no_minimal Value
+	var v_no_minimal_name Value
+	if len(args) > 0 { v_model = args[0] }
+	_ = v_model
+	if len(args) > 1 { v_level = args[1] }
+	_ = v_level
+	_ = v_clamp_minimal
+	_ = v_error
+	_ = v_is_31_pro
+	_ = v_is_37_flash
+	_ = v_is_gemini3
+	_ = v_is_high
+	_ = v_is_image
+	_ = v_is_image_name
+	_ = v_is_legacy_pro
+	_ = v_is_legacy_pro_name
+	_ = v_is_low
+	_ = v_is_medium
+	_ = v_is_medium_or_high
+	_ = v_is_minimal
+	_ = v_is_minimal_or_low
+	_ = v_is_supported_level
+	_ = v_message
+	_ = v_no_minimal
+	_ = v_no_minimal_name
+	v_is_minimal = _core_eq(v_level, "minimal")
+	v_is_low = _core_eq(v_level, "low")
+	v_is_medium = _core_eq(v_level, "medium")
+	v_is_high = _core_eq(v_level, "high")
+	v_is_minimal_or_low = _core_or(v_is_minimal, v_is_low)
+	v_is_medium_or_high = _core_or(v_is_medium, v_is_high)
+	v_is_supported_level = _core_or(v_is_minimal_or_low, v_is_medium_or_high)
+	if coreTruthy(v_is_supported_level) {
+	// empty
+	} else {
+		v_message = _core_string_format("unsupported Gemini thinking level: {}", v_level)
+		v_error = _core_ai_error_unsupported(v_message)
+		return nil, asAxError(v_error)
+	}
+	v_is_gemini3 = _core_contains(v_model, "gemini-3")
+	v_is_image_name = _core_contains(v_model, "-image")
+	v_is_image = _core_and(v_is_gemini3, v_is_image_name)
+	if coreTruthy(v_is_image) {
+		if coreTruthy(v_is_minimal_or_low) {
+			return "minimal", nil
+		} else {
+		// empty
+		}
+		return "high", nil
+	} else {
+	// empty
+	}
+	v_is_legacy_pro_name = _core_contains(v_model, "gemini-3-pro")
+	v_is_legacy_pro = _core_and(v_is_gemini3, v_is_legacy_pro_name)
+	if coreTruthy(v_is_legacy_pro) {
+		if coreTruthy(v_is_minimal_or_low) {
+			return "low", nil
+		} else {
+		// empty
+		}
+		return "high", nil
+	} else {
+	// empty
+	}
+	v_is_37_flash = _core_contains(v_model, "gemini-3.7-flash")
+	v_is_31_pro = _core_contains(v_model, "gemini-3.1-pro")
+	v_no_minimal_name = _core_or(v_is_37_flash, v_is_31_pro)
+	v_no_minimal = _core_and(v_is_gemini3, v_no_minimal_name)
+	v_clamp_minimal = _core_and(v_no_minimal, v_is_minimal)
+	if coreTruthy(v_clamp_minimal) {
+		return "low", nil
+	} else {
+	// empty
+	}
+	return v_level, nil
+}
+
+func _gemini_apply_thinking_config_impl(args ...Value) (Value, error) {
+	axirCoverageMark("_gemini_apply_thinking_config_impl")
 	var v_payload Value
+	var v_model Value
 	var v_model_config Value
-	var v_server_managed_sampling Value
 	var v_budget Value
+	var v_budget_is_none Value
+	var v_budget_is_number Value
+	var v_budget_is_string Value
+	var v_budget_levels Value
+	var v_budget_levels_snake Value
 	var v_budget_snake Value
-	var v_client_managed_sampling Value
+	var v_clamp_pro_zero Value
+	var v_clamped_level Value
+	var v_empty_budget_levels Value
+	var v_empty_level_mapping Value
+	var v_error Value
+	var v_explicit_level Value
 	var v_has_budget Value
+	var v_has_explicit_level Value
 	var v_has_show Value
 	var v_has_thinking Value
+	var v_high_budget Value
+	var v_highest_budget Value
+	var v_is_25_pro Value
+	var v_is_gemini3 Value
 	var v_is_high Value
 	var v_is_highest Value
 	var v_is_low Value
 	var v_is_medium Value
 	var v_is_minimal Value
 	var v_is_none Value
+	var v_is_zero Value
 	var v_level Value
-	var v_named_level Value
+	var v_level_is_string Value
+	var v_level_mapping Value
+	var v_level_mapping_snake Value
+	var v_level_snake Value
+	var v_low_budget Value
+	var v_mapped_level Value
+	var v_mapping_key Value
+	var v_medium_budget Value
+	var v_message Value
+	var v_minimum_budget Value
+	var v_numeric_budget Value
 	var v_show_snake Value
 	var v_show_thoughts Value
 	var v_thinking_config Value
+	var v_unknown_level Value
+	var v_use_explicit_level Value
 	if len(args) > 0 { v_payload = args[0] }
 	_ = v_payload
-	if len(args) > 1 { v_model_config = args[1] }
+	if len(args) > 1 { v_model = args[1] }
+	_ = v_model
+	if len(args) > 2 { v_model_config = args[2] }
 	_ = v_model_config
-	if len(args) > 2 { v_server_managed_sampling = args[2] }
-	_ = v_server_managed_sampling
 	_ = v_budget
+	_ = v_budget_is_none
+	_ = v_budget_is_number
+	_ = v_budget_is_string
+	_ = v_budget_levels
+	_ = v_budget_levels_snake
 	_ = v_budget_snake
-	_ = v_client_managed_sampling
+	_ = v_clamp_pro_zero
+	_ = v_clamped_level
+	_ = v_empty_budget_levels
+	_ = v_empty_level_mapping
+	_ = v_error
+	_ = v_explicit_level
 	_ = v_has_budget
+	_ = v_has_explicit_level
 	_ = v_has_show
 	_ = v_has_thinking
+	_ = v_high_budget
+	_ = v_highest_budget
+	_ = v_is_25_pro
+	_ = v_is_gemini3
 	_ = v_is_high
 	_ = v_is_highest
 	_ = v_is_low
 	_ = v_is_medium
 	_ = v_is_minimal
 	_ = v_is_none
+	_ = v_is_zero
 	_ = v_level
-	_ = v_named_level
+	_ = v_level_is_string
+	_ = v_level_mapping
+	_ = v_level_mapping_snake
+	_ = v_level_snake
+	_ = v_low_budget
+	_ = v_mapped_level
+	_ = v_mapping_key
+	_ = v_medium_budget
+	_ = v_message
+	_ = v_minimum_budget
+	_ = v_numeric_budget
 	_ = v_show_snake
 	_ = v_show_thoughts
 	_ = v_thinking_config
+	_ = v_unknown_level
+	_ = v_use_explicit_level
+	v_thinking_config = Object()
+	v_has_thinking = false
+	v_budget_is_none = false
+	v_is_gemini3 = _core_contains(v_model, "gemini-3")
+	v_is_25_pro = _core_contains(v_model, "gemini-2.5-pro")
+	v_empty_level_mapping = Object()
+	v_level_mapping_snake = coreGet(v_model_config, "thinking_level_mapping", v_empty_level_mapping)
+	v_level_mapping = coreGet(v_model_config, "thinkingLevelMapping", v_level_mapping_snake)
+	v_empty_budget_levels = Object()
+	v_budget_levels_snake = coreGet(v_model_config, "thinking_token_budget_levels", v_empty_budget_levels)
+	v_budget_levels = coreGet(v_model_config, "thinkingTokenBudgetLevels", v_budget_levels_snake)
+	v_minimum_budget = coreGet(v_budget_levels, "minimal", 200)
+	v_low_budget = coreGet(v_budget_levels, "low", 800)
+	v_medium_budget = coreGet(v_budget_levels, "medium", 5000)
+	v_high_budget = coreGet(v_budget_levels, "high", 10000)
+	v_highest_budget = coreGet(v_budget_levels, "highest", 24500)
+	v_budget_snake = coreGet(v_model_config, "thinking_token_budget", nil)
+	v_budget = coreGet(v_model_config, "thinkingTokenBudget", v_budget_snake)
+	v_has_budget = _core_is_not_none(v_budget)
+	if coreTruthy(v_has_budget) {
+		v_budget_is_number = coreTypeIs(v_budget, "number")
+		v_budget_is_string = coreTypeIs(v_budget, "string")
+		if coreTruthy(v_is_gemini3) {
+			if coreTruthy(v_budget_is_number) {
+				v_message = _core_string_format("Gemini 3 model {} does not support numeric thinkingTokenBudget", v_model)
+				v_error = _core_ai_error_unsupported(v_message)
+				return nil, asAxError(v_error)
+			} else {
+			// empty
+			}
+			if coreTruthy(v_budget_is_string) {
+			// empty
+			} else {
+				v_error = _core_ai_error_unsupported("Gemini thinkingTokenBudget must be a number or logical level")
+				return nil, asAxError(v_error)
+			}
+			v_level = ""
+			v_is_none = _core_eq(v_budget, "none")
+			if coreTruthy(v_is_none) {
+				v_level = "minimal"
+				v_budget_is_none = true
+			} else {
+			// empty
+			}
+			v_is_minimal = _core_eq(v_budget, "minimal")
+			if coreTruthy(v_is_minimal) {
+				v_level = "minimal"
+			} else {
+			// empty
+			}
+			v_is_low = _core_eq(v_budget, "low")
+			if coreTruthy(v_is_low) {
+				v_level = "low"
+			} else {
+			// empty
+			}
+			v_is_medium = _core_eq(v_budget, "medium")
+			if coreTruthy(v_is_medium) {
+				v_level = "medium"
+			} else {
+			// empty
+			}
+			v_is_high = _core_eq(v_budget, "high")
+			if coreTruthy(v_is_high) {
+				v_level = "high"
+			} else {
+			// empty
+			}
+			v_is_highest = _core_eq(v_budget, "highest")
+			if coreTruthy(v_is_highest) {
+				v_level = "high"
+			} else {
+			// empty
+			}
+			v_unknown_level = _core_eq(v_level, "")
+			if coreTruthy(v_unknown_level) {
+				v_message = _core_string_format("unsupported Gemini thinkingTokenBudget level: {}", v_budget)
+				v_error = _core_ai_error_unsupported(v_message)
+				return nil, asAxError(v_error)
+			} else {
+			// empty
+			}
+			v_mapping_key = v_budget
+			if coreTruthy(v_is_none) {
+				v_mapping_key = "minimal"
+			} else {
+			// empty
+			}
+			v_mapped_level = coreGet(v_level_mapping, v_mapping_key, v_level)
+			{ v, err := _gemini_clamp_thinking_level_impl(v_model, v_mapped_level); if err != nil { return nil, err }; v_clamped_level = v }
+			if err := coreSet(v_thinking_config, "thinkingLevel", v_clamped_level); err != nil { return nil, err }
+		} else {
+			if coreTruthy(v_budget_is_number) {
+				v_numeric_budget = v_budget
+				v_is_zero = _core_eq(v_budget, 0)
+				v_clamp_pro_zero = _core_and(v_is_25_pro, v_is_zero)
+				if coreTruthy(v_clamp_pro_zero) {
+					v_numeric_budget = v_minimum_budget
+				} else {
+				// empty
+				}
+				if err := coreSet(v_thinking_config, "thinkingBudget", v_numeric_budget); err != nil { return nil, err }
+			} else {
+				if coreTruthy(v_budget_is_string) {
+				// empty
+				} else {
+					v_error = _core_ai_error_unsupported("Gemini thinkingTokenBudget must be a number or logical level")
+					return nil, asAxError(v_error)
+				}
+				v_numeric_budget = -1
+				v_is_none = _core_eq(v_budget, "none")
+				if coreTruthy(v_is_none) {
+					v_numeric_budget = 0
+					if coreTruthy(v_is_25_pro) {
+						v_numeric_budget = v_minimum_budget
+					} else {
+					// empty
+					}
+					v_budget_is_none = true
+				} else {
+				// empty
+				}
+				v_is_minimal = _core_eq(v_budget, "minimal")
+				if coreTruthy(v_is_minimal) {
+					v_numeric_budget = v_minimum_budget
+				} else {
+				// empty
+				}
+				v_is_low = _core_eq(v_budget, "low")
+				if coreTruthy(v_is_low) {
+					v_numeric_budget = v_low_budget
+				} else {
+				// empty
+				}
+				v_is_medium = _core_eq(v_budget, "medium")
+				if coreTruthy(v_is_medium) {
+					v_numeric_budget = v_medium_budget
+				} else {
+				// empty
+				}
+				v_is_high = _core_eq(v_budget, "high")
+				if coreTruthy(v_is_high) {
+					v_numeric_budget = v_high_budget
+				} else {
+				// empty
+				}
+				v_is_highest = _core_eq(v_budget, "highest")
+				if coreTruthy(v_is_highest) {
+					v_numeric_budget = v_highest_budget
+				} else {
+				// empty
+				}
+				v_unknown_level = _core_eq(v_numeric_budget, -1)
+				if coreTruthy(v_unknown_level) {
+					v_message = _core_string_format("unsupported Gemini thinkingTokenBudget level: {}", v_budget)
+					v_error = _core_ai_error_unsupported(v_message)
+					return nil, asAxError(v_error)
+				} else {
+				// empty
+				}
+				if err := coreSet(v_thinking_config, "thinkingBudget", v_numeric_budget); err != nil { return nil, err }
+			}
+		}
+		v_has_thinking = true
+	} else {
+	// empty
+	}
+	v_level_snake = coreGet(v_model_config, "thinking_level", nil)
+	v_explicit_level = coreGet(v_model_config, "thinkingLevel", v_level_snake)
+	v_has_explicit_level = _core_is_not_none(v_explicit_level)
+	v_use_explicit_level = _core_and(v_is_gemini3, v_has_explicit_level)
+	if coreTruthy(v_use_explicit_level) {
+		v_level_is_string = coreTypeIs(v_explicit_level, "string")
+		if coreTruthy(v_level_is_string) {
+		// empty
+		} else {
+			v_error = _core_ai_error_unsupported("Gemini thinkingLevel must be a logical level")
+			return nil, asAxError(v_error)
+		}
+		{ v, err := _gemini_clamp_thinking_level_impl(v_model, v_explicit_level); if err != nil { return nil, err }; v_clamped_level = v }
+		_core_map_delete(v_thinking_config, "thinkingBudget")
+		if err := coreSet(v_thinking_config, "thinkingLevel", v_clamped_level); err != nil { return nil, err }
+		v_has_thinking = true
+	} else {
+	// empty
+	}
+	v_show_snake = coreGet(v_model_config, "show_thoughts", nil)
+	v_show_thoughts = coreGet(v_model_config, "showThoughts", v_show_snake)
+	v_has_show = _core_is_not_none(v_show_thoughts)
+	if coreTruthy(v_has_show) {
+		if err := coreSet(v_thinking_config, "includeThoughts", v_show_thoughts); err != nil { return nil, err }
+		v_has_thinking = true
+	} else {
+	// empty
+	}
+	if coreTruthy(v_budget_is_none) {
+		if err := coreSet(v_thinking_config, "includeThoughts", false); err != nil { return nil, err }
+		v_has_thinking = true
+	} else {
+	// empty
+	}
+	if coreTruthy(v_has_thinking) {
+		if err := coreSet(v_payload, "thinkingConfig", v_thinking_config); err != nil { return nil, err }
+	} else {
+	// empty
+	}
+	return nil, nil
+}
+
+func _gemini_apply_model_config_impl(args ...Value) (Value, error) {
+	axirCoverageMark("_gemini_apply_model_config_impl")
+	var v_payload Value
+	var v_model Value
+	var v_model_config Value
+	var v_server_managed_sampling Value
+	var v_client_managed_sampling Value
+	if len(args) > 0 { v_payload = args[0] }
+	_ = v_payload
+	if len(args) > 1 { v_model = args[1] }
+	_ = v_model
+	if len(args) > 2 { v_model_config = args[2] }
+	_ = v_model_config
+	if len(args) > 3 { v_server_managed_sampling = args[3] }
+	_ = v_server_managed_sampling
+	_ = v_client_managed_sampling
 	if _, err := _openai_copy_config_key_impl(v_payload, v_model_config, "maxTokens", "maxOutputTokens"); err != nil { return nil, err }
 	if _, err := _openai_copy_config_key_impl(v_payload, v_model_config, "max_tokens", "maxOutputTokens"); err != nil { return nil, err }
 	v_client_managed_sampling = _core_not(v_server_managed_sampling)
@@ -17361,73 +17747,7 @@ func _gemini_apply_model_config_impl(args ...Value) (Value, error) {
 	if _, err := _openai_copy_config_key_impl(v_payload, v_model_config, "n", "candidateCount"); err != nil { return nil, err }
 	if _, err := _openai_copy_config_key_impl(v_payload, v_model_config, "stopSequences", "stopSequences"); err != nil { return nil, err }
 	if _, err := _openai_copy_config_key_impl(v_payload, v_model_config, "stop_sequences", "stopSequences"); err != nil { return nil, err }
-	v_thinking_config = Object()
-	v_has_thinking = false
-	v_budget_snake = coreGet(v_model_config, "thinking_token_budget", nil)
-	v_budget = coreGet(v_model_config, "thinkingTokenBudget", v_budget_snake)
-	v_has_budget = _core_is_not_none(v_budget)
-	if coreTruthy(v_has_budget) {
-		v_level = ""
-		v_is_none = _core_eq(v_budget, "none")
-		if coreTruthy(v_is_none) {
-			v_level = "minimal"
-		} else {
-		// empty
-		}
-		v_is_minimal = _core_eq(v_budget, "minimal")
-		if coreTruthy(v_is_minimal) {
-			v_level = "minimal"
-		} else {
-		// empty
-		}
-		v_is_low = _core_eq(v_budget, "low")
-		if coreTruthy(v_is_low) {
-			v_level = "low"
-		} else {
-		// empty
-		}
-		v_is_medium = _core_eq(v_budget, "medium")
-		if coreTruthy(v_is_medium) {
-			v_level = "medium"
-		} else {
-		// empty
-		}
-		v_is_high = _core_eq(v_budget, "high")
-		if coreTruthy(v_is_high) {
-			v_level = "high"
-		} else {
-		// empty
-		}
-		v_is_highest = _core_eq(v_budget, "highest")
-		if coreTruthy(v_is_highest) {
-			v_level = "high"
-		} else {
-		// empty
-		}
-		v_named_level = _core_eq(v_level, "")
-		if coreTruthy(v_named_level) {
-			if err := coreSet(v_thinking_config, "thinkingBudget", v_budget); err != nil { return nil, err }
-		} else {
-			if err := coreSet(v_thinking_config, "thinkingLevel", v_level); err != nil { return nil, err }
-		}
-		v_has_thinking = true
-	} else {
-	// empty
-	}
-	v_show_snake = coreGet(v_model_config, "show_thoughts", nil)
-	v_show_thoughts = coreGet(v_model_config, "showThoughts", v_show_snake)
-	v_has_show = _core_is_not_none(v_show_thoughts)
-	if coreTruthy(v_has_show) {
-		if err := coreSet(v_thinking_config, "includeThoughts", v_show_thoughts); err != nil { return nil, err }
-		v_has_thinking = true
-	} else {
-	// empty
-	}
-	if coreTruthy(v_has_thinking) {
-		if err := coreSet(v_payload, "thinkingConfig", v_thinking_config); err != nil { return nil, err }
-	} else {
-	// empty
-	}
+	if _, err := _gemini_apply_thinking_config_impl(v_payload, v_model, v_model_config); err != nil { return nil, err }
 	return nil, nil
 }
 

--- a/packages/java/axir-provenance.json
+++ b/packages/java/axir-provenance.json
@@ -4,8 +4,8 @@
   "emitted_functions": 593,
   "files": {
     "dev/axllm/ax/Core.java": {
-      "emitted_lines": 24575,
-      "total_lines": 25885
+      "emitted_lines": 24606,
+      "total_lines": 25916
     }
   }
 }

--- a/packages/java/axir-provenance.json
+++ b/packages/java/axir-provenance.json
@@ -1,11 +1,11 @@
 {
   "target": "java",
   "enforced": true,
-  "emitted_functions": 593,
+  "emitted_functions": 595,
   "files": {
     "dev/axllm/ax/Core.java": {
-      "emitted_lines": 24606,
-      "total_lines": 25916
+      "emitted_lines": 24775,
+      "total_lines": 26085
     }
   }
 }

--- a/packages/java/dev/axllm/ax/Core.java
+++ b/packages/java/dev/axllm/ax/Core.java
@@ -8429,7 +8429,38 @@ final class Core {
     Object budget = Core.get(model_config, "thinkingTokenBudget", budget_snake);
     Object has_budget = Core.isNotNone(budget);
     if (Core.truthy(has_budget)) {
-      Core.set(thinking_config, "thinkingBudget", budget);
+      Object level = "";
+      Object is_none = Core.eq(budget, "none");
+      if (Core.truthy(is_none)) {
+        level = "minimal";
+      }
+      Object is_minimal = Core.eq(budget, "minimal");
+      if (Core.truthy(is_minimal)) {
+        level = "minimal";
+      }
+      Object is_low = Core.eq(budget, "low");
+      if (Core.truthy(is_low)) {
+        level = "low";
+      }
+      Object is_medium = Core.eq(budget, "medium");
+      if (Core.truthy(is_medium)) {
+        level = "medium";
+      }
+      Object is_high = Core.eq(budget, "high");
+      if (Core.truthy(is_high)) {
+        level = "high";
+      }
+      Object is_highest = Core.eq(budget, "highest");
+      if (Core.truthy(is_highest)) {
+        level = "high";
+      }
+      Object named_level = Core.eq(level, "");
+      if (Core.truthy(named_level)) {
+        Core.set(thinking_config, "thinkingBudget", budget);
+      }
+      if (!Core.truthy(named_level)) {
+        Core.set(thinking_config, "thinkingLevel", level);
+      }
       has_thinking = Boolean.TRUE;
     }
     Object show_snake = Core.get(model_config, "show_thoughts", null);

--- a/packages/java/dev/axllm/ax/Core.java
+++ b/packages/java/dev/axllm/ax/Core.java
@@ -6224,6 +6224,9 @@ final class Core {
     Core.set(voice_config, "prebuiltVoiceConfig", prebuilt_voice);
     Core.set(speech_config, "voiceConfig", voice_config);
     Core.set(generation_config, "speechConfig", speech_config);
+    Object empty_model_config = new java.util.LinkedHashMap<String, Object>();
+    Object model_config = Core.get(request, "model_config", empty_model_config);
+    Core._gemini_apply_thinking_config_impl(generation_config, request_model, model_config);
     Core.set(setup, "generationConfig", generation_config);
     Object include_transcript = Core.get(request_output_audio, "transcript", Boolean.TRUE);
     if (Core.truthy(include_transcript)) {
@@ -8356,7 +8359,7 @@ final class Core {
     Core.set(generation_config, "responseMimeType", "text/plain");
     Object empty_model_config = new java.util.LinkedHashMap<String, Object>();
     Object model_config = Core.get(request, "model_config", empty_model_config);
-    Core._gemini_apply_model_config_impl(generation_config, model_config, server_managed_sampling);
+    Core._gemini_apply_model_config_impl(generation_config, model, model_config, server_managed_sampling);
     Object response_format = Core.get(request, "response_format", null);
     Object has_response_format = Core.truthyValue(response_format);
     if (Core.truthy(has_response_format)) {
@@ -8406,7 +8409,222 @@ final class Core {
     return payload;
   }
 
-  static Object _gemini_apply_model_config_impl(Object payload, Object model_config, Object server_managed_sampling) {
+  static Object _gemini_clamp_thinking_level_impl(Object model, Object level) {
+    axirCoverageMark("_gemini_clamp_thinking_level_impl");
+    Object is_minimal = Core.eq(level, "minimal");
+    Object is_low = Core.eq(level, "low");
+    Object is_medium = Core.eq(level, "medium");
+    Object is_high = Core.eq(level, "high");
+    Object is_minimal_or_low = Core.or(is_minimal, is_low);
+    Object is_medium_or_high = Core.or(is_medium, is_high);
+    Object is_supported_level = Core.or(is_minimal_or_low, is_medium_or_high);
+    if (Core.truthy(is_supported_level)) {
+      // empty
+    }
+    if (!Core.truthy(is_supported_level)) {
+      Object message = Core.stringFormat("unsupported Gemini thinking level: {}", level);
+      Object error = Core.aiErrorUnsupported(message);
+      throw Core.asRuntime(error);
+    }
+    Object is_gemini3 = Core.contains(model, "gemini-3");
+    Object is_image_name = Core.contains(model, "-image");
+    Object is_image = Core.and(is_gemini3, is_image_name);
+    if (Core.truthy(is_image)) {
+      if (Core.truthy(is_minimal_or_low)) {
+        return "minimal";
+      }
+      return "high";
+    }
+    Object is_legacy_pro_name = Core.contains(model, "gemini-3-pro");
+    Object is_legacy_pro = Core.and(is_gemini3, is_legacy_pro_name);
+    if (Core.truthy(is_legacy_pro)) {
+      if (Core.truthy(is_minimal_or_low)) {
+        return "low";
+      }
+      return "high";
+    }
+    Object is_37_flash = Core.contains(model, "gemini-3.7-flash");
+    Object is_31_pro = Core.contains(model, "gemini-3.1-pro");
+    Object no_minimal_name = Core.or(is_37_flash, is_31_pro);
+    Object no_minimal = Core.and(is_gemini3, no_minimal_name);
+    Object clamp_minimal = Core.and(no_minimal, is_minimal);
+    if (Core.truthy(clamp_minimal)) {
+      return "low";
+    }
+    return level;
+  }
+
+  static Object _gemini_apply_thinking_config_impl(Object payload, Object model, Object model_config) {
+    axirCoverageMark("_gemini_apply_thinking_config_impl");
+    Object thinking_config = new java.util.LinkedHashMap<String, Object>();
+    Object has_thinking = Boolean.FALSE;
+    Object budget_is_none = Boolean.FALSE;
+    Object is_gemini3 = Core.contains(model, "gemini-3");
+    Object is_25_pro = Core.contains(model, "gemini-2.5-pro");
+    Object empty_level_mapping = new java.util.LinkedHashMap<String, Object>();
+    Object level_mapping_snake = Core.get(model_config, "thinking_level_mapping", empty_level_mapping);
+    Object level_mapping = Core.get(model_config, "thinkingLevelMapping", level_mapping_snake);
+    Object empty_budget_levels = new java.util.LinkedHashMap<String, Object>();
+    Object budget_levels_snake = Core.get(model_config, "thinking_token_budget_levels", empty_budget_levels);
+    Object budget_levels = Core.get(model_config, "thinkingTokenBudgetLevels", budget_levels_snake);
+    Object minimum_budget = Core.get(budget_levels, "minimal", 200);
+    Object low_budget = Core.get(budget_levels, "low", 800);
+    Object medium_budget = Core.get(budget_levels, "medium", 5000);
+    Object high_budget = Core.get(budget_levels, "high", 10000);
+    Object highest_budget = Core.get(budget_levels, "highest", 24500);
+    Object budget_snake = Core.get(model_config, "thinking_token_budget", null);
+    Object budget = Core.get(model_config, "thinkingTokenBudget", budget_snake);
+    Object has_budget = Core.isNotNone(budget);
+    if (Core.truthy(has_budget)) {
+      Object budget_is_number = Core.typeIs(budget, "number");
+      Object budget_is_string = Core.typeIs(budget, "string");
+      if (Core.truthy(is_gemini3)) {
+        if (Core.truthy(budget_is_number)) {
+          Object message = Core.stringFormat("Gemini 3 model {} does not support numeric thinkingTokenBudget", model);
+          Object error = Core.aiErrorUnsupported(message);
+          throw Core.asRuntime(error);
+        }
+        if (Core.truthy(budget_is_string)) {
+          // empty
+        }
+        if (!Core.truthy(budget_is_string)) {
+          Object error = Core.aiErrorUnsupported("Gemini thinkingTokenBudget must be a number or logical level");
+          throw Core.asRuntime(error);
+        }
+        Object level = "";
+        Object is_none = Core.eq(budget, "none");
+        if (Core.truthy(is_none)) {
+          level = "minimal";
+          budget_is_none = Boolean.TRUE;
+        }
+        Object is_minimal = Core.eq(budget, "minimal");
+        if (Core.truthy(is_minimal)) {
+          level = "minimal";
+        }
+        Object is_low = Core.eq(budget, "low");
+        if (Core.truthy(is_low)) {
+          level = "low";
+        }
+        Object is_medium = Core.eq(budget, "medium");
+        if (Core.truthy(is_medium)) {
+          level = "medium";
+        }
+        Object is_high = Core.eq(budget, "high");
+        if (Core.truthy(is_high)) {
+          level = "high";
+        }
+        Object is_highest = Core.eq(budget, "highest");
+        if (Core.truthy(is_highest)) {
+          level = "high";
+        }
+        Object unknown_level = Core.eq(level, "");
+        if (Core.truthy(unknown_level)) {
+          Object message = Core.stringFormat("unsupported Gemini thinkingTokenBudget level: {}", budget);
+          Object error = Core.aiErrorUnsupported(message);
+          throw Core.asRuntime(error);
+        }
+        Object mapping_key = budget;
+        if (Core.truthy(is_none)) {
+          mapping_key = "minimal";
+        }
+        Object mapped_level = Core.get(level_mapping, mapping_key, level);
+        Object clamped_level = Core._gemini_clamp_thinking_level_impl(model, mapped_level);
+        Core.set(thinking_config, "thinkingLevel", clamped_level);
+      }
+      if (!Core.truthy(is_gemini3)) {
+        if (Core.truthy(budget_is_number)) {
+          Object numeric_budget = budget;
+          Object is_zero = Core.eq(budget, 0);
+          Object clamp_pro_zero = Core.and(is_25_pro, is_zero);
+          if (Core.truthy(clamp_pro_zero)) {
+            numeric_budget = minimum_budget;
+          }
+          Core.set(thinking_config, "thinkingBudget", numeric_budget);
+        }
+        if (!Core.truthy(budget_is_number)) {
+          if (Core.truthy(budget_is_string)) {
+            // empty
+          }
+          if (!Core.truthy(budget_is_string)) {
+            Object error = Core.aiErrorUnsupported("Gemini thinkingTokenBudget must be a number or logical level");
+            throw Core.asRuntime(error);
+          }
+          Object numeric_budget = -1;
+          Object is_none = Core.eq(budget, "none");
+          if (Core.truthy(is_none)) {
+            numeric_budget = 0;
+            if (Core.truthy(is_25_pro)) {
+              numeric_budget = minimum_budget;
+            }
+            budget_is_none = Boolean.TRUE;
+          }
+          Object is_minimal = Core.eq(budget, "minimal");
+          if (Core.truthy(is_minimal)) {
+            numeric_budget = minimum_budget;
+          }
+          Object is_low = Core.eq(budget, "low");
+          if (Core.truthy(is_low)) {
+            numeric_budget = low_budget;
+          }
+          Object is_medium = Core.eq(budget, "medium");
+          if (Core.truthy(is_medium)) {
+            numeric_budget = medium_budget;
+          }
+          Object is_high = Core.eq(budget, "high");
+          if (Core.truthy(is_high)) {
+            numeric_budget = high_budget;
+          }
+          Object is_highest = Core.eq(budget, "highest");
+          if (Core.truthy(is_highest)) {
+            numeric_budget = highest_budget;
+          }
+          Object unknown_level = Core.eq(numeric_budget, -1);
+          if (Core.truthy(unknown_level)) {
+            Object message = Core.stringFormat("unsupported Gemini thinkingTokenBudget level: {}", budget);
+            Object error = Core.aiErrorUnsupported(message);
+            throw Core.asRuntime(error);
+          }
+          Core.set(thinking_config, "thinkingBudget", numeric_budget);
+        }
+      }
+      has_thinking = Boolean.TRUE;
+    }
+    Object level_snake = Core.get(model_config, "thinking_level", null);
+    Object explicit_level = Core.get(model_config, "thinkingLevel", level_snake);
+    Object has_explicit_level = Core.isNotNone(explicit_level);
+    Object use_explicit_level = Core.and(is_gemini3, has_explicit_level);
+    if (Core.truthy(use_explicit_level)) {
+      Object level_is_string = Core.typeIs(explicit_level, "string");
+      if (Core.truthy(level_is_string)) {
+        // empty
+      }
+      if (!Core.truthy(level_is_string)) {
+        Object error = Core.aiErrorUnsupported("Gemini thinkingLevel must be a logical level");
+        throw Core.asRuntime(error);
+      }
+      Object clamped_level = Core._gemini_clamp_thinking_level_impl(model, explicit_level);
+      Core.mapDelete(thinking_config, "thinkingBudget");
+      Core.set(thinking_config, "thinkingLevel", clamped_level);
+      has_thinking = Boolean.TRUE;
+    }
+    Object show_snake = Core.get(model_config, "show_thoughts", null);
+    Object show_thoughts = Core.get(model_config, "showThoughts", show_snake);
+    Object has_show = Core.isNotNone(show_thoughts);
+    if (Core.truthy(has_show)) {
+      Core.set(thinking_config, "includeThoughts", show_thoughts);
+      has_thinking = Boolean.TRUE;
+    }
+    if (Core.truthy(budget_is_none)) {
+      Core.set(thinking_config, "includeThoughts", Boolean.FALSE);
+      has_thinking = Boolean.TRUE;
+    }
+    if (Core.truthy(has_thinking)) {
+      Core.set(payload, "thinkingConfig", thinking_config);
+    }
+    return null;
+  }
+
+  static Object _gemini_apply_model_config_impl(Object payload, Object model, Object model_config, Object server_managed_sampling) {
     axirCoverageMark("_gemini_apply_model_config_impl");
     Core._openai_copy_config_key_impl(payload, model_config, "maxTokens", "maxOutputTokens");
     Core._openai_copy_config_key_impl(payload, model_config, "max_tokens", "maxOutputTokens");
@@ -8423,56 +8641,7 @@ final class Core {
     Core._openai_copy_config_key_impl(payload, model_config, "n", "candidateCount");
     Core._openai_copy_config_key_impl(payload, model_config, "stopSequences", "stopSequences");
     Core._openai_copy_config_key_impl(payload, model_config, "stop_sequences", "stopSequences");
-    Object thinking_config = new java.util.LinkedHashMap<String, Object>();
-    Object has_thinking = Boolean.FALSE;
-    Object budget_snake = Core.get(model_config, "thinking_token_budget", null);
-    Object budget = Core.get(model_config, "thinkingTokenBudget", budget_snake);
-    Object has_budget = Core.isNotNone(budget);
-    if (Core.truthy(has_budget)) {
-      Object level = "";
-      Object is_none = Core.eq(budget, "none");
-      if (Core.truthy(is_none)) {
-        level = "minimal";
-      }
-      Object is_minimal = Core.eq(budget, "minimal");
-      if (Core.truthy(is_minimal)) {
-        level = "minimal";
-      }
-      Object is_low = Core.eq(budget, "low");
-      if (Core.truthy(is_low)) {
-        level = "low";
-      }
-      Object is_medium = Core.eq(budget, "medium");
-      if (Core.truthy(is_medium)) {
-        level = "medium";
-      }
-      Object is_high = Core.eq(budget, "high");
-      if (Core.truthy(is_high)) {
-        level = "high";
-      }
-      Object is_highest = Core.eq(budget, "highest");
-      if (Core.truthy(is_highest)) {
-        level = "high";
-      }
-      Object named_level = Core.eq(level, "");
-      if (Core.truthy(named_level)) {
-        Core.set(thinking_config, "thinkingBudget", budget);
-      }
-      if (!Core.truthy(named_level)) {
-        Core.set(thinking_config, "thinkingLevel", level);
-      }
-      has_thinking = Boolean.TRUE;
-    }
-    Object show_snake = Core.get(model_config, "show_thoughts", null);
-    Object show_thoughts = Core.get(model_config, "showThoughts", show_snake);
-    Object has_show = Core.isNotNone(show_thoughts);
-    if (Core.truthy(has_show)) {
-      Core.set(thinking_config, "includeThoughts", show_thoughts);
-      has_thinking = Boolean.TRUE;
-    }
-    if (Core.truthy(has_thinking)) {
-      Core.set(payload, "thinkingConfig", thinking_config);
-    }
+    Core._gemini_apply_thinking_config_impl(payload, model, model_config);
     return null;
   }
 

--- a/packages/python/axir-provenance.json
+++ b/packages/python/axir-provenance.json
@@ -1,15 +1,15 @@
 {
   "target": "python",
   "enforced": true,
-  "emitted_functions": 593,
+  "emitted_functions": 595,
   "files": {
     "axllm/agent.py": {
       "emitted_lines": 8338,
       "total_lines": 10722
     },
     "axllm/ai.py": {
-      "emitted_lines": 7083,
-      "total_lines": 9668
+      "emitted_lines": 7261,
+      "total_lines": 9846
     },
     "axllm/flow.py": {
       "emitted_lines": 2287,

--- a/packages/python/axir-provenance.json
+++ b/packages/python/axir-provenance.json
@@ -8,8 +8,8 @@
       "total_lines": 10722
     },
     "axllm/ai.py": {
-      "emitted_lines": 7048,
-      "total_lines": 9633
+      "emitted_lines": 7083,
+      "total_lines": 9668
     },
     "axllm/flow.py": {
       "emitted_lines": 2287,

--- a/packages/python/axllm/ai.py
+++ b/packages/python/axllm/ai.py
@@ -7924,7 +7924,42 @@ def _gemini_apply_model_config_impl(payload: Any, model_config: Any, server_mana
     budget = _core_get(model_config, "thinkingTokenBudget", budget_snake)
     has_budget = _core_is_not_none(budget)
     if has_budget:
-        thinking_config["thinkingBudget"] = budget
+        level = ""
+        is_none = _core_eq(budget, "none")
+        if is_none:
+            level = "minimal"
+        else:
+            pass
+        is_minimal = _core_eq(budget, "minimal")
+        if is_minimal:
+            level = "minimal"
+        else:
+            pass
+        is_low = _core_eq(budget, "low")
+        if is_low:
+            level = "low"
+        else:
+            pass
+        is_medium = _core_eq(budget, "medium")
+        if is_medium:
+            level = "medium"
+        else:
+            pass
+        is_high = _core_eq(budget, "high")
+        if is_high:
+            level = "high"
+        else:
+            pass
+        is_highest = _core_eq(budget, "highest")
+        if is_highest:
+            level = "high"
+        else:
+            pass
+        named_level = _core_eq(level, "")
+        if named_level:
+            thinking_config["thinkingBudget"] = budget
+        else:
+            thinking_config["thinkingLevel"] = level
         has_thinking = True
     else:
         pass

--- a/packages/python/axllm/ai.py
+++ b/packages/python/axllm/ai.py
@@ -5714,6 +5714,9 @@ def _gemini_live_bidi_build_setup(descriptor: Any, request: Any) -> Any:
     voice_config["prebuiltVoiceConfig"] = prebuilt_voice
     speech_config["voiceConfig"] = voice_config
     generation_config["speechConfig"] = speech_config
+    empty_model_config = {}
+    model_config = _core_get(request, "model_config", empty_model_config)
+    _gemini_apply_thinking_config_impl(generation_config, request_model, model_config)
     setup["generationConfig"] = generation_config
     include_transcript = _core_get(request_output_audio, "transcript", True)
     if include_transcript:
@@ -7848,7 +7851,7 @@ def _gemini_build_chat_request(request: AxChatRequest, options: Any, is_vertex: 
     generation_config["responseMimeType"] = "text/plain"
     empty_model_config = {}
     model_config = _core_get(request, "model_config", empty_model_config)
-    _gemini_apply_model_config_impl(generation_config, model_config, server_managed_sampling)
+    _gemini_apply_model_config_impl(generation_config, model, model_config, server_managed_sampling)
     response_format = _core_get(request, "response_format", None)
     has_response_format = _core_truthy(response_format)
     if has_response_format:
@@ -7900,7 +7903,238 @@ def _gemini_build_chat_request(request: AxChatRequest, options: Any, is_vertex: 
     return payload
 
 
-def _gemini_apply_model_config_impl(payload: Any, model_config: Any, server_managed_sampling: bool) -> None:
+def _gemini_clamp_thinking_level_impl(model: str, level: str) -> str:
+    _core_coverage_mark("_gemini_clamp_thinking_level_impl")
+    is_minimal = _core_eq(level, "minimal")
+    is_low = _core_eq(level, "low")
+    is_medium = _core_eq(level, "medium")
+    is_high = _core_eq(level, "high")
+    is_minimal_or_low = _core_or(is_minimal, is_low)
+    is_medium_or_high = _core_or(is_medium, is_high)
+    is_supported_level = _core_or(is_minimal_or_low, is_medium_or_high)
+    if is_supported_level:
+        pass
+    else:
+        message = _core_string_format("unsupported Gemini thinking level: {}", level)
+        error = _core_ai_error_unsupported(message)
+        raise error
+    is_gemini3 = _core_contains(model, "gemini-3")
+    is_image_name = _core_contains(model, "-image")
+    is_image = _core_and(is_gemini3, is_image_name)
+    if is_image:
+        if is_minimal_or_low:
+            return "minimal"
+        else:
+            pass
+        return "high"
+    else:
+        pass
+    is_legacy_pro_name = _core_contains(model, "gemini-3-pro")
+    is_legacy_pro = _core_and(is_gemini3, is_legacy_pro_name)
+    if is_legacy_pro:
+        if is_minimal_or_low:
+            return "low"
+        else:
+            pass
+        return "high"
+    else:
+        pass
+    is_37_flash = _core_contains(model, "gemini-3.7-flash")
+    is_31_pro = _core_contains(model, "gemini-3.1-pro")
+    no_minimal_name = _core_or(is_37_flash, is_31_pro)
+    no_minimal = _core_and(is_gemini3, no_minimal_name)
+    clamp_minimal = _core_and(no_minimal, is_minimal)
+    if clamp_minimal:
+        return "low"
+    else:
+        pass
+    return level
+
+
+def _gemini_apply_thinking_config_impl(payload: Any, model: str, model_config: Any) -> None:
+    _core_coverage_mark("_gemini_apply_thinking_config_impl")
+    thinking_config = {}
+    has_thinking = False
+    budget_is_none = False
+    is_gemini3 = _core_contains(model, "gemini-3")
+    is_25_pro = _core_contains(model, "gemini-2.5-pro")
+    empty_level_mapping = {}
+    level_mapping_snake = _core_get(model_config, "thinking_level_mapping", empty_level_mapping)
+    level_mapping = _core_get(model_config, "thinkingLevelMapping", level_mapping_snake)
+    empty_budget_levels = {}
+    budget_levels_snake = _core_get(model_config, "thinking_token_budget_levels", empty_budget_levels)
+    budget_levels = _core_get(model_config, "thinkingTokenBudgetLevels", budget_levels_snake)
+    minimum_budget = _core_get(budget_levels, "minimal", 200)
+    low_budget = _core_get(budget_levels, "low", 800)
+    medium_budget = _core_get(budget_levels, "medium", 5000)
+    high_budget = _core_get(budget_levels, "high", 10000)
+    highest_budget = _core_get(budget_levels, "highest", 24500)
+    budget_snake = _core_get(model_config, "thinking_token_budget", None)
+    budget = _core_get(model_config, "thinkingTokenBudget", budget_snake)
+    has_budget = _core_is_not_none(budget)
+    if has_budget:
+        budget_is_number = _core_type_is(budget, "number")
+        budget_is_string = _core_type_is(budget, "string")
+        if is_gemini3:
+            if budget_is_number:
+                message = _core_string_format("Gemini 3 model {} does not support numeric thinkingTokenBudget", model)
+                error = _core_ai_error_unsupported(message)
+                raise error
+            else:
+                pass
+            if budget_is_string:
+                pass
+            else:
+                error = _core_ai_error_unsupported("Gemini thinkingTokenBudget must be a number or logical level")
+                raise error
+            level = ""
+            is_none = _core_eq(budget, "none")
+            if is_none:
+                level = "minimal"
+                budget_is_none = True
+            else:
+                pass
+            is_minimal = _core_eq(budget, "minimal")
+            if is_minimal:
+                level = "minimal"
+            else:
+                pass
+            is_low = _core_eq(budget, "low")
+            if is_low:
+                level = "low"
+            else:
+                pass
+            is_medium = _core_eq(budget, "medium")
+            if is_medium:
+                level = "medium"
+            else:
+                pass
+            is_high = _core_eq(budget, "high")
+            if is_high:
+                level = "high"
+            else:
+                pass
+            is_highest = _core_eq(budget, "highest")
+            if is_highest:
+                level = "high"
+            else:
+                pass
+            unknown_level = _core_eq(level, "")
+            if unknown_level:
+                message = _core_string_format("unsupported Gemini thinkingTokenBudget level: {}", budget)
+                error = _core_ai_error_unsupported(message)
+                raise error
+            else:
+                pass
+            mapping_key = budget
+            if is_none:
+                mapping_key = "minimal"
+            else:
+                pass
+            mapped_level = _core_get(level_mapping, mapping_key, level)
+            clamped_level = _gemini_clamp_thinking_level_impl(model, mapped_level)
+            thinking_config["thinkingLevel"] = clamped_level
+        else:
+            if budget_is_number:
+                numeric_budget = budget
+                is_zero = _core_eq(budget, 0)
+                clamp_pro_zero = _core_and(is_25_pro, is_zero)
+                if clamp_pro_zero:
+                    numeric_budget = minimum_budget
+                else:
+                    pass
+                thinking_config["thinkingBudget"] = numeric_budget
+            else:
+                if budget_is_string:
+                    pass
+                else:
+                    error = _core_ai_error_unsupported("Gemini thinkingTokenBudget must be a number or logical level")
+                    raise error
+                numeric_budget = -1
+                is_none = _core_eq(budget, "none")
+                if is_none:
+                    numeric_budget = 0
+                    if is_25_pro:
+                        numeric_budget = minimum_budget
+                    else:
+                        pass
+                    budget_is_none = True
+                else:
+                    pass
+                is_minimal = _core_eq(budget, "minimal")
+                if is_minimal:
+                    numeric_budget = minimum_budget
+                else:
+                    pass
+                is_low = _core_eq(budget, "low")
+                if is_low:
+                    numeric_budget = low_budget
+                else:
+                    pass
+                is_medium = _core_eq(budget, "medium")
+                if is_medium:
+                    numeric_budget = medium_budget
+                else:
+                    pass
+                is_high = _core_eq(budget, "high")
+                if is_high:
+                    numeric_budget = high_budget
+                else:
+                    pass
+                is_highest = _core_eq(budget, "highest")
+                if is_highest:
+                    numeric_budget = highest_budget
+                else:
+                    pass
+                unknown_level = _core_eq(numeric_budget, -1)
+                if unknown_level:
+                    message = _core_string_format("unsupported Gemini thinkingTokenBudget level: {}", budget)
+                    error = _core_ai_error_unsupported(message)
+                    raise error
+                else:
+                    pass
+                thinking_config["thinkingBudget"] = numeric_budget
+        has_thinking = True
+    else:
+        pass
+    level_snake = _core_get(model_config, "thinking_level", None)
+    explicit_level = _core_get(model_config, "thinkingLevel", level_snake)
+    has_explicit_level = _core_is_not_none(explicit_level)
+    use_explicit_level = _core_and(is_gemini3, has_explicit_level)
+    if use_explicit_level:
+        level_is_string = _core_type_is(explicit_level, "string")
+        if level_is_string:
+            pass
+        else:
+            error = _core_ai_error_unsupported("Gemini thinkingLevel must be a logical level")
+            raise error
+        clamped_level = _gemini_clamp_thinking_level_impl(model, explicit_level)
+        _core_map_delete(thinking_config, "thinkingBudget")
+        thinking_config["thinkingLevel"] = clamped_level
+        has_thinking = True
+    else:
+        pass
+    show_snake = _core_get(model_config, "show_thoughts", None)
+    show_thoughts = _core_get(model_config, "showThoughts", show_snake)
+    has_show = _core_is_not_none(show_thoughts)
+    if has_show:
+        thinking_config["includeThoughts"] = show_thoughts
+        has_thinking = True
+    else:
+        pass
+    if budget_is_none:
+        thinking_config["includeThoughts"] = False
+        has_thinking = True
+    else:
+        pass
+    if has_thinking:
+        payload["thinkingConfig"] = thinking_config
+    else:
+        pass
+    return None
+
+
+def _gemini_apply_model_config_impl(payload: Any, model: str, model_config: Any, server_managed_sampling: bool) -> None:
     _core_coverage_mark("_gemini_apply_model_config_impl")
     _openai_copy_config_key_impl(payload, model_config, "maxTokens", "maxOutputTokens")
     _openai_copy_config_key_impl(payload, model_config, "max_tokens", "maxOutputTokens")
@@ -7918,63 +8152,7 @@ def _gemini_apply_model_config_impl(payload: Any, model_config: Any, server_mana
     _openai_copy_config_key_impl(payload, model_config, "n", "candidateCount")
     _openai_copy_config_key_impl(payload, model_config, "stopSequences", "stopSequences")
     _openai_copy_config_key_impl(payload, model_config, "stop_sequences", "stopSequences")
-    thinking_config = {}
-    has_thinking = False
-    budget_snake = _core_get(model_config, "thinking_token_budget", None)
-    budget = _core_get(model_config, "thinkingTokenBudget", budget_snake)
-    has_budget = _core_is_not_none(budget)
-    if has_budget:
-        level = ""
-        is_none = _core_eq(budget, "none")
-        if is_none:
-            level = "minimal"
-        else:
-            pass
-        is_minimal = _core_eq(budget, "minimal")
-        if is_minimal:
-            level = "minimal"
-        else:
-            pass
-        is_low = _core_eq(budget, "low")
-        if is_low:
-            level = "low"
-        else:
-            pass
-        is_medium = _core_eq(budget, "medium")
-        if is_medium:
-            level = "medium"
-        else:
-            pass
-        is_high = _core_eq(budget, "high")
-        if is_high:
-            level = "high"
-        else:
-            pass
-        is_highest = _core_eq(budget, "highest")
-        if is_highest:
-            level = "high"
-        else:
-            pass
-        named_level = _core_eq(level, "")
-        if named_level:
-            thinking_config["thinkingBudget"] = budget
-        else:
-            thinking_config["thinkingLevel"] = level
-        has_thinking = True
-    else:
-        pass
-    show_snake = _core_get(model_config, "show_thoughts", None)
-    show_thoughts = _core_get(model_config, "showThoughts", show_snake)
-    has_show = _core_is_not_none(show_thoughts)
-    if has_show:
-        thinking_config["includeThoughts"] = show_thoughts
-        has_thinking = True
-    else:
-        pass
-    if has_thinking:
-        payload["thinkingConfig"] = thinking_config
-    else:
-        pass
+    _gemini_apply_thinking_config_impl(payload, model, model_config)
     return None
 
 

--- a/packages/rust/axir-provenance.json
+++ b/packages/rust/axir-provenance.json
@@ -1,11 +1,11 @@
 {
   "target": "rust",
   "enforced": true,
-  "emitted_functions": 593,
+  "emitted_functions": 595,
   "files": {
     "src/lib.rs": {
-      "emitted_lines": 56670,
-      "total_lines": 80753
+      "emitted_lines": 56991,
+      "total_lines": 81074
     }
   }
 }

--- a/packages/rust/axir-provenance.json
+++ b/packages/rust/axir-provenance.json
@@ -4,8 +4,8 @@
   "emitted_functions": 593,
   "files": {
     "src/lib.rs": {
-      "emitted_lines": 56628,
-      "total_lines": 80711
+      "emitted_lines": 56670,
+      "total_lines": 80753
     }
   }
 }

--- a/packages/rust/src/lib.rs
+++ b/packages/rust/src/lib.rs
@@ -35515,6 +35515,7 @@ fn _gemini_live_bidi_build_setup(args: &[CoreValue]) -> Result<CoreValue, AxErro
     let mut v_audio_descriptor = CoreValue::Null;
     let mut v_default_model = CoreValue::Null;
     let mut v_default_voice = CoreValue::Null;
+    let mut v_empty_model_config = CoreValue::Null;
     let mut v_error = CoreValue::Null;
     let mut v_generation_config = CoreValue::Null;
     let mut v_has_instructions = CoreValue::Null;
@@ -35523,6 +35524,7 @@ fn _gemini_live_bidi_build_setup(args: &[CoreValue]) -> Result<CoreValue, AxErro
     let mut v_instructions = CoreValue::Null;
     let mut v_modalities = CoreValue::Null;
     let mut v_model = CoreValue::Null;
+    let mut v_model_config = CoreValue::Null;
     let mut v_model_prefix = CoreValue::Null;
     let mut v_out = CoreValue::Null;
     let mut v_output_audio_descriptor = CoreValue::Null;
@@ -35623,6 +35625,17 @@ fn _gemini_live_bidi_build_setup(args: &[CoreValue]) -> Result<CoreValue, AxErro
         CoreValue::from("speechConfig"),
         v_speech_config.clone(),
     )?;
+    v_empty_model_config = CoreValue::new_map();
+    v_model_config = core_get(
+        &v_request,
+        &CoreValue::from("model_config"),
+        v_empty_model_config.clone(),
+    );
+    _gemini_apply_thinking_config_impl(&[
+        v_generation_config.clone(),
+        v_request_model.clone(),
+        v_model_config.clone(),
+    ])?;
     core_set(
         &v_setup,
         CoreValue::from("generationConfig"),
@@ -40718,6 +40731,7 @@ fn _gemini_build_chat_request(args: &[CoreValue]) -> Result<CoreValue, AxError> 
     );
     _gemini_apply_model_config_impl(&[
         v_generation_config.clone(),
+        v_model.clone(),
         v_model_config.clone(),
         v_server_managed_sampling.clone(),
     ])?;
@@ -40830,28 +40844,411 @@ fn _gemini_build_chat_request(args: &[CoreValue]) -> Result<CoreValue, AxError> 
     unreachable_code,
     clippy::all
 )]
-fn _gemini_apply_model_config_impl(args: &[CoreValue]) -> Result<CoreValue, AxError> {
-    axir_coverage_mark("_gemini_apply_model_config_impl");
+fn _gemini_clamp_thinking_level_impl(args: &[CoreValue]) -> Result<CoreValue, AxError> {
+    axir_coverage_mark("_gemini_clamp_thinking_level_impl");
+    let mut v_model = core_arg(args, 0);
+    let mut v_level = core_arg(args, 1);
+    let mut v_clamp_minimal = CoreValue::Null;
+    let mut v_error = CoreValue::Null;
+    let mut v_is_31_pro = CoreValue::Null;
+    let mut v_is_37_flash = CoreValue::Null;
+    let mut v_is_gemini3 = CoreValue::Null;
+    let mut v_is_high = CoreValue::Null;
+    let mut v_is_image = CoreValue::Null;
+    let mut v_is_image_name = CoreValue::Null;
+    let mut v_is_legacy_pro = CoreValue::Null;
+    let mut v_is_legacy_pro_name = CoreValue::Null;
+    let mut v_is_low = CoreValue::Null;
+    let mut v_is_medium = CoreValue::Null;
+    let mut v_is_medium_or_high = CoreValue::Null;
+    let mut v_is_minimal = CoreValue::Null;
+    let mut v_is_minimal_or_low = CoreValue::Null;
+    let mut v_is_supported_level = CoreValue::Null;
+    let mut v_message = CoreValue::Null;
+    let mut v_no_minimal = CoreValue::Null;
+    let mut v_no_minimal_name = CoreValue::Null;
+    v_is_minimal = core_eq(&[v_level.clone(), CoreValue::from("minimal")])?;
+    v_is_low = core_eq(&[v_level.clone(), CoreValue::from("low")])?;
+    v_is_medium = core_eq(&[v_level.clone(), CoreValue::from("medium")])?;
+    v_is_high = core_eq(&[v_level.clone(), CoreValue::from("high")])?;
+    v_is_minimal_or_low = core_or(&[v_is_minimal.clone(), v_is_low.clone()])?;
+    v_is_medium_or_high = core_or(&[v_is_medium.clone(), v_is_high.clone()])?;
+    v_is_supported_level = core_or(&[v_is_minimal_or_low.clone(), v_is_medium_or_high.clone()])?;
+    if core_truthy(&v_is_supported_level) {
+    } else {
+        v_message = core_string_format(&[
+            CoreValue::from("unsupported Gemini thinking level: {}"),
+            v_level.clone(),
+        ])?;
+        v_error = core_ai_error_unsupported(&[v_message.clone()])?;
+        return Err(core_as_error(&v_error));
+    }
+    v_is_gemini3 = core_contains(&[v_model.clone(), CoreValue::from("gemini-3")])?;
+    v_is_image_name = core_contains(&[v_model.clone(), CoreValue::from("-image")])?;
+    v_is_image = core_and(&[v_is_gemini3.clone(), v_is_image_name.clone()])?;
+    if core_truthy(&v_is_image) {
+        if core_truthy(&v_is_minimal_or_low) {
+            return Ok(CoreValue::from("minimal"));
+        }
+        return Ok(CoreValue::from("high"));
+    }
+    v_is_legacy_pro_name = core_contains(&[v_model.clone(), CoreValue::from("gemini-3-pro")])?;
+    v_is_legacy_pro = core_and(&[v_is_gemini3.clone(), v_is_legacy_pro_name.clone()])?;
+    if core_truthy(&v_is_legacy_pro) {
+        if core_truthy(&v_is_minimal_or_low) {
+            return Ok(CoreValue::from("low"));
+        }
+        return Ok(CoreValue::from("high"));
+    }
+    v_is_37_flash = core_contains(&[v_model.clone(), CoreValue::from("gemini-3.7-flash")])?;
+    v_is_31_pro = core_contains(&[v_model.clone(), CoreValue::from("gemini-3.1-pro")])?;
+    v_no_minimal_name = core_or(&[v_is_37_flash.clone(), v_is_31_pro.clone()])?;
+    v_no_minimal = core_and(&[v_is_gemini3.clone(), v_no_minimal_name.clone()])?;
+    v_clamp_minimal = core_and(&[v_no_minimal.clone(), v_is_minimal.clone()])?;
+    if core_truthy(&v_clamp_minimal) {
+        return Ok(CoreValue::from("low"));
+    }
+    return Ok(v_level.clone());
+}
+
+#[allow(
+    unused_variables,
+    unused_assignments,
+    unused_mut,
+    unreachable_code,
+    clippy::all
+)]
+fn _gemini_apply_thinking_config_impl(args: &[CoreValue]) -> Result<CoreValue, AxError> {
+    axir_coverage_mark("_gemini_apply_thinking_config_impl");
     let mut v_payload = core_arg(args, 0);
-    let mut v_model_config = core_arg(args, 1);
-    let mut v_server_managed_sampling = core_arg(args, 2);
+    let mut v_model = core_arg(args, 1);
+    let mut v_model_config = core_arg(args, 2);
     let mut v_budget = CoreValue::Null;
+    let mut v_budget_is_none = CoreValue::Null;
+    let mut v_budget_is_number = CoreValue::Null;
+    let mut v_budget_is_string = CoreValue::Null;
+    let mut v_budget_levels = CoreValue::Null;
+    let mut v_budget_levels_snake = CoreValue::Null;
     let mut v_budget_snake = CoreValue::Null;
-    let mut v_client_managed_sampling = CoreValue::Null;
+    let mut v_clamp_pro_zero = CoreValue::Null;
+    let mut v_clamped_level = CoreValue::Null;
+    let mut v_empty_budget_levels = CoreValue::Null;
+    let mut v_empty_level_mapping = CoreValue::Null;
+    let mut v_error = CoreValue::Null;
+    let mut v_explicit_level = CoreValue::Null;
     let mut v_has_budget = CoreValue::Null;
+    let mut v_has_explicit_level = CoreValue::Null;
     let mut v_has_show = CoreValue::Null;
     let mut v_has_thinking = CoreValue::Null;
+    let mut v_high_budget = CoreValue::Null;
+    let mut v_highest_budget = CoreValue::Null;
+    let mut v_is_25_pro = CoreValue::Null;
+    let mut v_is_gemini3 = CoreValue::Null;
     let mut v_is_high = CoreValue::Null;
     let mut v_is_highest = CoreValue::Null;
     let mut v_is_low = CoreValue::Null;
     let mut v_is_medium = CoreValue::Null;
     let mut v_is_minimal = CoreValue::Null;
     let mut v_is_none = CoreValue::Null;
+    let mut v_is_zero = CoreValue::Null;
     let mut v_level = CoreValue::Null;
-    let mut v_named_level = CoreValue::Null;
+    let mut v_level_is_string = CoreValue::Null;
+    let mut v_level_mapping = CoreValue::Null;
+    let mut v_level_mapping_snake = CoreValue::Null;
+    let mut v_level_snake = CoreValue::Null;
+    let mut v_low_budget = CoreValue::Null;
+    let mut v_mapped_level = CoreValue::Null;
+    let mut v_mapping_key = CoreValue::Null;
+    let mut v_medium_budget = CoreValue::Null;
+    let mut v_message = CoreValue::Null;
+    let mut v_minimum_budget = CoreValue::Null;
+    let mut v_numeric_budget = CoreValue::Null;
     let mut v_show_snake = CoreValue::Null;
     let mut v_show_thoughts = CoreValue::Null;
     let mut v_thinking_config = CoreValue::Null;
+    let mut v_unknown_level = CoreValue::Null;
+    let mut v_use_explicit_level = CoreValue::Null;
+    v_thinking_config = CoreValue::new_map();
+    v_has_thinking = CoreValue::Bool(false);
+    v_budget_is_none = CoreValue::Bool(false);
+    v_is_gemini3 = core_contains(&[v_model.clone(), CoreValue::from("gemini-3")])?;
+    v_is_25_pro = core_contains(&[v_model.clone(), CoreValue::from("gemini-2.5-pro")])?;
+    v_empty_level_mapping = CoreValue::new_map();
+    v_level_mapping_snake = core_get(
+        &v_model_config,
+        &CoreValue::from("thinking_level_mapping"),
+        v_empty_level_mapping.clone(),
+    );
+    v_level_mapping = core_get(
+        &v_model_config,
+        &CoreValue::from("thinkingLevelMapping"),
+        v_level_mapping_snake.clone(),
+    );
+    v_empty_budget_levels = CoreValue::new_map();
+    v_budget_levels_snake = core_get(
+        &v_model_config,
+        &CoreValue::from("thinking_token_budget_levels"),
+        v_empty_budget_levels.clone(),
+    );
+    v_budget_levels = core_get(
+        &v_model_config,
+        &CoreValue::from("thinkingTokenBudgetLevels"),
+        v_budget_levels_snake.clone(),
+    );
+    v_minimum_budget = core_get(
+        &v_budget_levels,
+        &CoreValue::from("minimal"),
+        CoreValue::Num(200f64),
+    );
+    v_low_budget = core_get(
+        &v_budget_levels,
+        &CoreValue::from("low"),
+        CoreValue::Num(800f64),
+    );
+    v_medium_budget = core_get(
+        &v_budget_levels,
+        &CoreValue::from("medium"),
+        CoreValue::Num(5000f64),
+    );
+    v_high_budget = core_get(
+        &v_budget_levels,
+        &CoreValue::from("high"),
+        CoreValue::Num(10000f64),
+    );
+    v_highest_budget = core_get(
+        &v_budget_levels,
+        &CoreValue::from("highest"),
+        CoreValue::Num(24500f64),
+    );
+    v_budget_snake = core_get(
+        &v_model_config,
+        &CoreValue::from("thinking_token_budget"),
+        CoreValue::Null,
+    );
+    v_budget = core_get(
+        &v_model_config,
+        &CoreValue::from("thinkingTokenBudget"),
+        v_budget_snake.clone(),
+    );
+    v_has_budget = core_is_not_none(&[v_budget.clone()])?;
+    if core_truthy(&v_has_budget) {
+        v_budget_is_number = core_type_is(&v_budget, CoreValue::from("number"));
+        v_budget_is_string = core_type_is(&v_budget, CoreValue::from("string"));
+        if core_truthy(&v_is_gemini3) {
+            if core_truthy(&v_budget_is_number) {
+                v_message = core_string_format(&[
+                    CoreValue::from(
+                        "Gemini 3 model {} does not support numeric thinkingTokenBudget",
+                    ),
+                    v_model.clone(),
+                ])?;
+                v_error = core_ai_error_unsupported(&[v_message.clone()])?;
+                return Err(core_as_error(&v_error));
+            }
+            if core_truthy(&v_budget_is_string) {
+            } else {
+                v_error = core_ai_error_unsupported(&[CoreValue::from(
+                    "Gemini thinkingTokenBudget must be a number or logical level",
+                )])?;
+                return Err(core_as_error(&v_error));
+            }
+            v_level = CoreValue::from("");
+            v_is_none = core_eq(&[v_budget.clone(), CoreValue::from("none")])?;
+            if core_truthy(&v_is_none) {
+                v_level = CoreValue::from("minimal");
+                v_budget_is_none = CoreValue::Bool(true);
+            }
+            v_is_minimal = core_eq(&[v_budget.clone(), CoreValue::from("minimal")])?;
+            if core_truthy(&v_is_minimal) {
+                v_level = CoreValue::from("minimal");
+            }
+            v_is_low = core_eq(&[v_budget.clone(), CoreValue::from("low")])?;
+            if core_truthy(&v_is_low) {
+                v_level = CoreValue::from("low");
+            }
+            v_is_medium = core_eq(&[v_budget.clone(), CoreValue::from("medium")])?;
+            if core_truthy(&v_is_medium) {
+                v_level = CoreValue::from("medium");
+            }
+            v_is_high = core_eq(&[v_budget.clone(), CoreValue::from("high")])?;
+            if core_truthy(&v_is_high) {
+                v_level = CoreValue::from("high");
+            }
+            v_is_highest = core_eq(&[v_budget.clone(), CoreValue::from("highest")])?;
+            if core_truthy(&v_is_highest) {
+                v_level = CoreValue::from("high");
+            }
+            v_unknown_level = core_eq(&[v_level.clone(), CoreValue::from("")])?;
+            if core_truthy(&v_unknown_level) {
+                v_message = core_string_format(&[
+                    CoreValue::from("unsupported Gemini thinkingTokenBudget level: {}"),
+                    v_budget.clone(),
+                ])?;
+                v_error = core_ai_error_unsupported(&[v_message.clone()])?;
+                return Err(core_as_error(&v_error));
+            }
+            v_mapping_key = v_budget.clone();
+            if core_truthy(&v_is_none) {
+                v_mapping_key = CoreValue::from("minimal");
+            }
+            v_mapped_level = core_get(&v_level_mapping, &v_mapping_key.clone(), v_level.clone());
+            v_clamped_level =
+                _gemini_clamp_thinking_level_impl(&[v_model.clone(), v_mapped_level.clone()])?;
+            core_set(
+                &v_thinking_config,
+                CoreValue::from("thinkingLevel"),
+                v_clamped_level.clone(),
+            )?;
+        } else {
+            if core_truthy(&v_budget_is_number) {
+                v_numeric_budget = v_budget.clone();
+                v_is_zero = core_eq(&[v_budget.clone(), CoreValue::Num(0f64)])?;
+                v_clamp_pro_zero = core_and(&[v_is_25_pro.clone(), v_is_zero.clone()])?;
+                if core_truthy(&v_clamp_pro_zero) {
+                    v_numeric_budget = v_minimum_budget.clone();
+                }
+                core_set(
+                    &v_thinking_config,
+                    CoreValue::from("thinkingBudget"),
+                    v_numeric_budget.clone(),
+                )?;
+            } else {
+                if core_truthy(&v_budget_is_string) {
+                } else {
+                    v_error = core_ai_error_unsupported(&[CoreValue::from(
+                        "Gemini thinkingTokenBudget must be a number or logical level",
+                    )])?;
+                    return Err(core_as_error(&v_error));
+                }
+                v_numeric_budget = CoreValue::Num(-1f64);
+                v_is_none = core_eq(&[v_budget.clone(), CoreValue::from("none")])?;
+                if core_truthy(&v_is_none) {
+                    v_numeric_budget = CoreValue::Num(0f64);
+                    if core_truthy(&v_is_25_pro) {
+                        v_numeric_budget = v_minimum_budget.clone();
+                    }
+                    v_budget_is_none = CoreValue::Bool(true);
+                }
+                v_is_minimal = core_eq(&[v_budget.clone(), CoreValue::from("minimal")])?;
+                if core_truthy(&v_is_minimal) {
+                    v_numeric_budget = v_minimum_budget.clone();
+                }
+                v_is_low = core_eq(&[v_budget.clone(), CoreValue::from("low")])?;
+                if core_truthy(&v_is_low) {
+                    v_numeric_budget = v_low_budget.clone();
+                }
+                v_is_medium = core_eq(&[v_budget.clone(), CoreValue::from("medium")])?;
+                if core_truthy(&v_is_medium) {
+                    v_numeric_budget = v_medium_budget.clone();
+                }
+                v_is_high = core_eq(&[v_budget.clone(), CoreValue::from("high")])?;
+                if core_truthy(&v_is_high) {
+                    v_numeric_budget = v_high_budget.clone();
+                }
+                v_is_highest = core_eq(&[v_budget.clone(), CoreValue::from("highest")])?;
+                if core_truthy(&v_is_highest) {
+                    v_numeric_budget = v_highest_budget.clone();
+                }
+                v_unknown_level = core_eq(&[v_numeric_budget.clone(), CoreValue::Num(-1f64)])?;
+                if core_truthy(&v_unknown_level) {
+                    v_message = core_string_format(&[
+                        CoreValue::from("unsupported Gemini thinkingTokenBudget level: {}"),
+                        v_budget.clone(),
+                    ])?;
+                    v_error = core_ai_error_unsupported(&[v_message.clone()])?;
+                    return Err(core_as_error(&v_error));
+                }
+                core_set(
+                    &v_thinking_config,
+                    CoreValue::from("thinkingBudget"),
+                    v_numeric_budget.clone(),
+                )?;
+            }
+        }
+        v_has_thinking = CoreValue::Bool(true);
+    }
+    v_level_snake = core_get(
+        &v_model_config,
+        &CoreValue::from("thinking_level"),
+        CoreValue::Null,
+    );
+    v_explicit_level = core_get(
+        &v_model_config,
+        &CoreValue::from("thinkingLevel"),
+        v_level_snake.clone(),
+    );
+    v_has_explicit_level = core_is_not_none(&[v_explicit_level.clone()])?;
+    v_use_explicit_level = core_and(&[v_is_gemini3.clone(), v_has_explicit_level.clone()])?;
+    if core_truthy(&v_use_explicit_level) {
+        v_level_is_string = core_type_is(&v_explicit_level, CoreValue::from("string"));
+        if core_truthy(&v_level_is_string) {
+        } else {
+            v_error = core_ai_error_unsupported(&[CoreValue::from(
+                "Gemini thinkingLevel must be a logical level",
+            )])?;
+            return Err(core_as_error(&v_error));
+        }
+        v_clamped_level =
+            _gemini_clamp_thinking_level_impl(&[v_model.clone(), v_explicit_level.clone()])?;
+        core_map_delete(&[v_thinking_config.clone(), CoreValue::from("thinkingBudget")])?;
+        core_set(
+            &v_thinking_config,
+            CoreValue::from("thinkingLevel"),
+            v_clamped_level.clone(),
+        )?;
+        v_has_thinking = CoreValue::Bool(true);
+    }
+    v_show_snake = core_get(
+        &v_model_config,
+        &CoreValue::from("show_thoughts"),
+        CoreValue::Null,
+    );
+    v_show_thoughts = core_get(
+        &v_model_config,
+        &CoreValue::from("showThoughts"),
+        v_show_snake.clone(),
+    );
+    v_has_show = core_is_not_none(&[v_show_thoughts.clone()])?;
+    if core_truthy(&v_has_show) {
+        core_set(
+            &v_thinking_config,
+            CoreValue::from("includeThoughts"),
+            v_show_thoughts.clone(),
+        )?;
+        v_has_thinking = CoreValue::Bool(true);
+    }
+    if core_truthy(&v_budget_is_none) {
+        core_set(
+            &v_thinking_config,
+            CoreValue::from("includeThoughts"),
+            CoreValue::Bool(false),
+        )?;
+        v_has_thinking = CoreValue::Bool(true);
+    }
+    if core_truthy(&v_has_thinking) {
+        core_set(
+            &v_payload,
+            CoreValue::from("thinkingConfig"),
+            v_thinking_config.clone(),
+        )?;
+    }
+    return Ok(CoreValue::Null);
+}
+
+#[allow(
+    unused_variables,
+    unused_assignments,
+    unused_mut,
+    unreachable_code,
+    clippy::all
+)]
+fn _gemini_apply_model_config_impl(args: &[CoreValue]) -> Result<CoreValue, AxError> {
+    axir_coverage_mark("_gemini_apply_model_config_impl");
+    let mut v_payload = core_arg(args, 0);
+    let mut v_model = core_arg(args, 1);
+    let mut v_model_config = core_arg(args, 2);
+    let mut v_server_managed_sampling = core_arg(args, 3);
+    let mut v_client_managed_sampling = CoreValue::Null;
     _openai_copy_config_key_impl(&[
         v_payload.clone(),
         v_model_config.clone(),
@@ -40927,87 +41324,11 @@ fn _gemini_apply_model_config_impl(args: &[CoreValue]) -> Result<CoreValue, AxEr
         CoreValue::from("stop_sequences"),
         CoreValue::from("stopSequences"),
     ])?;
-    v_thinking_config = CoreValue::new_map();
-    v_has_thinking = CoreValue::Bool(false);
-    v_budget_snake = core_get(
-        &v_model_config,
-        &CoreValue::from("thinking_token_budget"),
-        CoreValue::Null,
-    );
-    v_budget = core_get(
-        &v_model_config,
-        &CoreValue::from("thinkingTokenBudget"),
-        v_budget_snake.clone(),
-    );
-    v_has_budget = core_is_not_none(&[v_budget.clone()])?;
-    if core_truthy(&v_has_budget) {
-        v_level = CoreValue::from("");
-        v_is_none = core_eq(&[v_budget.clone(), CoreValue::from("none")])?;
-        if core_truthy(&v_is_none) {
-            v_level = CoreValue::from("minimal");
-        }
-        v_is_minimal = core_eq(&[v_budget.clone(), CoreValue::from("minimal")])?;
-        if core_truthy(&v_is_minimal) {
-            v_level = CoreValue::from("minimal");
-        }
-        v_is_low = core_eq(&[v_budget.clone(), CoreValue::from("low")])?;
-        if core_truthy(&v_is_low) {
-            v_level = CoreValue::from("low");
-        }
-        v_is_medium = core_eq(&[v_budget.clone(), CoreValue::from("medium")])?;
-        if core_truthy(&v_is_medium) {
-            v_level = CoreValue::from("medium");
-        }
-        v_is_high = core_eq(&[v_budget.clone(), CoreValue::from("high")])?;
-        if core_truthy(&v_is_high) {
-            v_level = CoreValue::from("high");
-        }
-        v_is_highest = core_eq(&[v_budget.clone(), CoreValue::from("highest")])?;
-        if core_truthy(&v_is_highest) {
-            v_level = CoreValue::from("high");
-        }
-        v_named_level = core_eq(&[v_level.clone(), CoreValue::from("")])?;
-        if core_truthy(&v_named_level) {
-            core_set(
-                &v_thinking_config,
-                CoreValue::from("thinkingBudget"),
-                v_budget.clone(),
-            )?;
-        } else {
-            core_set(
-                &v_thinking_config,
-                CoreValue::from("thinkingLevel"),
-                v_level.clone(),
-            )?;
-        }
-        v_has_thinking = CoreValue::Bool(true);
-    }
-    v_show_snake = core_get(
-        &v_model_config,
-        &CoreValue::from("show_thoughts"),
-        CoreValue::Null,
-    );
-    v_show_thoughts = core_get(
-        &v_model_config,
-        &CoreValue::from("showThoughts"),
-        v_show_snake.clone(),
-    );
-    v_has_show = core_is_not_none(&[v_show_thoughts.clone()])?;
-    if core_truthy(&v_has_show) {
-        core_set(
-            &v_thinking_config,
-            CoreValue::from("includeThoughts"),
-            v_show_thoughts.clone(),
-        )?;
-        v_has_thinking = CoreValue::Bool(true);
-    }
-    if core_truthy(&v_has_thinking) {
-        core_set(
-            &v_payload,
-            CoreValue::from("thinkingConfig"),
-            v_thinking_config.clone(),
-        )?;
-    }
+    _gemini_apply_thinking_config_impl(&[
+        v_payload.clone(),
+        v_model.clone(),
+        v_model_config.clone(),
+    ])?;
     return Ok(CoreValue::Null);
 }
 
@@ -80749,4 +81070,4 @@ fn mcp_oauth_validate_issuer(args: &[CoreValue]) -> Result<CoreValue, AxError> {
     return Ok(v_out.clone());
 }
 
-// END AXIR CORE EMITTED FUNCTIONS (593 of 593 core functions)
+// END AXIR CORE EMITTED FUNCTIONS (595 of 595 core functions)

--- a/packages/rust/src/lib.rs
+++ b/packages/rust/src/lib.rs
@@ -40841,6 +40841,14 @@ fn _gemini_apply_model_config_impl(args: &[CoreValue]) -> Result<CoreValue, AxEr
     let mut v_has_budget = CoreValue::Null;
     let mut v_has_show = CoreValue::Null;
     let mut v_has_thinking = CoreValue::Null;
+    let mut v_is_high = CoreValue::Null;
+    let mut v_is_highest = CoreValue::Null;
+    let mut v_is_low = CoreValue::Null;
+    let mut v_is_medium = CoreValue::Null;
+    let mut v_is_minimal = CoreValue::Null;
+    let mut v_is_none = CoreValue::Null;
+    let mut v_level = CoreValue::Null;
+    let mut v_named_level = CoreValue::Null;
     let mut v_show_snake = CoreValue::Null;
     let mut v_show_thoughts = CoreValue::Null;
     let mut v_thinking_config = CoreValue::Null;
@@ -40933,11 +40941,45 @@ fn _gemini_apply_model_config_impl(args: &[CoreValue]) -> Result<CoreValue, AxEr
     );
     v_has_budget = core_is_not_none(&[v_budget.clone()])?;
     if core_truthy(&v_has_budget) {
-        core_set(
-            &v_thinking_config,
-            CoreValue::from("thinkingBudget"),
-            v_budget.clone(),
-        )?;
+        v_level = CoreValue::from("");
+        v_is_none = core_eq(&[v_budget.clone(), CoreValue::from("none")])?;
+        if core_truthy(&v_is_none) {
+            v_level = CoreValue::from("minimal");
+        }
+        v_is_minimal = core_eq(&[v_budget.clone(), CoreValue::from("minimal")])?;
+        if core_truthy(&v_is_minimal) {
+            v_level = CoreValue::from("minimal");
+        }
+        v_is_low = core_eq(&[v_budget.clone(), CoreValue::from("low")])?;
+        if core_truthy(&v_is_low) {
+            v_level = CoreValue::from("low");
+        }
+        v_is_medium = core_eq(&[v_budget.clone(), CoreValue::from("medium")])?;
+        if core_truthy(&v_is_medium) {
+            v_level = CoreValue::from("medium");
+        }
+        v_is_high = core_eq(&[v_budget.clone(), CoreValue::from("high")])?;
+        if core_truthy(&v_is_high) {
+            v_level = CoreValue::from("high");
+        }
+        v_is_highest = core_eq(&[v_budget.clone(), CoreValue::from("highest")])?;
+        if core_truthy(&v_is_highest) {
+            v_level = CoreValue::from("high");
+        }
+        v_named_level = core_eq(&[v_level.clone(), CoreValue::from("")])?;
+        if core_truthy(&v_named_level) {
+            core_set(
+                &v_thinking_config,
+                CoreValue::from("thinkingBudget"),
+                v_budget.clone(),
+            )?;
+        } else {
+            core_set(
+                &v_thinking_config,
+                CoreValue::from("thinkingLevel"),
+                v_level.clone(),
+            )?;
+        }
         v_has_thinking = CoreValue::Bool(true);
     }
     v_show_snake = core_get(

--- a/src/ax/ai/google-gemini/api.test.ts
+++ b/src/ax/ai/google-gemini/api.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 
+import { ai as createAI } from '../wrap.js';
 import {
   AxAIGoogleGemini,
   axAIGoogleGeminiDefaultConfig,
@@ -694,7 +695,328 @@ describe('AxAIGoogleGemini model key preset merging', () => {
     expect(reqBody.generationConfig.thinkingConfig.includeThoughts).toBe(false);
   });
 
-  it('maps thinkingTokenBudget to thinkingLevel for Gemini 3 Pro (low/high only)', async () => {
+  it.each([
+    {
+      model: AxAIGoogleGeminiModel.Gemini35Flash,
+      requested: 'highest' as const,
+      expectedLevel: 'high',
+    },
+    {
+      model: AxAIGoogleGeminiModel.Gemini37Flash,
+      requested: 'minimal' as const,
+      expectedLevel: 'low',
+    },
+    {
+      model: AxAIGoogleGeminiModel.Gemini31Pro,
+      requested: 'medium' as const,
+      expectedLevel: 'medium',
+    },
+    {
+      model: AxAIGoogleGeminiModel.Gemini31FlashImage,
+      requested: 'medium' as const,
+      expectedLevel: 'high',
+    },
+    {
+      model: 'gemini-3-pro-preview',
+      requested: 'medium' as const,
+      expectedLevel: 'high',
+    },
+  ])(
+    'maps $model $requested to the supported Gemini 3 level',
+    async ({ model, requested, expectedLevel }) => {
+      const capture: { lastBody?: any } = {};
+      const ai = new AxAIGoogleGemini({
+        apiKey: 'key',
+        config: { model: model as AxAIGoogleGeminiModel },
+        models: [],
+        options: {
+          fetch: createMockFetch(
+            {
+              candidates: [
+                {
+                  content: { parts: [{ text: 'ok' }] },
+                  finishReason: 'STOP',
+                },
+              ],
+            },
+            capture
+          ),
+        },
+      });
+
+      await ai.chat(
+        { chatPrompt: [{ role: 'user', content: 'hi' }] },
+        { thinkingTokenBudget: requested, showThoughts: true, stream: false }
+      );
+
+      expect(capture.lastBody?.generationConfig?.thinkingConfig).toEqual({
+        thinkingLevel: expectedLevel,
+        includeThoughts: true,
+      });
+    }
+  );
+
+  it.each([
+    {
+      model: AxAIGoogleGeminiModel.Gemini25Flash,
+      requested: 'high' as const,
+      expectedBudget: 10_000,
+      expectedThoughts: true,
+    },
+    {
+      model: AxAIGoogleGeminiModel.Gemini25Flash,
+      requested: 'none' as const,
+      expectedBudget: 0,
+      expectedThoughts: false,
+    },
+    {
+      model: AxAIGoogleGeminiModel.Gemini25Pro,
+      requested: 'none' as const,
+      expectedBudget: 200,
+      expectedThoughts: false,
+    },
+  ])(
+    'maps $model $requested to numeric budget $expectedBudget',
+    async ({ model, requested, expectedBudget, expectedThoughts }) => {
+      const capture: { lastBody?: any } = {};
+      const ai = new AxAIGoogleGemini({
+        apiKey: 'key',
+        config: { model },
+        models: [],
+        options: {
+          fetch: createMockFetch(
+            {
+              candidates: [
+                {
+                  content: { parts: [{ text: 'ok' }] },
+                  finishReason: 'STOP',
+                },
+              ],
+            },
+            capture
+          ),
+        },
+      });
+
+      await ai.chat(
+        { chatPrompt: [{ role: 'user', content: 'hi' }] },
+        { thinkingTokenBudget: requested, showThoughts: true, stream: false }
+      );
+
+      expect(capture.lastBody?.generationConfig?.thinkingConfig).toEqual({
+        thinkingBudget: expectedBudget,
+        includeThoughts: expectedThoughts,
+      });
+    }
+  );
+
+  it('clamps custom level mappings to the selected model family', async () => {
+    const capture: { lastBody?: any } = {};
+    const ai = new AxAIGoogleGemini({
+      apiKey: 'key',
+      config: {
+        model: AxAIGoogleGeminiModel.Gemini37Flash,
+        thinkingLevelMapping: { minimal: 'minimal' },
+      },
+      models: [],
+      options: {
+        fetch: createMockFetch(
+          {
+            candidates: [
+              {
+                content: { parts: [{ text: 'ok' }] },
+                finishReason: 'STOP',
+              },
+            ],
+          },
+          capture
+        ),
+      },
+    });
+
+    await ai.chat(
+      { chatPrompt: [{ role: 'user', content: 'hi' }] },
+      { thinkingTokenBudget: 'minimal', stream: false }
+    );
+
+    expect(
+      capture.lastBody?.generationConfig?.thinkingConfig?.thinkingLevel
+    ).toBe('low');
+  });
+
+  it('resolves named model presets before selecting level or budget fields', async () => {
+    const capture: { lastBody?: any } = {};
+    const ai = new AxAIGoogleGemini({
+      apiKey: 'key',
+      config: { model: AxAIGoogleGeminiModel.Gemini25Flash },
+      models: [
+        {
+          key: 'modern',
+          model: AxAIGoogleGeminiModel.Gemini37Flash,
+          description: 'Gemini 3 preset',
+          thinkingTokenBudget: 'minimal',
+          showThoughts: true,
+        },
+        {
+          key: 'legacy',
+          model: AxAIGoogleGeminiModel.Gemini25Flash,
+          description: 'Gemini 2.5 preset',
+          thinkingTokenBudget: 'high',
+          showThoughts: true,
+        },
+      ],
+      options: {
+        fetch: createMockFetch(
+          {
+            candidates: [
+              {
+                content: { parts: [{ text: 'ok' }] },
+                finishReason: 'STOP',
+              },
+            ],
+          },
+          capture
+        ),
+      },
+    });
+
+    await ai.chat(
+      { model: 'modern', chatPrompt: [{ role: 'user', content: 'hi' }] },
+      { stream: false }
+    );
+    expect(capture.lastBody?.generationConfig?.thinkingConfig).toEqual({
+      thinkingLevel: 'low',
+      includeThoughts: true,
+    });
+
+    await ai.chat(
+      { model: 'legacy', chatPrompt: [{ role: 'user', content: 'hi' }] },
+      { stream: false }
+    );
+    expect(capture.lastBody?.generationConfig?.thinkingConfig).toEqual({
+      thinkingBudget: 10_000,
+      includeThoughts: true,
+    });
+
+    await ai.chat(
+      { model: 'modern', chatPrompt: [{ role: 'user', content: 'hi' }] },
+      {
+        thinkingTokenBudget: 'high',
+        showThoughts: false,
+        stream: false,
+      }
+    );
+    expect(capture.lastBody?.generationConfig?.thinkingConfig).toEqual({
+      thinkingLevel: 'high',
+      includeThoughts: false,
+    });
+  });
+
+  it('rejects numeric thinking budgets in Gemini 3 named model presets', () => {
+    expect(
+      () =>
+        new AxAIGoogleGemini({
+          apiKey: 'key',
+          config: { model: AxAIGoogleGeminiModel.Gemini25Flash },
+          models: [
+            {
+              key: 'modern',
+              model: AxAIGoogleGeminiModel.Gemini35Flash,
+              description: 'Gemini 3 preset',
+              config: { thinking: { thinkingTokenBudget: 1000 } },
+            },
+          ],
+        })
+    ).toThrow(/do not support numeric thinkingTokenBudget/);
+  });
+
+  it.each(['google-gemini', 'gemini', 'google_gemini'])(
+    'uses native Gemini thinking for the %s deployment profile name',
+    async (profile) => {
+      const capture: { lastBody?: any } = {};
+      const service = createAI({
+        name: profile,
+        apiKey: 'key',
+        config: { model: AxAIGoogleGeminiModel.Gemini35Flash },
+      } as any);
+      service.setOptions({
+        fetch: createMockFetch(
+          {
+            candidates: [
+              {
+                content: { parts: [{ text: 'ok' }] },
+                finishReason: 'STOP',
+              },
+            ],
+          },
+          capture
+        ),
+      });
+
+      await service.chat(
+        { chatPrompt: [{ role: 'user', content: 'hi' }] },
+        { thinkingTokenBudget: 'high', stream: false }
+      );
+
+      expect(capture.lastBody?.generationConfig?.thinkingConfig).toEqual({
+        thinkingLevel: 'high',
+      });
+    }
+  );
+
+  it('uses native Gemini thinking when the google-gemini profile targets Vertex', async () => {
+    const capture: { lastBody?: any } = {};
+    const service = createAI({
+      name: 'google-gemini',
+      apiKey: async () => 'vertex-token',
+      projectId: 'demo-project',
+      region: 'us-central1',
+      config: { model: AxAIGoogleGeminiModel.Gemini35Flash },
+    });
+    service.setOptions({
+      fetch: createMockFetch(
+        {
+          candidates: [
+            {
+              content: { parts: [{ text: 'ok' }] },
+              finishReason: 'STOP',
+            },
+          ],
+        },
+        capture
+      ),
+    });
+
+    await service.chat(
+      { chatPrompt: [{ role: 'user', content: 'hi' }] },
+      { thinkingTokenBudget: 'high', stream: false }
+    );
+
+    expect(capture.lastBody?.generationConfig?.thinkingConfig).toEqual({
+      thinkingLevel: 'high',
+    });
+  });
+
+  it('does not apply native Gemini thinking to the OpenAI-compatible vertex-ai profile', async () => {
+    const fetch = vi.fn();
+    const service = createAI({
+      name: 'vertex-ai',
+      apiKey: 'token',
+      apiURL: 'https://vertex.example.test/v1',
+      config: { model: AxAIGoogleGeminiModel.Gemini35Flash },
+      options: { fetch },
+    });
+
+    await expect(
+      service.chat(
+        { chatPrompt: [{ role: 'user', content: 'hi' }] },
+        { thinkingTokenBudget: 'high', stream: false }
+      )
+    ).rejects.toThrow(/Thinking is not verified for profile vertex-ai/);
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it('preserves medium thinking for Gemini 3.1 Pro', async () => {
     const ai = new AxAIGoogleGemini({
       apiKey: 'key',
       config: { model: AxAIGoogleGeminiModel.Gemini3Pro },
@@ -716,8 +1038,6 @@ describe('AxAIGoogleGemini model key preset merging', () => {
 
     ai.setOptions({ fetch });
 
-    // 'medium' maps to 'high' for Gemini 3 Pro (which only supports low/high)
-    // Note: maxTokens cannot be set with thinkingLevel, so we don't set it
     await ai.chat(
       {
         chatPrompt: [{ role: 'user', content: 'hi' }],
@@ -727,8 +1047,9 @@ describe('AxAIGoogleGemini model key preset merging', () => {
 
     const reqBody = capture.lastBody;
     expect(reqBody?.generationConfig?.thinkingConfig).toBeDefined();
-    // medium level maps to 'high' for Gemini 3 Pro
-    expect(reqBody.generationConfig.thinkingConfig.thinkingLevel).toBe('high');
+    expect(reqBody.generationConfig.thinkingConfig.thinkingLevel).toBe(
+      'medium'
+    );
     expect(
       reqBody.generationConfig.thinkingConfig.thinkingBudget
     ).toBeUndefined();
@@ -822,9 +1143,7 @@ describe('AxAIGoogleGemini model key preset merging', () => {
     ).toThrow(/do not support numeric thinkingTokenBudget/);
   });
 
-  it('maps thinkingTokenBudget none to minimal for Gemini 3+ (includeThoughts controlled by showThoughts)', async () => {
-    // Gemini 3+ models cannot fully disable thinking - 'minimal' is the lowest level
-    // When 'none' is specified, we map to 'minimal'. includeThoughts is controlled separately by showThoughts option.
+  it('maps thinkingTokenBudget none to the minimum and always hides thoughts', async () => {
     const ai = new AxAIGoogleGemini({
       apiKey: 'key',
       config: { model: AxAIGoogleGeminiModel.Gemini3Flash },
@@ -856,14 +1175,12 @@ describe('AxAIGoogleGemini model key preset merging', () => {
     );
 
     const reqBody = capture.lastBody;
-    // thinkingConfig should have thinkingLevel='minimal'
-    // includeThoughts should NOT be automatically set - it's controlled by showThoughts option
     expect(reqBody?.generationConfig?.thinkingConfig?.thinkingLevel).toBe(
       'minimal'
     );
-    expect(
-      reqBody?.generationConfig?.thinkingConfig?.includeThoughts
-    ).toBeUndefined();
+    expect(reqBody?.generationConfig?.thinkingConfig?.includeThoughts).toBe(
+      false
+    );
   });
 
   it('allows thinkingTokenBudget none to disable thinking for Gemini 2.5', async () => {
@@ -2432,6 +2749,52 @@ describe('AxAIGoogleGemini Live audio chat', () => {
     expect(config.audio?.output?.includeTranscript).toBe(true);
     expect(config.audio?.live?.turnTimeoutMs).toBe(30_000);
   });
+
+  it.each([
+    {
+      model: AxAIGoogleGeminiModel.Gemini31FlashLive,
+      expected: { thinkingLevel: 'high', includeThoughts: true },
+    },
+    {
+      model: AxAIGoogleGeminiModel.Gemini25FlashNativeAudio,
+      expected: { thinkingBudget: 10_000, includeThoughts: true },
+    },
+  ])(
+    'uses model-aware thinking in Live setup for $model',
+    async ({ model, expected }) => {
+      const restore = installFakeGeminiLiveWebSocket([
+        { serverContent: { turnComplete: true } },
+      ]);
+
+      try {
+        const ai = new AxAIGoogleGemini({
+          apiKey: 'key',
+          config: {
+            ...axAIGoogleGeminiLiveAudioDefaultConfig(),
+            model,
+          },
+          models: [],
+        });
+
+        await ai.chat(
+          {
+            chatPrompt: [{ role: 'user', content: 'answer aloud' }],
+          },
+          {
+            thinkingTokenBudget: 'high',
+            showThoughts: true,
+            stream: false,
+          }
+        );
+
+        const socket = FakeGeminiLiveWebSocket.instances[0];
+        const setup = JSON.parse(socket?.sent[0] ?? '{}');
+        expect(setup.setup.generationConfig.thinkingConfig).toEqual(expected);
+      } finally {
+        restore();
+      }
+    }
+  );
 
   it('aggregates a bounded one-turn WebSocket audio response', async () => {
     const restore = installFakeGeminiLiveWebSocket([

--- a/src/ax/ai/google-gemini/api.ts
+++ b/src/ax/ai/google-gemini/api.ts
@@ -17,12 +17,6 @@ import { resolveVertexAIHost } from '../vertex.js';
 const isGemini3Model = (model: string): boolean => model.includes('gemini-3');
 
 /**
- * Check if a model is Gemini 3 Pro
- */
-const isGemini3Pro = (model: string): boolean =>
-  model.includes('gemini-3') && model.includes('pro');
-
-/**
  * Gemini 3.7 Flash, 3.6 Flash, and 3.5 Flash-Lite use server-managed
  * sampling and ignore temperature, topP, and topK.
  */
@@ -86,6 +80,163 @@ import {
   type AxAIGoogleVertexBatchEmbedResponse,
   GEMINI_CONTEXT_CACHE_SUPPORTED_MODELS,
 } from './types.js';
+
+type AxGeminiLogicalThinkingLevel =
+  | 'none'
+  | 'minimal'
+  | 'low'
+  | 'medium'
+  | 'high'
+  | 'highest';
+
+type AxGemini3ThinkingFamily = 'full' | 'no-minimal' | 'image' | 'legacy-pro';
+
+const axGeminiLogicalThinkingLevels = new Set<AxGeminiLogicalThinkingLevel>([
+  'none',
+  'minimal',
+  'low',
+  'medium',
+  'high',
+  'highest',
+]);
+
+const getGemini3ThinkingFamily = (
+  model: string
+): AxGemini3ThinkingFamily | undefined => {
+  const normalized = model.toLowerCase();
+  if (!isGemini3Model(normalized)) return undefined;
+  if (normalized.includes('-image')) return 'image';
+  if (normalized.includes('gemini-3-pro')) return 'legacy-pro';
+  if (
+    normalized.includes('gemini-3.7-flash') ||
+    normalized.includes('gemini-3.1-pro')
+  ) {
+    return 'no-minimal';
+  }
+  return 'full';
+};
+
+const clampGemini3ThinkingLevel = (
+  model: string,
+  level: AxAIGoogleGeminiThinkingLevel
+): AxAIGoogleGeminiThinkingLevel => {
+  switch (getGemini3ThinkingFamily(model)) {
+    case 'image':
+      return level === 'minimal' || level === 'low' ? 'minimal' : 'high';
+    case 'legacy-pro':
+      return level === 'minimal' || level === 'low' ? 'low' : 'high';
+    case 'no-minimal':
+      return level === 'minimal' ? 'low' : level;
+    case 'full':
+    case undefined:
+      return level;
+  }
+};
+
+const resolveGeminiThinkingConfig = ({
+  model,
+  direct,
+  logicalLevel,
+  showThoughts,
+  thinkingLevelMapping,
+  thinkingTokenBudgetLevels,
+}: {
+  model: string;
+  direct?: AxAIGoogleGeminiConfig['thinking'];
+  logicalLevel?: AxAIServiceOptions['thinkingTokenBudget'] | number;
+  showThoughts?: boolean;
+  thinkingLevelMapping?: AxAIGoogleGeminiThinkingLevelMapping;
+  thinkingTokenBudgetLevels?: AxAIGoogleGeminiConfig['thinkingTokenBudgetLevels'];
+}): NonNullable<AxAIGoogleGeminiGenerationConfig['thinkingConfig']> => {
+  const thinkingConfig: NonNullable<
+    AxAIGoogleGeminiGenerationConfig['thinkingConfig']
+  > = {};
+  const gemini3Family = getGemini3ThinkingFamily(model);
+
+  if (direct?.thinkingTokenBudget !== undefined) {
+    if (gemini3Family) {
+      throw new Error(
+        `Gemini 3 models (${model}) do not support numeric thinkingTokenBudget. ` +
+          `Use a logical thinkingTokenBudget level or thinkingLevel instead.`
+      );
+    }
+    thinkingConfig.thinkingBudget =
+      model.includes('gemini-2.5-pro') && direct.thinkingTokenBudget === 0
+        ? (thinkingTokenBudgetLevels?.minimal ?? 200)
+        : direct.thinkingTokenBudget;
+  }
+
+  if (direct?.thinkingLevel !== undefined && gemini3Family) {
+    thinkingConfig.thinkingLevel = clampGemini3ThinkingLevel(
+      model,
+      direct.thinkingLevel
+    );
+  }
+
+  if (direct?.includeThoughts !== undefined) {
+    thinkingConfig.includeThoughts = direct.includeThoughts;
+  }
+
+  if (logicalLevel !== undefined) {
+    if (typeof logicalLevel === 'number') {
+      if (gemini3Family) {
+        throw new Error(
+          `Gemini 3 models (${model}) do not support numeric thinkingTokenBudget. ` +
+            `Use a logical thinkingTokenBudget level instead.`
+        );
+      }
+      thinkingConfig.thinkingBudget =
+        model.includes('gemini-2.5-pro') && logicalLevel === 0
+          ? (thinkingTokenBudgetLevels?.minimal ?? 200)
+          : logicalLevel;
+      delete thinkingConfig.thinkingLevel;
+    } else {
+      if (!axGeminiLogicalThinkingLevels.has(logicalLevel)) {
+        throw new Error(
+          `Unsupported Gemini thinkingTokenBudget level '${String(logicalLevel)}'`
+        );
+      }
+
+      if (gemini3Family) {
+        const mappingKey = logicalLevel === 'none' ? 'minimal' : logicalLevel;
+        const defaultLevel =
+          mappingKey === 'highest'
+            ? 'high'
+            : (mappingKey as AxAIGoogleGeminiThinkingLevel);
+        const mappedLevel = thinkingLevelMapping?.[mappingKey] ?? defaultLevel;
+        thinkingConfig.thinkingLevel = clampGemini3ThinkingLevel(
+          model,
+          mappedLevel
+        );
+        delete thinkingConfig.thinkingBudget;
+      } else {
+        const minimum = thinkingTokenBudgetLevels?.minimal ?? 200;
+        const budgets: Record<AxGeminiLogicalThinkingLevel, number> = {
+          none: model.includes('gemini-2.5-pro') ? minimum : 0,
+          minimal: minimum,
+          low: thinkingTokenBudgetLevels?.low ?? 800,
+          medium: thinkingTokenBudgetLevels?.medium ?? 5000,
+          high: thinkingTokenBudgetLevels?.high ?? 10000,
+          highest: thinkingTokenBudgetLevels?.highest ?? 24500,
+        };
+        thinkingConfig.thinkingBudget = budgets[logicalLevel];
+        delete thinkingConfig.thinkingLevel;
+      }
+    }
+  }
+
+  if (showThoughts !== undefined) {
+    thinkingConfig.includeThoughts = showThoughts;
+  }
+  if (logicalLevel === 'none') {
+    thinkingConfig.includeThoughts = false;
+  }
+
+  if (thinkingConfig.thinkingLevel !== undefined) {
+    delete thinkingConfig.thinkingBudget;
+  }
+  return thinkingConfig;
+};
 
 export { axAIGoogleGeminiLiveAudioDefaultConfig } from './live_audio.js';
 
@@ -259,7 +410,7 @@ export const axAIGoogleGeminiDefaultConfig = (): AxAIGoogleGeminiConfig =>
       highest: 24500,
     },
     // Default mapping for Gemini 3+ models (thinkingTokenBudget → thinkingLevel)
-    // Note: 'none' always maps to 'minimal' for Gemini 3+ (which can't disable thinking)
+    // 'none' starts at minimal, is model-clamped, and always hides thoughts.
     thinkingLevelMapping: {
       minimal: 'minimal',
       low: 'low',
@@ -284,7 +435,7 @@ export const axAIGoogleGeminiDefaultCreativeConfig =
         highest: 24500,
       },
       // Default mapping for Gemini 3+ models (thinkingTokenBudget → thinkingLevel)
-      // Note: 'none' always maps to 'minimal' for Gemini 3+ (which can't disable thinking)
+      // 'none' starts at minimal, is model-clamped, and always hides thoughts.
       thinkingLevelMapping: {
         minimal: 'minimal',
         low: 'low',
@@ -356,31 +507,12 @@ class AxAIGoogleGeminiImpl
       throw new Error('Auto truncate is not supported for GoogleGemini');
     }
 
-    // Validate Gemini 3 thinking configuration
-    const model = this.config.model;
-    if (isGemini3Model(model)) {
-      // Gemini 3 models don't support numeric thinkingBudget, only thinkingLevel
-      if (
-        this.config.thinking?.thinkingTokenBudget !== undefined &&
-        typeof this.config.thinking.thinkingTokenBudget === 'number'
-      ) {
-        throw new Error(
-          `Gemini 3 models (${model}) do not support numeric thinkingTokenBudget. ` +
-            `Use thinkingLevel ('low', 'medium', 'high') instead, or pass thinkingTokenBudget as a string level via options.`
-        );
-      }
-
-      // Gemini 3 Pro only supports 'low' and 'high' thinkingLevel
-      if (isGemini3Pro(model) && this.config.thinking?.thinkingLevel) {
-        const level = this.config.thinking.thinkingLevel;
-        if (level !== 'low' && level !== 'high') {
-          throw new Error(
-            `Gemini 3 Pro (${model}) only supports thinkingLevel 'low' or 'high', got '${level}'. ` +
-              `Use 'low' for less thinking or 'high' for more thinking.`
-          );
-        }
-      }
-    }
+    resolveGeminiThinkingConfig({
+      model: this.config.model,
+      direct: this.config.thinking,
+      thinkingLevelMapping: this.config.thinkingLevelMapping,
+      thinkingTokenBudgetLevels: this.config.thinkingTokenBudgetLevels,
+    });
   }
 
   /**
@@ -1032,107 +1164,14 @@ class AxAIGoogleGeminiImpl
 
     const { tools, toolConfig } = this.buildToolState(req, config);
 
-    const thinkingConfig: AxAIGoogleGeminiGenerationConfig['thinkingConfig'] =
-      {};
-
-    if (this.config.thinking?.includeThoughts) {
-      thinkingConfig.includeThoughts = true;
-    }
-
-    if (this.config.thinking?.thinkingTokenBudget) {
-      thinkingConfig.thinkingBudget = this.config.thinking.thinkingTokenBudget;
-    }
-    // thinkingLevel is only supported by Gemini 3+ models
-    // Gemini 2.5 and older models use numeric thinkingBudget instead
-    if (this.config.thinking?.thinkingLevel && isGemini3Model(model)) {
-      thinkingConfig.thinkingLevel = this.config.thinking.thinkingLevel;
-    }
-
-    // Then, override based on prompt-specific config
-    if (config?.thinkingTokenBudget) {
-      //The thinkingBudget must be an integer in the range 0 to 24576
-      const effectiveMappings = this.getEffectiveMappings(model);
-      const levels = effectiveMappings.thinkingTokenBudgetLevels;
-      const isGemini3 = isGemini3Model(model);
-
-      if (isGemini3) {
-        // Gemini 3 uses thinkingLevel instead of numeric thinkingBudget
-        // Gemini 3 Flash: supports minimal, low, medium, high
-        // Gemini 3 Pro: supports only low, high
-        const isPro = isGemini3Pro(model);
-        const mapping = effectiveMappings.thinkingLevelMapping;
-
-        if (config.thinkingTokenBudget === 'none') {
-          // Gemini 3+ cannot disable thinking - 'minimal' is the lowest level
-          // Map 'none' to 'minimal'. Note: includeThoughts is controlled separately by showThoughts option.
-          thinkingConfig.thinkingLevel =
-            mapping?.minimal ?? ('minimal' as AxAIGoogleGeminiThinkingLevel);
-        } else {
-          // Use configurable mapping
-          const levelToMap =
-            config.thinkingTokenBudget as keyof AxAIGoogleGeminiThinkingLevelMapping;
-          let mappedLevel = mapping?.[levelToMap];
-
-          // Fallback to defaults if not configured
-          if (!mappedLevel) {
-            mappedLevel =
-              levelToMap === 'highest'
-                ? 'high'
-                : (levelToMap as AxAIGoogleGeminiThinkingLevel);
-          }
-
-          thinkingConfig.thinkingLevel = mappedLevel;
-        }
-
-        // Pro only supports 'low' and 'high' - validate/adjust
-        if (isPro && thinkingConfig.thinkingLevel) {
-          const level = thinkingConfig.thinkingLevel;
-          if (level !== 'low' && level !== 'high') {
-            // Adjust: minimal -> low, medium -> high
-            thinkingConfig.thinkingLevel = level === 'minimal' ? 'low' : 'high';
-          }
-        }
-      } else {
-        // Non-Gemini 3 models use numeric thinkingBudget
-        switch (config.thinkingTokenBudget) {
-          case 'none':
-            thinkingConfig.thinkingBudget = 0;
-            thinkingConfig.includeThoughts = false;
-            delete thinkingConfig.thinkingLevel;
-            break;
-          case 'minimal':
-            thinkingConfig.thinkingBudget = levels?.minimal ?? 200;
-            break;
-          case 'low':
-            thinkingConfig.thinkingBudget = levels?.low ?? 800;
-            break;
-          case 'medium':
-            thinkingConfig.thinkingBudget = levels?.medium ?? 5000;
-            break;
-          case 'high':
-            thinkingConfig.thinkingBudget = levels?.high ?? 10000;
-            break;
-          case 'highest':
-            thinkingConfig.thinkingBudget = levels?.highest ?? 24500;
-            break;
-        }
-      }
-    }
-
-    // If thinkingLevel is set, remove thinkingBudget as they cannot be used together
-    if (thinkingConfig.thinkingLevel) {
-      delete thinkingConfig.thinkingBudget;
-    }
-
-    // Clean up thinking parameters for incompatible models
-    // thinkingLevel is only supported by Gemini 3+ models
-    if (!isGemini3Model(model)) {
-      delete thinkingConfig.thinkingLevel;
-    }
-    // thinkingBudget is not supported by Gemini 3+ models (which use thinkingLevel instead)
-    if (isGemini3Model(model)) {
-      delete thinkingConfig.thinkingBudget;
-    }
+    const effectiveMappings = this.getEffectiveMappings(model);
+    const thinkingConfig = resolveGeminiThinkingConfig({
+      model,
+      direct: this.config.thinking,
+      logicalLevel: config?.thinkingTokenBudget,
+      showThoughts: config?.showThoughts,
+      ...effectiveMappings,
+    });
 
     // Validate: maxTokens cannot be set when thinkingLevel is used (Gemini limitation)
     const effectiveMaxTokens =
@@ -1143,13 +1182,6 @@ class AxAIGoogleGeminiImpl
           `When thinking is enabled, the model manages output tokens automatically. ` +
           `Remove the maxTokens setting or disable thinking.`
       );
-    }
-
-    if (config?.showThoughts !== undefined) {
-      // Only override includeThoughts if thinkingTokenBudget is not 'none'
-      if (config?.thinkingTokenBudget !== 'none') {
-        thinkingConfig.includeThoughts = config.showThoughts;
-      }
     }
 
     const serverManagedSampling = usesServerManagedSampling(model as string);
@@ -1813,6 +1845,14 @@ class AxAIGoogleGeminiImpl
 
     // Build the generation config using existing logic
     const serverManagedSampling = usesServerManagedSampling(model as string);
+    const effectiveMappings = this.getEffectiveMappings(model);
+    const thinkingConfig = resolveGeminiThinkingConfig({
+      model,
+      direct: this.config.thinking,
+      logicalLevel: options.thinkingTokenBudget,
+      showThoughts: options.showThoughts,
+      ...effectiveMappings,
+    });
     const generationConfig: AxAIGoogleGeminiGenerationConfig = {
       maxOutputTokens: req.modelConfig?.maxTokens ?? this.config.maxTokens,
       ...(!serverManagedSampling
@@ -1833,6 +1873,7 @@ class AxAIGoogleGeminiImpl
       stopSequences:
         req.modelConfig?.stopSequences ?? this.config.stopSequences,
       responseMimeType: 'text/plain',
+      ...(Object.keys(thinkingConfig).length > 0 ? { thinkingConfig } : {}),
     };
 
     // Gemini 3+ models require a minimum temperature of 1.0
@@ -2397,6 +2438,13 @@ export class AxAIGoogleGemini<TModelKey = string> extends AxBaseAI<
       // Map exact numeric thinking budget to the closest supported level
       const numericBudget = cfg.thinking?.thinkingTokenBudget;
       if (typeof numericBudget === 'number') {
+        const presetModel = String(anyItem.model ?? Config.model);
+        if (isGemini3Model(presetModel)) {
+          throw new Error(
+            `Gemini 3 models (${presetModel}) do not support numeric thinkingTokenBudget. ` +
+              `Use a logical thinkingTokenBudget level instead.`
+          );
+        }
         const levels = Config.thinkingTokenBudgetLevels;
         const candidates = [
           ['minimal', levels?.minimal ?? 200],

--- a/src/ax/ai/google-gemini/types.ts
+++ b/src/ax/ai/google-gemini/types.ts
@@ -267,8 +267,8 @@ export type AxAIGoogleGeminiThinkingTokenBudgetLevels = {
 };
 
 /**
- * Maps thinkingTokenBudget string levels to Gemini 3+ thinkingLevel values.
- * 'none' is handled separately (disables thinking or maps to 'minimal' for Gemini 3+).
+ * Maps thinkingTokenBudget string levels to Gemini 3 thinkingLevel values.
+ * The mapped result is clamped to the levels supported by the resolved model.
  */
 export type AxAIGoogleGeminiThinkingLevelMapping = {
   minimal?: AxAIGoogleGeminiThinkingLevel;

--- a/src/ax/skills/ax-ai.md
+++ b/src/ax/skills/ax-ai.md
@@ -401,14 +401,26 @@ console.log(res.results[0]?.content);
 
 ### Budget Levels
 
-| Level | Anthropic (tokens) | Gemini (tokens) |
-|---|---|---|
-| `'none'` | disabled | minimal |
-| `'minimal'` | 1,024 | 200 |
-| `'low'` | 5,000 | 800 |
-| `'medium'` | 10,000 | 5,000 |
-| `'high'` | 20,000 | 10,000 |
-| `'highest'` | 32,000 | 24,500 |
+| Level | Anthropic (tokens) | Gemini 2.5 (tokens) | Gemini 3 level |
+|---|---|---|---|
+| `'none'` | disabled | 0 on Flash/Lite; minimum on Pro | lowest supported, thoughts hidden |
+| `'minimal'` | 1,024 | 200 | `minimal`, or `low` when `minimal` is unsupported |
+| `'low'` | 5,000 | 800 | `low` |
+| `'medium'` | 10,000 | 5,000 | `medium`, or the nearest image/legacy level |
+| `'high'` | 20,000 | 10,000 | `high` |
+| `'highest'` | 32,000 | 24,500 | `high` |
+
+Gemini 3 uses `thinkingLevel`; Gemini 2.5 and older models use numeric
+`thinkingBudget`. Ax selects the wire field after resolving a named model
+preset to its real model. Gemini 3.7 Flash and Gemini 3.1 Pro clamp `minimal`
+to `low`; image and legacy Gemini 3 models clamp to their documented two-level
+sets. Numeric Gemini 3 budgets fail locally. `none` always hides returned
+thoughts, even when the model must still perform its minimum amount of thinking.
+
+The native `google-gemini` deployment profile and its aliases use these Gemini
+rules, including when configured for Vertex with `projectId` and `region`. The
+separate OpenAI-compatible `vertex-ai` profile keeps its own request rules and
+does not inherit native Gemini fields from a Gemini-looking model ID.
 
 For GPT-5.6, these map to `none`, `low`, `low`, `medium`, `high`, and a top rung
 that depends on the API surface: `xhigh` on Chat Completions, which rejects

--- a/src/ax/skills/ax-gen.md
+++ b/src/ax/skills/ax-gen.md
@@ -321,7 +321,10 @@ console.log(result.thought);
 
 Rules:
 
-- `thinkingTokenBudget` can be `'low'`, `'medium'`, `'high'`, or a number.
+- `thinkingTokenBudget` accepts `'none'`, `'minimal'`, `'low'`, `'medium'`,
+  `'high'`, or `'highest'`. Provider-specific numeric configuration is only for
+  models such as Gemini 2.5 that expose a numeric thinking budget; Gemini 3 uses
+  model-aware thinking levels instead.
 - Set `showThoughts: true` to include the model's reasoning in `result.thought`.
 
 ## Structured Outputs

--- a/tools/axir/extractors/axai-goldens.ts
+++ b/tools/axir/extractors/axai-goldens.ts
@@ -5072,6 +5072,42 @@ writeFixture('openai-speak-error-surfaces-error', {
 // reasoning text back got a chat log with no thought in it. TypeScript maps both
 // (src/ax/ai/google-gemini/api.ts:1043 and :1148); the port dropped them between
 // merge_model_config, which accepts them, and the request, which never read them.
+// An effort level is not a token count. Gemini's thinkingBudget is an int32 and
+// rejects a level with a hard 400, while thinkingLevel is what the Gemini 3
+// family documents — so a caller asking for high-effort reasoning broke every
+// request rather than getting it. none becomes minimal because Gemini 3 cannot
+// disable thinking, and highest is spelled high.
+writeFixture('gemini-thinking-level-routes-away-from-the-budget', {
+  kind: 'ai_chat',
+  provider: 'google-gemini',
+  model: 'gemini-3.5-flash',
+  request: {
+    chat_prompt: [{ role: 'user', content: 'think hard' }],
+    model_config: {
+      stream: false,
+      thinkingTokenBudget: 'highest',
+      showThoughts: true,
+    },
+  },
+  transport_responses: [
+    {
+      status: 200,
+      json: {
+        candidates: [
+          { content: { parts: [{ text: 'ok' }] }, finishReason: 'STOP' },
+        ],
+      },
+    },
+  ],
+  expected_transport_request: {
+    json: {
+      generationConfig: {
+        thinkingConfig: { thinkingLevel: 'high', includeThoughts: true },
+      },
+    },
+  },
+});
+
 writeFixture('gemini-thinking-config-reaches-the-request', {
   kind: 'ai_chat',
   provider: 'google-gemini',

--- a/tools/axir/extractors/axai-goldens.ts
+++ b/tools/axir/extractors/axai-goldens.ts
@@ -3676,6 +3676,126 @@ writeFixture('grok-realtime-audio-session-and-events', {
   ],
 });
 
+for (const { fixtureName, model, expectedThinkingConfig } of [
+  {
+    fixtureName: 'gemini-31-live-thinking-level',
+    model: 'gemini-3.1-flash-live-preview',
+    expectedThinkingConfig: {
+      thinkingLevel: 'high',
+      includeThoughts: true,
+    },
+  },
+  {
+    fixtureName: 'gemini-25-live-thinking-budget',
+    model: 'gemini-2.5-flash-native-audio-preview-12-2025',
+    expectedThinkingConfig: {
+      thinkingBudget: 10000,
+      includeThoughts: true,
+    },
+  },
+] as const) {
+  writeFixture(fixtureName, {
+    kind: 'ai_realtime',
+    provider: 'google-gemini',
+    model,
+    request: {
+      model,
+      chat_prompt: [{ role: 'user', content: 'Answer with audio.' }],
+      model_config: {
+        thinkingTokenBudget: 'high',
+        showThoughts: true,
+      },
+      audio: { output: { voice: 'Kore', transcript: true } },
+    },
+    expected_setup: {
+      setup: {
+        model: `models/${model}`,
+        generationConfig: {
+          responseModalities: ['AUDIO'],
+          speechConfig: {
+            voiceConfig: { prebuiltVoiceConfig: { voiceName: 'Kore' } },
+          },
+          thinkingConfig: expectedThinkingConfig,
+        },
+        outputAudioTranscription: {},
+      },
+    },
+  });
+}
+
+for (const profile of ['gemini', 'google_gemini'] as const) {
+  const model = 'gemini-3.1-flash-live-preview';
+  writeFixture(
+    `gemini-live-thinking-profile-alias-${profile.replace('_', '-')}`,
+    {
+      kind: 'ai_realtime',
+      provider: profile,
+      model,
+      request: {
+        model,
+        chat_prompt: [{ role: 'user', content: 'Answer with audio.' }],
+        model_config: { thinkingTokenBudget: 'high' },
+        audio: { output: { voice: 'Kore', transcript: true } },
+      },
+      expected_setup: {
+        setup: {
+          model: `models/${model}`,
+          generationConfig: {
+            responseModalities: ['AUDIO'],
+            speechConfig: {
+              voiceConfig: { prebuiltVoiceConfig: { voiceName: 'Kore' } },
+            },
+            thinkingConfig: { thinkingLevel: 'high' },
+          },
+          outputAudioTranscription: {},
+        },
+      },
+    }
+  );
+}
+
+writeFixture('gemini-live-thinking-native-vertex-path', {
+  kind: 'ai_realtime',
+  provider: 'google-gemini',
+  model: 'gemini-3.1-flash-live-preview',
+  service_options: { projectId: 'demo-project', region: 'us-central1' },
+  request: {
+    model: 'gemini-3.1-flash-live-preview',
+    chat_prompt: [{ role: 'user', content: 'Answer with audio.' }],
+    model_config: { thinkingTokenBudget: 'high' },
+    audio: { output: { voice: 'Kore', transcript: true } },
+  },
+  expected_setup: {
+    setup: {
+      model: 'models/gemini-3.1-flash-live-preview',
+      generationConfig: {
+        responseModalities: ['AUDIO'],
+        speechConfig: {
+          voiceConfig: { prebuiltVoiceConfig: { voiceName: 'Kore' } },
+        },
+        thinkingConfig: { thinkingLevel: 'high' },
+      },
+      outputAudioTranscription: {},
+    },
+  },
+});
+
+writeFixture('gemini-3-live-numeric-thinking-budget-rejected', {
+  kind: 'ai_realtime',
+  provider: 'google-gemini',
+  model: 'gemini-3.1-flash-live-preview',
+  request: {
+    model: 'gemini-3.1-flash-live-preview',
+    chat_prompt: [{ role: 'user', content: 'Answer with audio.' }],
+    model_config: { thinkingTokenBudget: 2048 },
+    audio: { output: { voice: 'Kore' } },
+  },
+  // The realtime conformance runner invokes setup when this assertion is
+  // present; the resolver must fail before the placeholder can be compared.
+  expected_setup: {},
+  expected_error_contains: 'does not support numeric thinkingTokenBudget',
+});
+
 writeFixture('gemini-live-realtime-audio-session-and-events', {
   kind: 'ai_realtime',
   provider: 'google-gemini',
@@ -5111,7 +5231,7 @@ writeFixture('gemini-thinking-level-routes-away-from-the-budget', {
 writeFixture('gemini-thinking-config-reaches-the-request', {
   kind: 'ai_chat',
   provider: 'google-gemini',
-  model: 'gemini-3.5-flash',
+  model: 'gemini-2.5-flash',
   request: {
     chat_prompt: [{ role: 'user', content: 'think about this' }],
     model_config: {
@@ -5137,6 +5257,328 @@ writeFixture('gemini-thinking-config-reaches-the-request', {
       },
     },
   },
+});
+
+for (const {
+  fixtureName,
+  model,
+  requested,
+  expectedLevel,
+  expectedThoughts,
+} of [
+  {
+    fixtureName: 'gemini-37-minimal-clamps-to-low',
+    model: 'gemini-3.7-flash',
+    requested: 'minimal',
+    expectedLevel: 'low',
+    expectedThoughts: true,
+  },
+  {
+    fixtureName: 'gemini-37-none-clamps-to-low-and-hides-thoughts',
+    model: 'gemini-3.7-flash',
+    requested: 'none',
+    expectedLevel: 'low',
+    expectedThoughts: false,
+  },
+  {
+    fixtureName: 'gemini-31-pro-preserves-medium',
+    model: 'gemini-3.1-pro-preview',
+    requested: 'medium',
+    expectedLevel: 'medium',
+    expectedThoughts: true,
+  },
+  {
+    fixtureName: 'gemini-31-image-medium-clamps-to-high',
+    model: 'gemini-3.1-flash-image-preview',
+    requested: 'medium',
+    expectedLevel: 'high',
+    expectedThoughts: true,
+  },
+  {
+    fixtureName: 'gemini-legacy-3-pro-medium-clamps-to-high',
+    model: 'gemini-3-pro-preview',
+    requested: 'medium',
+    expectedLevel: 'high',
+    expectedThoughts: true,
+  },
+] as const) {
+  writeFixture(fixtureName, {
+    kind: 'ai_chat',
+    provider: 'google-gemini',
+    model,
+    request: {
+      chat_prompt: [{ role: 'user', content: 'think about this' }],
+      model_config: {
+        stream: false,
+        thinkingTokenBudget: requested,
+        showThoughts: true,
+      },
+    },
+    transport_responses: [
+      {
+        status: 200,
+        json: {
+          candidates: [
+            { content: { parts: [{ text: 'ok' }] }, finishReason: 'STOP' },
+          ],
+        },
+      },
+    ],
+    expected_transport_request: {
+      json: {
+        generationConfig: {
+          thinkingConfig: {
+            thinkingLevel: expectedLevel,
+            includeThoughts: expectedThoughts,
+          },
+        },
+      },
+    },
+    expected_transport_json_absent: [
+      'generationConfig.thinkingConfig.thinkingBudget',
+    ],
+  });
+}
+
+for (const {
+  fixtureName,
+  model,
+  requested,
+  expectedBudget,
+  expectedThoughts,
+} of [
+  {
+    fixtureName: 'gemini-25-flash-high-uses-numeric-budget',
+    model: 'gemini-2.5-flash',
+    requested: 'high',
+    expectedBudget: 10000,
+    expectedThoughts: true,
+  },
+  {
+    fixtureName: 'gemini-25-flash-none-disables-thinking',
+    model: 'gemini-2.5-flash',
+    requested: 'none',
+    expectedBudget: 0,
+    expectedThoughts: false,
+  },
+  {
+    fixtureName: 'gemini-25-pro-none-clamps-to-minimum-budget',
+    model: 'gemini-2.5-pro',
+    requested: 'none',
+    expectedBudget: 200,
+    expectedThoughts: false,
+  },
+] as const) {
+  writeFixture(fixtureName, {
+    kind: 'ai_chat',
+    provider: 'google-gemini',
+    model,
+    request: {
+      chat_prompt: [{ role: 'user', content: 'think about this' }],
+      model_config: {
+        stream: false,
+        thinkingTokenBudget: requested,
+        showThoughts: true,
+      },
+    },
+    transport_responses: [
+      {
+        status: 200,
+        json: {
+          candidates: [
+            { content: { parts: [{ text: 'ok' }] }, finishReason: 'STOP' },
+          ],
+        },
+      },
+    ],
+    expected_transport_request: {
+      json: {
+        generationConfig: {
+          thinkingConfig: {
+            thinkingBudget: expectedBudget,
+            includeThoughts: expectedThoughts,
+          },
+        },
+      },
+    },
+    expected_transport_json_absent: [
+      'generationConfig.thinkingConfig.thinkingLevel',
+    ],
+  });
+}
+
+writeFixture('gemini-37-custom-level-mapping-is-clamped', {
+  kind: 'ai_chat',
+  provider: 'google-gemini',
+  model: 'gemini-3.7-flash',
+  request: {
+    chat_prompt: [{ role: 'user', content: 'think about this' }],
+    model_config: {
+      stream: false,
+      thinkingTokenBudget: 'high',
+      thinkingLevelMapping: { high: 'minimal' },
+    },
+  },
+  transport_responses: [
+    {
+      status: 200,
+      json: {
+        candidates: [
+          { content: { parts: [{ text: 'ok' }] }, finishReason: 'STOP' },
+        ],
+      },
+    },
+  ],
+  expected_transport_request: {
+    json: {
+      generationConfig: { thinkingConfig: { thinkingLevel: 'low' } },
+    },
+  },
+  expected_transport_json_absent: [
+    'generationConfig.thinkingConfig.thinkingBudget',
+  ],
+});
+
+writeFixture('gemini-25-custom-budget-rung-is-preserved', {
+  kind: 'ai_chat',
+  provider: 'google-gemini',
+  model: 'gemini-2.5-flash',
+  request: {
+    chat_prompt: [{ role: 'user', content: 'think about this' }],
+    model_config: {
+      stream: false,
+      thinkingTokenBudget: 'high',
+      thinkingTokenBudgetLevels: { high: 12345 },
+    },
+  },
+  transport_responses: [
+    {
+      status: 200,
+      json: {
+        candidates: [
+          { content: { parts: [{ text: 'ok' }] }, finishReason: 'STOP' },
+        ],
+      },
+    },
+  ],
+  expected_transport_request: {
+    json: {
+      generationConfig: { thinkingConfig: { thinkingBudget: 12345 } },
+    },
+  },
+  expected_transport_json_absent: [
+    'generationConfig.thinkingConfig.thinkingLevel',
+  ],
+});
+
+for (const { fixtureName, value, expectedError } of [
+  {
+    fixtureName: 'gemini-3-numeric-thinking-budget-rejected',
+    value: 2048,
+    expectedError: 'does not support numeric thinkingTokenBudget',
+  },
+  {
+    fixtureName: 'gemini-3-unknown-thinking-level-rejected',
+    value: 'extreme',
+    expectedError: 'unsupported Gemini thinkingTokenBudget level',
+  },
+] as const) {
+  writeFixture(fixtureName, {
+    kind: 'ai_chat',
+    provider: 'google-gemini',
+    model: 'gemini-3.5-flash',
+    request: {
+      chat_prompt: [{ role: 'user', content: 'think about this' }],
+      model_config: { stream: false, thinkingTokenBudget: value },
+    },
+    expected_error_contains: expectedError,
+  });
+}
+
+for (const profile of ['gemini', 'google_gemini'] as const) {
+  writeFixture(`gemini-thinking-profile-alias-${profile.replace('_', '-')}`, {
+    kind: 'ai_chat',
+    provider: profile,
+    model: 'gemini-3.5-flash',
+    request: {
+      chat_prompt: [{ role: 'user', content: 'think hard' }],
+      model_config: { stream: false, thinkingTokenBudget: 'high' },
+    },
+    transport_responses: [
+      {
+        status: 200,
+        json: {
+          candidates: [
+            { content: { parts: [{ text: 'ok' }] }, finishReason: 'STOP' },
+          ],
+        },
+      },
+    ],
+    expected_transport_request: {
+      json: {
+        generationConfig: { thinkingConfig: { thinkingLevel: 'high' } },
+      },
+    },
+  });
+}
+
+writeFixture('gemini-thinking-native-vertex-path', {
+  kind: 'ai_chat',
+  provider: 'google-gemini',
+  model: 'gemini-3.5-flash',
+  service_options: { projectId: 'demo-project', region: 'us-central1' },
+  request: {
+    chat_prompt: [{ role: 'user', content: 'think hard' }],
+    model_config: { stream: false, thinkingTokenBudget: 'high' },
+  },
+  transport_responses: [
+    {
+      status: 200,
+      json: {
+        candidates: [
+          { content: { parts: [{ text: 'ok' }] }, finishReason: 'STOP' },
+        ],
+      },
+    },
+  ],
+  expected_transport_request: {
+    json: {
+      generationConfig: { thinkingConfig: { thinkingLevel: 'high' } },
+    },
+  },
+});
+
+writeFixture('vertex-openai-gemini-model-does-not-inherit-native-thinking', {
+  kind: 'ai_chat',
+  provider: 'vertex-ai',
+  model: 'gemini-3.5-flash',
+  base_url: 'https://vertex.example.test/v1',
+  request: {
+    chat_prompt: [{ role: 'user', content: 'think hard' }],
+    model_config: { stream: false, thinkingTokenBudget: 'high' },
+  },
+  transport_responses: [
+    {
+      status: 200,
+      json: {
+        choices: [
+          {
+            index: 0,
+            message: { role: 'assistant', content: 'ok' },
+            finish_reason: 'stop',
+          },
+        ],
+      },
+    },
+  ],
+  expected_transport_json_absent: [
+    'generationConfig',
+    'thinkingConfig',
+    'thinkingLevel',
+    'thinking_level',
+    'thinkingBudget',
+    'thinking_budget',
+  ],
 });
 
 writeFixture('context-cache-rejection', {

--- a/website/content-src/templates/subsystem-ai.md
+++ b/website/content-src/templates/subsystem-ai.md
@@ -94,6 +94,20 @@ breakpoints. Give AxGen a stable `promptCacheKey` plus `contextCache`; those
 forward options reach the provider in every language. Cache reads and writes
 are normalized separately for usage and catalog-backed cost estimates.
 
+### Gemini thinking levels
+
+Ax resolves the effective Gemini model before translating a logical thinking
+level. Gemini 3 requests send `thinkingLevel`, clamped to the levels supported
+by the selected model family; Gemini 2.5 and older requests send a numeric
+`thinkingBudget`. Numeric budgets fail locally for Gemini 3, and logical `none`
+always hides returned thoughts even when the model must retain its minimum
+thinking level.
+
+The native `google-gemini`, `gemini`, and `google_gemini` deployment profile
+names share this behavior, including native Gemini configured for Vertex with a
+project and region. The separate OpenAI-compatible `vertex-ai` profile remains
+profile-owned and does not gain native Gemini request fields from its model ID.
+
 ### Gemini inference service tiers
 
 Gemini GenerateContent supports `standard`, `flex`, and `priority` service

--- a/website/static/cpp/.well-known/agent-skills/ax-cpp-agent-context/SKILL.md
+++ b/website/static/cpp/.well-known/agent-skills/ax-cpp-agent-context/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-cpp-agent-context"
 description: "Use when writing C++ code with `axllm` for deciding between context maps, trajectory context policy, offline optimization (ACE/GEPA), and memory recall for long-context agents."
-version: "24.0.10"
+version: "24.0.12"
 ---
 # AxAgent Context Selection For C++
 

--- a/website/static/cpp/.well-known/agent-skills/ax-cpp-agent-memory-skills/SKILL.md
+++ b/website/static/cpp/.well-known/agent-skills/ax-cpp-agent-memory-skills/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-cpp-agent-memory-skills"
 description: "Use when writing C++ code with `axllm` for agent memory, recall callbacks, dynamic skill discovery, loaded-skill state, and used-skill tracking."
-version: "24.0.10"
+version: "24.0.12"
 ---
 # AxAgent Memory And Skills For C++
 

--- a/website/static/cpp/.well-known/agent-skills/ax-cpp-agent-observability/SKILL.md
+++ b/website/static/cpp/.well-known/agent-skills/ax-cpp-agent-observability/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-cpp-agent-observability"
 description: "Use when writing C++ code with `axllm` for agent tracing, centralized and multi-tenant usage accounting, action logs, runtime diagnostics, replay, and production debugging."
-version: "24.0.10"
+version: "24.0.12"
 ---
 # AxAgent Observability For C++
 

--- a/website/static/cpp/.well-known/agent-skills/ax-cpp-agent-optimize/SKILL.md
+++ b/website/static/cpp/.well-known/agent-skills/ax-cpp-agent-optimize/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-cpp-agent-optimize"
 description: "Use when writing C++ code with `axllm` for agent optimization, verified agent-playbook evolution, evaluators, judges, optimizer artifacts, BootstrapFewShot, and GEPA."
-version: "24.0.10"
+version: "24.0.12"
 ---
 # AxAgent Optimize For C++
 

--- a/website/static/cpp/.well-known/agent-skills/ax-cpp-agent-rlm/SKILL.md
+++ b/website/static/cpp/.well-known/agent-skills/ax-cpp-agent-rlm/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-cpp-agent-rlm"
 description: "Use when writing C++ code with `axllm` for RLM executor loops, AxCodeRuntime sessions, runtime envelopes, process runtimes, and optional runtime profiles."
-version: "24.0.10"
+version: "24.0.12"
 ---
 # AxAgent RLM Runtime For C++
 

--- a/website/static/cpp/.well-known/agent-skills/ax-cpp-agent/SKILL.md
+++ b/website/static/cpp/.well-known/agent-skills/ax-cpp-agent/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-cpp-agent"
 description: "Use when writing C++ code with `axllm` for agents, child delegation, tools, MCP, citations, persistent playbook learning, stage instructions, runtime state, final typed responses, and direct-respond executor skipping."
-version: "24.0.10"
+version: "24.0.12"
 ---
 # AxAgent For C++
 

--- a/website/static/cpp/.well-known/agent-skills/ax-cpp-ai/SKILL.md
+++ b/website/static/cpp/.well-known/agent-skills/ax-cpp-ai/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-cpp-ai"
 description: "Use when writing C++ code with `axllm` for named deployment profiles, generic provider clients, model selection, OpenAI-compatible calls, Responses, Gemini, Anthropic, routers, and balancers."
-version: "24.0.10"
+version: "24.0.12"
 ---
 # AxAI Providers For C++
 

--- a/website/static/cpp/.well-known/agent-skills/ax-cpp-audio/SKILL.md
+++ b/website/static/cpp/.well-known/agent-skills/ax-cpp-audio/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-cpp-audio"
 description: "Use when writing C++ code with `axllm` for audio input/output, OpenAI Responses audio mapping, realtime event folding, and generated package audio examples."
-version: "24.0.10"
+version: "24.0.12"
 ---
 # Ax Audio And Realtime For C++
 

--- a/website/static/cpp/.well-known/agent-skills/ax-cpp-flow/SKILL.md
+++ b/website/static/cpp/.well-known/agent-skills/ax-cpp-flow/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-cpp-flow"
 description: "Use when writing C++ code with `axllm` for flows, nodes, program graphs, nested programs, dynamic options, caching, and optimizer components."
-version: "24.0.10"
+version: "24.0.12"
 ---
 # AxFlow For C++
 

--- a/website/static/cpp/.well-known/agent-skills/ax-cpp-gen/SKILL.md
+++ b/website/static/cpp/.well-known/agent-skills/ax-cpp-gen/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-cpp-gen"
 description: "Use when writing C++ code with `axllm` for AxGen programs, forward calls, indexed multi-sampling, result pickers, streaming, tools, assertions, traces, usage, and output parsing."
-version: "24.0.10"
+version: "24.0.12"
 ---
 # AxGen Structured Generation For C++
 

--- a/website/static/cpp/.well-known/agent-skills/ax-cpp-gepa/SKILL.md
+++ b/website/static/cpp/.well-known/agent-skills/ax-cpp-gepa/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-cpp-gepa"
 description: "Use when writing C++ code with `axllm` for GEPA, Pareto tradeoffs, reflection clients, metric budgets, optimizer state, and artifacts."
-version: "24.0.10"
+version: "24.0.12"
 ---
 # Ax GEPA For C++
 

--- a/website/static/cpp/.well-known/agent-skills/ax-cpp-llm/SKILL.md
+++ b/website/static/cpp/.well-known/agent-skills/ax-cpp-llm/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-cpp-llm"
 description: "Use when writing C++ code with `axllm` for using the generated Ax package, factory functions, package docs, examples, and API reference."
-version: "24.0.10"
+version: "24.0.12"
 ---
 # Ax LLM Quick Reference For C++
 

--- a/website/static/cpp/.well-known/agent-skills/ax-cpp-playbook/SKILL.md
+++ b/website/static/cpp/.well-known/agent-skills/ax-cpp-playbook/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-cpp-playbook"
 description: "Use when writing C++ code with `axllm` for the playbook() context-engineering surface, agent-bound verified evolution, run-end learning, online updates, and rendering a playbook into a program."
-version: "24.0.10"
+version: "24.0.12"
 ---
 # Ax Playbook For C++
 

--- a/website/static/cpp/.well-known/agent-skills/ax-cpp-refine/SKILL.md
+++ b/website/static/cpp/.well-known/agent-skills/ax-cpp-refine/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-cpp-refine"
 description: "Use when writing C++ code with `axllm` for reward-scored generation, iterative candidate improvement, evaluator feedback, and optimizer-backed refinement patterns."
-version: "24.0.10"
+version: "24.0.12"
 ---
 # Ax Refinement Patterns For C++
 

--- a/website/static/cpp/.well-known/agent-skills/ax-cpp-signature/SKILL.md
+++ b/website/static/cpp/.well-known/agent-skills/ax-cpp-signature/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-cpp-signature"
 description: "Use when writing C++ code with `axllm` for string signatures, field descriptors, JSON schema output, validation, and typed tool argument shapes."
-version: "24.0.10"
+version: "24.0.12"
 ---
 # Ax Signatures For C++
 

--- a/website/static/cpp/.well-known/agent-skills/index.json
+++ b/website/static/cpp/.well-known/agent-skills/index.json
@@ -6,105 +6,105 @@
       "type": "skill-md",
       "description": "Use when writing C++ code with `axllm` for using the generated Ax package, factory functions, package docs, examples, and API reference.",
       "url": "ax-cpp-llm/SKILL.md",
-      "digest": "sha256:0eada90eafc9f944deda1b7721d57ec6299e9ca08b58805527d2f59977ce77e3"
+      "digest": "sha256:06e775239c8fbddc0be6091f2cb1138e0033954743bd970957115d0f11529b37"
     },
     {
       "name": "ax-cpp-ai",
       "type": "skill-md",
       "description": "Use when writing C++ code with `axllm` for named deployment profiles, generic provider clients, model selection, OpenAI-compatible calls, Responses, Gemini, Anthropic, routers, and balancers.",
       "url": "ax-cpp-ai/SKILL.md",
-      "digest": "sha256:8ac3341d46f0ce1047fb841d9e0dfd069da1db2c7cd0a47d9e9ad8b13a3f99d7"
+      "digest": "sha256:0e855a267cee720a0ee32d82cf515a4427e0c7d4aa804be0c509ccbe936ece76"
     },
     {
       "name": "ax-cpp-audio",
       "type": "skill-md",
       "description": "Use when writing C++ code with `axllm` for audio input/output, OpenAI Responses audio mapping, realtime event folding, and generated package audio examples.",
       "url": "ax-cpp-audio/SKILL.md",
-      "digest": "sha256:49f5979d673d16ec6de922488269091bf14a51053e2c249b5cc76e55acf651b5"
+      "digest": "sha256:6d7edca87fbbe8995224ceecf693089c51bbd5e70d38a4fa8c045394dc7889e7"
     },
     {
       "name": "ax-cpp-signature",
       "type": "skill-md",
       "description": "Use when writing C++ code with `axllm` for string signatures, field descriptors, JSON schema output, validation, and typed tool argument shapes.",
       "url": "ax-cpp-signature/SKILL.md",
-      "digest": "sha256:280327426fa276d4792e9e1bab4c9a43483b0db033d7b8fe04169c33f185f12e"
+      "digest": "sha256:75552f763cc188244f113cde43375e303da41a30b8770b36a8527a7aa38e259a"
     },
     {
       "name": "ax-cpp-gen",
       "type": "skill-md",
       "description": "Use when writing C++ code with `axllm` for AxGen programs, forward calls, indexed multi-sampling, result pickers, streaming, tools, assertions, traces, usage, and output parsing.",
       "url": "ax-cpp-gen/SKILL.md",
-      "digest": "sha256:62dbf5f38455d920d0eac435dac0184a2c1a52128a15a6daa35830ad5d01bdaf"
+      "digest": "sha256:74b3cd53720dc79876dff85822a401d606b0c61e119ff6212e9631f3cf75d6ee"
     },
     {
       "name": "ax-cpp-flow",
       "type": "skill-md",
       "description": "Use when writing C++ code with `axllm` for flows, nodes, program graphs, nested programs, dynamic options, caching, and optimizer components.",
       "url": "ax-cpp-flow/SKILL.md",
-      "digest": "sha256:6f3eb03161e52064cac240ae0709418921f343d02143c02e241fb22bb9e380a5"
+      "digest": "sha256:79255a72f7443a9aaa7f2577a0f9e32296910172e46ad010ce6b74207f8c2350"
     },
     {
       "name": "ax-cpp-agent",
       "type": "skill-md",
       "description": "Use when writing C++ code with `axllm` for agents, child delegation, tools, MCP, citations, persistent playbook learning, stage instructions, runtime state, final typed responses, and direct-respond executor skipping.",
       "url": "ax-cpp-agent/SKILL.md",
-      "digest": "sha256:bbff7ca77fa9c08ea78a9c21dcaecfbd1f81474e1b02856a5b228d12ce7af8e3"
+      "digest": "sha256:5c6d0b3d334d7d432d9826732d41aec297613adf7e76768b8f0e793d1cf661cd"
     },
     {
       "name": "ax-cpp-agent-rlm",
       "type": "skill-md",
       "description": "Use when writing C++ code with `axllm` for RLM executor loops, AxCodeRuntime sessions, runtime envelopes, process runtimes, and optional runtime profiles.",
       "url": "ax-cpp-agent-rlm/SKILL.md",
-      "digest": "sha256:eadc133a8e7b9ba5992e0255b793a1f2775d79c5dbbfae3038f9060c5e9a8803"
+      "digest": "sha256:9bea02258b31547142d97dcca081b048b1a39df78cff37952eeed92a39fac12d"
     },
     {
       "name": "ax-cpp-agent-memory-skills",
       "type": "skill-md",
       "description": "Use when writing C++ code with `axllm` for agent memory, recall callbacks, dynamic skill discovery, loaded-skill state, and used-skill tracking.",
       "url": "ax-cpp-agent-memory-skills/SKILL.md",
-      "digest": "sha256:ba44f7d53444ce9798e7ec567c9bb601cdb58da8b3f94c9b5b93a89d7ff54e22"
+      "digest": "sha256:483c5ad41361072d6ac076f7b4b1b889c1011d4b6ad4359e92256b2f7ab6258b"
     },
     {
       "name": "ax-cpp-agent-observability",
       "type": "skill-md",
       "description": "Use when writing C++ code with `axllm` for agent tracing, centralized and multi-tenant usage accounting, action logs, runtime diagnostics, replay, and production debugging.",
       "url": "ax-cpp-agent-observability/SKILL.md",
-      "digest": "sha256:a4ccbc51c532e1a137d7dbe08f25a8b1c188fec7b74291513080a54b17ecda75"
+      "digest": "sha256:9ff23107b9c3e4393f18c1d4b7cb9bcce0f5b633b5348f84068705c8639fd800"
     },
     {
       "name": "ax-cpp-agent-optimize",
       "type": "skill-md",
       "description": "Use when writing C++ code with `axllm` for agent optimization, verified agent-playbook evolution, evaluators, judges, optimizer artifacts, BootstrapFewShot, and GEPA.",
       "url": "ax-cpp-agent-optimize/SKILL.md",
-      "digest": "sha256:278db99e9c6a3765bf16b9e71398920414868f132336239e63e90c1346cc0f28"
+      "digest": "sha256:55dfa4a1a5167a67a9c646e86292b0f8de539607f7742df77426bf98deb7202c"
     },
     {
       "name": "ax-cpp-agent-context",
       "type": "skill-md",
       "description": "Use when writing C++ code with `axllm` for deciding between context maps, trajectory context policy, offline optimization (ACE/GEPA), and memory recall for long-context agents.",
       "url": "ax-cpp-agent-context/SKILL.md",
-      "digest": "sha256:fca2fb9a6927163e9e45f2a4332ea108abec16d57ee8fe9b6923c33d7b83bfb4"
+      "digest": "sha256:9346fc4fac71701f81a0b10deb8b6655bf96ccf7331849d4baa7517b240af048"
     },
     {
       "name": "ax-cpp-gepa",
       "type": "skill-md",
       "description": "Use when writing C++ code with `axllm` for GEPA, Pareto tradeoffs, reflection clients, metric budgets, optimizer state, and artifacts.",
       "url": "ax-cpp-gepa/SKILL.md",
-      "digest": "sha256:ef61d406d31d7e64cde2189b15ef2c607a9f46409e6ecfcaffbaeb2d78673002"
+      "digest": "sha256:3e41b1c2a3d2354ebfd8d12836da151f9328ac3caede1d0304a909a163197af6"
     },
     {
       "name": "ax-cpp-refine",
       "type": "skill-md",
       "description": "Use when writing C++ code with `axllm` for reward-scored generation, iterative candidate improvement, evaluator feedback, and optimizer-backed refinement patterns.",
       "url": "ax-cpp-refine/SKILL.md",
-      "digest": "sha256:fb98d7be0c4b63f0b937937d3f067911c3463c26d328f339fb5c881604900a8f"
+      "digest": "sha256:e037d128ceae18be8be24d42c375549ae50068b638490016b97f23d961173ae7"
     },
     {
       "name": "ax-cpp-playbook",
       "type": "skill-md",
       "description": "Use when writing C++ code with `axllm` for the playbook() context-engineering surface, agent-bound verified evolution, run-end learning, online updates, and rendering a playbook into a program.",
       "url": "ax-cpp-playbook/SKILL.md",
-      "digest": "sha256:db5344c1c8c769c29bb6387a0e5e8feacc2cd11aeaf832234cd3865236e2139b"
+      "digest": "sha256:440620511da180c00c43a6af15fc5c2b258d9bd785b329bc9c7671a57aed30ef"
     }
   ]
 }

--- a/website/static/go/.well-known/agent-skills/ax-go-agent-context/SKILL.md
+++ b/website/static/go/.well-known/agent-skills/ax-go-agent-context/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-go-agent-context"
 description: "Use when writing Go code with `github.com/ax-llm/ax/packages/go` for deciding between context maps, trajectory context policy, offline optimization (ACE/GEPA), and memory recall for long-context agents."
-version: "24.0.10"
+version: "24.0.12"
 ---
 # AxAgent Context Selection For Go
 

--- a/website/static/go/.well-known/agent-skills/ax-go-agent-memory-skills/SKILL.md
+++ b/website/static/go/.well-known/agent-skills/ax-go-agent-memory-skills/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-go-agent-memory-skills"
 description: "Use when writing Go code with `github.com/ax-llm/ax/packages/go` for agent memory, recall callbacks, dynamic skill discovery, loaded-skill state, and used-skill tracking."
-version: "24.0.10"
+version: "24.0.12"
 ---
 # AxAgent Memory And Skills For Go
 

--- a/website/static/go/.well-known/agent-skills/ax-go-agent-observability/SKILL.md
+++ b/website/static/go/.well-known/agent-skills/ax-go-agent-observability/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-go-agent-observability"
 description: "Use when writing Go code with `github.com/ax-llm/ax/packages/go` for agent tracing, centralized and multi-tenant usage accounting, action logs, runtime diagnostics, replay, and production debugging."
-version: "24.0.10"
+version: "24.0.12"
 ---
 # AxAgent Observability For Go
 

--- a/website/static/go/.well-known/agent-skills/ax-go-agent-optimize/SKILL.md
+++ b/website/static/go/.well-known/agent-skills/ax-go-agent-optimize/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-go-agent-optimize"
 description: "Use when writing Go code with `github.com/ax-llm/ax/packages/go` for agent optimization, verified agent-playbook evolution, evaluators, judges, optimizer artifacts, BootstrapFewShot, and GEPA."
-version: "24.0.10"
+version: "24.0.12"
 ---
 # AxAgent Optimize For Go
 

--- a/website/static/go/.well-known/agent-skills/ax-go-agent-rlm/SKILL.md
+++ b/website/static/go/.well-known/agent-skills/ax-go-agent-rlm/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-go-agent-rlm"
 description: "Use when writing Go code with `github.com/ax-llm/ax/packages/go` for RLM executor loops, AxCodeRuntime sessions, runtime envelopes, process runtimes, and optional runtime profiles."
-version: "24.0.10"
+version: "24.0.12"
 ---
 # AxAgent RLM Runtime For Go
 

--- a/website/static/go/.well-known/agent-skills/ax-go-agent/SKILL.md
+++ b/website/static/go/.well-known/agent-skills/ax-go-agent/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-go-agent"
 description: "Use when writing Go code with `github.com/ax-llm/ax/packages/go` for agents, child delegation, tools, MCP, citations, persistent playbook learning, stage instructions, runtime state, final typed responses, and direct-respond executor skipping."
-version: "24.0.10"
+version: "24.0.12"
 ---
 # AxAgent For Go
 

--- a/website/static/go/.well-known/agent-skills/ax-go-ai/SKILL.md
+++ b/website/static/go/.well-known/agent-skills/ax-go-ai/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-go-ai"
 description: "Use when writing Go code with `github.com/ax-llm/ax/packages/go` for named deployment profiles, generic provider clients, model selection, OpenAI-compatible calls, Responses, Gemini, Anthropic, routers, and balancers."
-version: "24.0.10"
+version: "24.0.12"
 ---
 # AxAI Providers For Go
 

--- a/website/static/go/.well-known/agent-skills/ax-go-audio/SKILL.md
+++ b/website/static/go/.well-known/agent-skills/ax-go-audio/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-go-audio"
 description: "Use when writing Go code with `github.com/ax-llm/ax/packages/go` for audio input/output, OpenAI Responses audio mapping, realtime event folding, and generated package audio examples."
-version: "24.0.10"
+version: "24.0.12"
 ---
 # Ax Audio And Realtime For Go
 

--- a/website/static/go/.well-known/agent-skills/ax-go-flow/SKILL.md
+++ b/website/static/go/.well-known/agent-skills/ax-go-flow/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-go-flow"
 description: "Use when writing Go code with `github.com/ax-llm/ax/packages/go` for flows, nodes, program graphs, nested programs, dynamic options, caching, and optimizer components."
-version: "24.0.10"
+version: "24.0.12"
 ---
 # AxFlow For Go
 

--- a/website/static/go/.well-known/agent-skills/ax-go-gen/SKILL.md
+++ b/website/static/go/.well-known/agent-skills/ax-go-gen/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-go-gen"
 description: "Use when writing Go code with `github.com/ax-llm/ax/packages/go` for AxGen programs, forward calls, indexed multi-sampling, result pickers, streaming, tools, assertions, traces, usage, and output parsing."
-version: "24.0.10"
+version: "24.0.12"
 ---
 # AxGen Structured Generation For Go
 

--- a/website/static/go/.well-known/agent-skills/ax-go-gepa/SKILL.md
+++ b/website/static/go/.well-known/agent-skills/ax-go-gepa/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-go-gepa"
 description: "Use when writing Go code with `github.com/ax-llm/ax/packages/go` for GEPA, Pareto tradeoffs, reflection clients, metric budgets, optimizer state, and artifacts."
-version: "24.0.10"
+version: "24.0.12"
 ---
 # Ax GEPA For Go
 

--- a/website/static/go/.well-known/agent-skills/ax-go-llm/SKILL.md
+++ b/website/static/go/.well-known/agent-skills/ax-go-llm/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-go-llm"
 description: "Use when writing Go code with `github.com/ax-llm/ax/packages/go` for using the generated Ax package, factory functions, package docs, examples, and API reference."
-version: "24.0.10"
+version: "24.0.12"
 ---
 # Ax LLM Quick Reference For Go
 

--- a/website/static/go/.well-known/agent-skills/ax-go-playbook/SKILL.md
+++ b/website/static/go/.well-known/agent-skills/ax-go-playbook/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-go-playbook"
 description: "Use when writing Go code with `github.com/ax-llm/ax/packages/go` for the playbook() context-engineering surface, agent-bound verified evolution, run-end learning, online updates, and rendering a playbook into a program."
-version: "24.0.10"
+version: "24.0.12"
 ---
 # Ax Playbook For Go
 

--- a/website/static/go/.well-known/agent-skills/ax-go-refine/SKILL.md
+++ b/website/static/go/.well-known/agent-skills/ax-go-refine/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-go-refine"
 description: "Use when writing Go code with `github.com/ax-llm/ax/packages/go` for reward-scored generation, iterative candidate improvement, evaluator feedback, and optimizer-backed refinement patterns."
-version: "24.0.10"
+version: "24.0.12"
 ---
 # Ax Refinement Patterns For Go
 

--- a/website/static/go/.well-known/agent-skills/ax-go-signature/SKILL.md
+++ b/website/static/go/.well-known/agent-skills/ax-go-signature/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-go-signature"
 description: "Use when writing Go code with `github.com/ax-llm/ax/packages/go` for string signatures, field descriptors, JSON schema output, validation, and typed tool argument shapes."
-version: "24.0.10"
+version: "24.0.12"
 ---
 # Ax Signatures For Go
 

--- a/website/static/go/.well-known/agent-skills/index.json
+++ b/website/static/go/.well-known/agent-skills/index.json
@@ -6,105 +6,105 @@
       "type": "skill-md",
       "description": "Use when writing Go code with `github.com/ax-llm/ax/packages/go` for using the generated Ax package, factory functions, package docs, examples, and API reference.",
       "url": "ax-go-llm/SKILL.md",
-      "digest": "sha256:6d719b8e2c95e20ad2c3e5da49e0ae55f02054400709fa527e5a7ba4a0cfe9a9"
+      "digest": "sha256:39792be3b7763a6c086ec90a3d09b7340420222dfa55d3cbb08657fc488bb48e"
     },
     {
       "name": "ax-go-ai",
       "type": "skill-md",
       "description": "Use when writing Go code with `github.com/ax-llm/ax/packages/go` for named deployment profiles, generic provider clients, model selection, OpenAI-compatible calls, Responses, Gemini, Anthropic, routers, and balancers.",
       "url": "ax-go-ai/SKILL.md",
-      "digest": "sha256:134cdc0c7e837afb9618431239f24f753f3fb50ec1cd4d5c0e7ba8556fa8cf32"
+      "digest": "sha256:0b082e501b11dde600370b9abab249836f321e4dd6af74745adfafd0cbc0b97d"
     },
     {
       "name": "ax-go-audio",
       "type": "skill-md",
       "description": "Use when writing Go code with `github.com/ax-llm/ax/packages/go` for audio input/output, OpenAI Responses audio mapping, realtime event folding, and generated package audio examples.",
       "url": "ax-go-audio/SKILL.md",
-      "digest": "sha256:23ae442416aeff7125b2074903cd202dc7c529a5d6d33e241a98c8145effc6eb"
+      "digest": "sha256:9fb27a545802e23eb0f775f5f994646d46761af2d811c411816ab07dc3a5958e"
     },
     {
       "name": "ax-go-signature",
       "type": "skill-md",
       "description": "Use when writing Go code with `github.com/ax-llm/ax/packages/go` for string signatures, field descriptors, JSON schema output, validation, and typed tool argument shapes.",
       "url": "ax-go-signature/SKILL.md",
-      "digest": "sha256:4d63814d5f8392d5a276c30bce9588efca8d319f78db48a29ae3cc58b2b4767c"
+      "digest": "sha256:d8808f13922960a3641ba520e684767ca6ea1401abc37e656ff0a9016e718dd5"
     },
     {
       "name": "ax-go-gen",
       "type": "skill-md",
       "description": "Use when writing Go code with `github.com/ax-llm/ax/packages/go` for AxGen programs, forward calls, indexed multi-sampling, result pickers, streaming, tools, assertions, traces, usage, and output parsing.",
       "url": "ax-go-gen/SKILL.md",
-      "digest": "sha256:be6bb74525005f4c2ce2f214b1f8fbadf673400f6bdef0b00295a703cef2219c"
+      "digest": "sha256:23774a60f86939035880e599943065e05ea56adb6db99a0a7b6fdaccfa0b6b18"
     },
     {
       "name": "ax-go-flow",
       "type": "skill-md",
       "description": "Use when writing Go code with `github.com/ax-llm/ax/packages/go` for flows, nodes, program graphs, nested programs, dynamic options, caching, and optimizer components.",
       "url": "ax-go-flow/SKILL.md",
-      "digest": "sha256:3cccf45d7065adbade475970f01f2ae25d1897d24e9ec5f637317e6bf4ccebf0"
+      "digest": "sha256:3eb612cdcbee51a1911da36755a6225ecf50395a34b7a5a29a41cc561d326c1b"
     },
     {
       "name": "ax-go-agent",
       "type": "skill-md",
       "description": "Use when writing Go code with `github.com/ax-llm/ax/packages/go` for agents, child delegation, tools, MCP, citations, persistent playbook learning, stage instructions, runtime state, final typed responses, and direct-respond executor skipping.",
       "url": "ax-go-agent/SKILL.md",
-      "digest": "sha256:4de536b4ab8a05f825f884ff28d53c59e28f80f2edd1f026d71babc49ecfd489"
+      "digest": "sha256:56a2907ee74819cf23993494198c67e312f6ca216f84219ca2239f59ea32cfaa"
     },
     {
       "name": "ax-go-agent-rlm",
       "type": "skill-md",
       "description": "Use when writing Go code with `github.com/ax-llm/ax/packages/go` for RLM executor loops, AxCodeRuntime sessions, runtime envelopes, process runtimes, and optional runtime profiles.",
       "url": "ax-go-agent-rlm/SKILL.md",
-      "digest": "sha256:f9c5a9768afddf338a7d3762a6b2f607e01fa0bdee06c463e118a091a68ad66e"
+      "digest": "sha256:23b9edc58bd0aa770c58344f60c101e67950a7a1e2c741a8b9e328fb3474b3ac"
     },
     {
       "name": "ax-go-agent-memory-skills",
       "type": "skill-md",
       "description": "Use when writing Go code with `github.com/ax-llm/ax/packages/go` for agent memory, recall callbacks, dynamic skill discovery, loaded-skill state, and used-skill tracking.",
       "url": "ax-go-agent-memory-skills/SKILL.md",
-      "digest": "sha256:5aa859880f6652788760871532ca588c6d5d819737b4c891241ff36f2cb133d3"
+      "digest": "sha256:bac5d14462cef55399f2d6475cd0bcb0565d55e877cbaf7dce614965c70b944f"
     },
     {
       "name": "ax-go-agent-observability",
       "type": "skill-md",
       "description": "Use when writing Go code with `github.com/ax-llm/ax/packages/go` for agent tracing, centralized and multi-tenant usage accounting, action logs, runtime diagnostics, replay, and production debugging.",
       "url": "ax-go-agent-observability/SKILL.md",
-      "digest": "sha256:3805edc7697b0df2cc0ab8c7a536468c0625c3db24adc75a42dc7a32069619dd"
+      "digest": "sha256:6a9e232c03c924f7cfda0e7140eb1d9f4f4a04ac62b0a0625afcb92e44e4a13b"
     },
     {
       "name": "ax-go-agent-optimize",
       "type": "skill-md",
       "description": "Use when writing Go code with `github.com/ax-llm/ax/packages/go` for agent optimization, verified agent-playbook evolution, evaluators, judges, optimizer artifacts, BootstrapFewShot, and GEPA.",
       "url": "ax-go-agent-optimize/SKILL.md",
-      "digest": "sha256:71222b84bffa138474ee89a1c9562593be24d63498cccd2c3b5509d18fc306a3"
+      "digest": "sha256:27186f2e562523a4a3a6e8be3670c2706f94496980e2d23df9f287c7f9c1c4e4"
     },
     {
       "name": "ax-go-agent-context",
       "type": "skill-md",
       "description": "Use when writing Go code with `github.com/ax-llm/ax/packages/go` for deciding between context maps, trajectory context policy, offline optimization (ACE/GEPA), and memory recall for long-context agents.",
       "url": "ax-go-agent-context/SKILL.md",
-      "digest": "sha256:e44953e96f85607d199d75400c62cb0a587bfddbba65f15227b96289390f21bd"
+      "digest": "sha256:b7f51ebfea3c4499173899ede7bf48276d84a4353f12cc532b85af1e4ecc7312"
     },
     {
       "name": "ax-go-gepa",
       "type": "skill-md",
       "description": "Use when writing Go code with `github.com/ax-llm/ax/packages/go` for GEPA, Pareto tradeoffs, reflection clients, metric budgets, optimizer state, and artifacts.",
       "url": "ax-go-gepa/SKILL.md",
-      "digest": "sha256:0d45ed61ba16d6d041e9ce40abf3cbd7de9bd1fb6f923dfbd6ba7ba728410456"
+      "digest": "sha256:1d1dfa18553e827ea36b66a7b22009c4c06582ca2df4cd2e706f22cee97ef723"
     },
     {
       "name": "ax-go-refine",
       "type": "skill-md",
       "description": "Use when writing Go code with `github.com/ax-llm/ax/packages/go` for reward-scored generation, iterative candidate improvement, evaluator feedback, and optimizer-backed refinement patterns.",
       "url": "ax-go-refine/SKILL.md",
-      "digest": "sha256:0438dceebff609553c9fa3bb530964114fb23b4bbec7087a2b8e1e124cfe92d9"
+      "digest": "sha256:6ec766a6a50b2e3695eb74892f1661f8b110b15074a6f58a1e4413615d5b40e8"
     },
     {
       "name": "ax-go-playbook",
       "type": "skill-md",
       "description": "Use when writing Go code with `github.com/ax-llm/ax/packages/go` for the playbook() context-engineering surface, agent-bound verified evolution, run-end learning, online updates, and rendering a playbook into a program.",
       "url": "ax-go-playbook/SKILL.md",
-      "digest": "sha256:520e82c05b8d0fd9a2446d33024203d860d5bcd5d3f378fd24336c9d9f29faf8"
+      "digest": "sha256:d4fd45e6f530a3119a7efb7cd461f3898aed0460ad79461aec843cdd4b162957"
     }
   ]
 }

--- a/website/static/java/.well-known/agent-skills/ax-java-agent-context/SKILL.md
+++ b/website/static/java/.well-known/agent-skills/ax-java-agent-context/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-java-agent-context"
 description: "Use when writing Java code with `dev.axllm:ax` for deciding between context maps, trajectory context policy, offline optimization (ACE/GEPA), and memory recall for long-context agents."
-version: "24.0.10"
+version: "24.0.12"
 ---
 # AxAgent Context Selection For Java
 

--- a/website/static/java/.well-known/agent-skills/ax-java-agent-memory-skills/SKILL.md
+++ b/website/static/java/.well-known/agent-skills/ax-java-agent-memory-skills/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-java-agent-memory-skills"
 description: "Use when writing Java code with `dev.axllm:ax` for agent memory, recall callbacks, dynamic skill discovery, loaded-skill state, and used-skill tracking."
-version: "24.0.10"
+version: "24.0.12"
 ---
 # AxAgent Memory And Skills For Java
 

--- a/website/static/java/.well-known/agent-skills/ax-java-agent-observability/SKILL.md
+++ b/website/static/java/.well-known/agent-skills/ax-java-agent-observability/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-java-agent-observability"
 description: "Use when writing Java code with `dev.axllm:ax` for agent tracing, centralized and multi-tenant usage accounting, action logs, runtime diagnostics, replay, and production debugging."
-version: "24.0.10"
+version: "24.0.12"
 ---
 # AxAgent Observability For Java
 

--- a/website/static/java/.well-known/agent-skills/ax-java-agent-optimize/SKILL.md
+++ b/website/static/java/.well-known/agent-skills/ax-java-agent-optimize/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-java-agent-optimize"
 description: "Use when writing Java code with `dev.axllm:ax` for agent optimization, verified agent-playbook evolution, evaluators, judges, optimizer artifacts, BootstrapFewShot, and GEPA."
-version: "24.0.10"
+version: "24.0.12"
 ---
 # AxAgent Optimize For Java
 

--- a/website/static/java/.well-known/agent-skills/ax-java-agent-rlm/SKILL.md
+++ b/website/static/java/.well-known/agent-skills/ax-java-agent-rlm/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-java-agent-rlm"
 description: "Use when writing Java code with `dev.axllm:ax` for RLM executor loops, AxCodeRuntime sessions, runtime envelopes, process runtimes, and optional runtime profiles."
-version: "24.0.10"
+version: "24.0.12"
 ---
 # AxAgent RLM Runtime For Java
 

--- a/website/static/java/.well-known/agent-skills/ax-java-agent/SKILL.md
+++ b/website/static/java/.well-known/agent-skills/ax-java-agent/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-java-agent"
 description: "Use when writing Java code with `dev.axllm:ax` for agents, child delegation, tools, MCP, citations, persistent playbook learning, stage instructions, runtime state, final typed responses, and direct-respond executor skipping."
-version: "24.0.10"
+version: "24.0.12"
 ---
 # AxAgent For Java
 

--- a/website/static/java/.well-known/agent-skills/ax-java-ai/SKILL.md
+++ b/website/static/java/.well-known/agent-skills/ax-java-ai/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-java-ai"
 description: "Use when writing Java code with `dev.axllm:ax` for named deployment profiles, generic provider clients, model selection, OpenAI-compatible calls, Responses, Gemini, Anthropic, routers, and balancers."
-version: "24.0.10"
+version: "24.0.12"
 ---
 # AxAI Providers For Java
 

--- a/website/static/java/.well-known/agent-skills/ax-java-audio/SKILL.md
+++ b/website/static/java/.well-known/agent-skills/ax-java-audio/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-java-audio"
 description: "Use when writing Java code with `dev.axllm:ax` for audio input/output, OpenAI Responses audio mapping, realtime event folding, and generated package audio examples."
-version: "24.0.10"
+version: "24.0.12"
 ---
 # Ax Audio And Realtime For Java
 

--- a/website/static/java/.well-known/agent-skills/ax-java-flow/SKILL.md
+++ b/website/static/java/.well-known/agent-skills/ax-java-flow/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-java-flow"
 description: "Use when writing Java code with `dev.axllm:ax` for flows, nodes, program graphs, nested programs, dynamic options, caching, and optimizer components."
-version: "24.0.10"
+version: "24.0.12"
 ---
 # AxFlow For Java
 

--- a/website/static/java/.well-known/agent-skills/ax-java-gen/SKILL.md
+++ b/website/static/java/.well-known/agent-skills/ax-java-gen/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-java-gen"
 description: "Use when writing Java code with `dev.axllm:ax` for AxGen programs, forward calls, indexed multi-sampling, result pickers, streaming, tools, assertions, traces, usage, and output parsing."
-version: "24.0.10"
+version: "24.0.12"
 ---
 # AxGen Structured Generation For Java
 

--- a/website/static/java/.well-known/agent-skills/ax-java-gepa/SKILL.md
+++ b/website/static/java/.well-known/agent-skills/ax-java-gepa/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-java-gepa"
 description: "Use when writing Java code with `dev.axllm:ax` for GEPA, Pareto tradeoffs, reflection clients, metric budgets, optimizer state, and artifacts."
-version: "24.0.10"
+version: "24.0.12"
 ---
 # Ax GEPA For Java
 

--- a/website/static/java/.well-known/agent-skills/ax-java-llm/SKILL.md
+++ b/website/static/java/.well-known/agent-skills/ax-java-llm/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-java-llm"
 description: "Use when writing Java code with `dev.axllm:ax` for using the generated Ax package, factory functions, package docs, examples, and API reference."
-version: "24.0.10"
+version: "24.0.12"
 ---
 # Ax LLM Quick Reference For Java
 

--- a/website/static/java/.well-known/agent-skills/ax-java-playbook/SKILL.md
+++ b/website/static/java/.well-known/agent-skills/ax-java-playbook/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-java-playbook"
 description: "Use when writing Java code with `dev.axllm:ax` for the playbook() context-engineering surface, agent-bound verified evolution, run-end learning, online updates, and rendering a playbook into a program."
-version: "24.0.10"
+version: "24.0.12"
 ---
 # Ax Playbook For Java
 

--- a/website/static/java/.well-known/agent-skills/ax-java-refine/SKILL.md
+++ b/website/static/java/.well-known/agent-skills/ax-java-refine/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-java-refine"
 description: "Use when writing Java code with `dev.axllm:ax` for reward-scored generation, iterative candidate improvement, evaluator feedback, and optimizer-backed refinement patterns."
-version: "24.0.10"
+version: "24.0.12"
 ---
 # Ax Refinement Patterns For Java
 

--- a/website/static/java/.well-known/agent-skills/ax-java-signature/SKILL.md
+++ b/website/static/java/.well-known/agent-skills/ax-java-signature/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-java-signature"
 description: "Use when writing Java code with `dev.axllm:ax` for string signatures, field descriptors, JSON schema output, validation, and typed tool argument shapes."
-version: "24.0.10"
+version: "24.0.12"
 ---
 # Ax Signatures For Java
 

--- a/website/static/java/.well-known/agent-skills/index.json
+++ b/website/static/java/.well-known/agent-skills/index.json
@@ -6,105 +6,105 @@
       "type": "skill-md",
       "description": "Use when writing Java code with `dev.axllm:ax` for using the generated Ax package, factory functions, package docs, examples, and API reference.",
       "url": "ax-java-llm/SKILL.md",
-      "digest": "sha256:a4e6fbd384f0afd0185a313988374d200e533ac306af20475607ae374b9cf5c9"
+      "digest": "sha256:4faab776e9ef15fe75bb1217c5a2c70f77165472e5bec57179c6a5d88189160d"
     },
     {
       "name": "ax-java-ai",
       "type": "skill-md",
       "description": "Use when writing Java code with `dev.axllm:ax` for named deployment profiles, generic provider clients, model selection, OpenAI-compatible calls, Responses, Gemini, Anthropic, routers, and balancers.",
       "url": "ax-java-ai/SKILL.md",
-      "digest": "sha256:840c3203d18c638a33144c70f8fb35381dc37ce9ca6f5698bf77343ae9482bb6"
+      "digest": "sha256:43fae383f457665054c27a77805d7c035e1215537df091fa526e050787816aa4"
     },
     {
       "name": "ax-java-audio",
       "type": "skill-md",
       "description": "Use when writing Java code with `dev.axllm:ax` for audio input/output, OpenAI Responses audio mapping, realtime event folding, and generated package audio examples.",
       "url": "ax-java-audio/SKILL.md",
-      "digest": "sha256:04ae7703ea3fc5e5490980a8db06d0a1f04def7bb1d098b3929b02f5ceb8f32b"
+      "digest": "sha256:d8a67508881845e0fa5125a566d2502ac8b7b988553c871dba685cd12631ea39"
     },
     {
       "name": "ax-java-signature",
       "type": "skill-md",
       "description": "Use when writing Java code with `dev.axllm:ax` for string signatures, field descriptors, JSON schema output, validation, and typed tool argument shapes.",
       "url": "ax-java-signature/SKILL.md",
-      "digest": "sha256:901ddd9da6a549d499e8baf46e736288b9297430c2b3df9b6dd0bcc54e79356c"
+      "digest": "sha256:a7796a8cdb5cc974be8e3b383d4a46985f98a1ce9076d9e1b85f52ea2a9d0e60"
     },
     {
       "name": "ax-java-gen",
       "type": "skill-md",
       "description": "Use when writing Java code with `dev.axllm:ax` for AxGen programs, forward calls, indexed multi-sampling, result pickers, streaming, tools, assertions, traces, usage, and output parsing.",
       "url": "ax-java-gen/SKILL.md",
-      "digest": "sha256:3d0ec5a14a7cbf5b0520a99ee2bc5959b95c5796118ab725d040f31009722ddd"
+      "digest": "sha256:037f21fea62c3f5c7adb629f64f683c409436b40ef093abd60ee4fd0de69afa7"
     },
     {
       "name": "ax-java-flow",
       "type": "skill-md",
       "description": "Use when writing Java code with `dev.axllm:ax` for flows, nodes, program graphs, nested programs, dynamic options, caching, and optimizer components.",
       "url": "ax-java-flow/SKILL.md",
-      "digest": "sha256:688d53811643ae6d69e0c070777eae391c9c31897c66ec1b13ad8b56fd542129"
+      "digest": "sha256:c6ee324ec1a0f4965e885ef432a0a1452d4e0f38fcb985ee6e0abef6de7ee7de"
     },
     {
       "name": "ax-java-agent",
       "type": "skill-md",
       "description": "Use when writing Java code with `dev.axllm:ax` for agents, child delegation, tools, MCP, citations, persistent playbook learning, stage instructions, runtime state, final typed responses, and direct-respond executor skipping.",
       "url": "ax-java-agent/SKILL.md",
-      "digest": "sha256:9a65816823cbf863453a721b93d4fba8b5183ec21de588f3a540ec18579c5f87"
+      "digest": "sha256:b6069af4fdf14f37980b78578951c233e74633925dfa047fdae7a67be935e8eb"
     },
     {
       "name": "ax-java-agent-rlm",
       "type": "skill-md",
       "description": "Use when writing Java code with `dev.axllm:ax` for RLM executor loops, AxCodeRuntime sessions, runtime envelopes, process runtimes, and optional runtime profiles.",
       "url": "ax-java-agent-rlm/SKILL.md",
-      "digest": "sha256:6edca40399aaffe2a7ad51200b896428febf342888847acfcda2d7d61d4f1ff3"
+      "digest": "sha256:eb5c8bcb60e1d546110befd06de5295965659eb6ef1b0f62292d2ce491a8a623"
     },
     {
       "name": "ax-java-agent-memory-skills",
       "type": "skill-md",
       "description": "Use when writing Java code with `dev.axllm:ax` for agent memory, recall callbacks, dynamic skill discovery, loaded-skill state, and used-skill tracking.",
       "url": "ax-java-agent-memory-skills/SKILL.md",
-      "digest": "sha256:3abe7628fbd4d1689c005d828425ce41765ddff73c6f054df3bf971b4b569479"
+      "digest": "sha256:76e8f300ae1cf395403840dd5b9927c86dc35caaf6117a110f319b1238cd9b0b"
     },
     {
       "name": "ax-java-agent-observability",
       "type": "skill-md",
       "description": "Use when writing Java code with `dev.axllm:ax` for agent tracing, centralized and multi-tenant usage accounting, action logs, runtime diagnostics, replay, and production debugging.",
       "url": "ax-java-agent-observability/SKILL.md",
-      "digest": "sha256:8cae886718077eaa6960e9946bf6f44a2630bcc2f21f379a8990b7f26503c367"
+      "digest": "sha256:c1aade89df1b771053287a6389e1e398083a1ec81416ad8d294ee6cca9c653ee"
     },
     {
       "name": "ax-java-agent-optimize",
       "type": "skill-md",
       "description": "Use when writing Java code with `dev.axllm:ax` for agent optimization, verified agent-playbook evolution, evaluators, judges, optimizer artifacts, BootstrapFewShot, and GEPA.",
       "url": "ax-java-agent-optimize/SKILL.md",
-      "digest": "sha256:6bac7a4405df3d3a3dbc7c3b7451e24f0bce1f16ea3535b9ea0d324194a2781b"
+      "digest": "sha256:9ea5efdfa83b41c2261286e6a06fd6f3edb48559a6dbadc079278b5911da6094"
     },
     {
       "name": "ax-java-agent-context",
       "type": "skill-md",
       "description": "Use when writing Java code with `dev.axllm:ax` for deciding between context maps, trajectory context policy, offline optimization (ACE/GEPA), and memory recall for long-context agents.",
       "url": "ax-java-agent-context/SKILL.md",
-      "digest": "sha256:ed81d37023c96d7b5b5e0971e0053b28af9baa7c7cb97d8bca099e8abbe19a33"
+      "digest": "sha256:0825e1a76b396d0db9327baf69f675bb08e389f6ae152b3ec396fb2e70d7750b"
     },
     {
       "name": "ax-java-gepa",
       "type": "skill-md",
       "description": "Use when writing Java code with `dev.axllm:ax` for GEPA, Pareto tradeoffs, reflection clients, metric budgets, optimizer state, and artifacts.",
       "url": "ax-java-gepa/SKILL.md",
-      "digest": "sha256:2829c237db4671e0ad50bdb6c5a5d6ced43c8f90085075ace2a60929791650f6"
+      "digest": "sha256:3a1fac9f30933e751652d99ab13ca83f23dea18dcd1d45462956c99958026d32"
     },
     {
       "name": "ax-java-refine",
       "type": "skill-md",
       "description": "Use when writing Java code with `dev.axllm:ax` for reward-scored generation, iterative candidate improvement, evaluator feedback, and optimizer-backed refinement patterns.",
       "url": "ax-java-refine/SKILL.md",
-      "digest": "sha256:1f9f9d9c3131010df0ea7222fb5eb889e4909d67a0cab17fb91a3fc37a6ece8a"
+      "digest": "sha256:50cea7c5e4a18d7c1458f5c4b96d7641a95e1f5f8c9217691b477c184c7d3f2d"
     },
     {
       "name": "ax-java-playbook",
       "type": "skill-md",
       "description": "Use when writing Java code with `dev.axllm:ax` for the playbook() context-engineering surface, agent-bound verified evolution, run-end learning, online updates, and rendering a playbook into a program.",
       "url": "ax-java-playbook/SKILL.md",
-      "digest": "sha256:118d993d44ea24b4e822d0eac1fce7457225138451086384a3230dea6ef87306"
+      "digest": "sha256:e0dd80f93e5fd144c5883ed949f920498e3f26b678e3b166e1d0d2488c7bba18"
     }
   ]
 }

--- a/website/static/python/.well-known/agent-skills/ax-python-agent-context/SKILL.md
+++ b/website/static/python/.well-known/agent-skills/ax-python-agent-context/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-python-agent-context"
 description: "Use when writing Python code with `axllm` for deciding between context maps, trajectory context policy, offline optimization (ACE/GEPA), and memory recall for long-context agents."
-version: "24.0.10"
+version: "24.0.12"
 ---
 # AxAgent Context Selection For Python
 

--- a/website/static/python/.well-known/agent-skills/ax-python-agent-memory-skills/SKILL.md
+++ b/website/static/python/.well-known/agent-skills/ax-python-agent-memory-skills/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-python-agent-memory-skills"
 description: "Use when writing Python code with `axllm` for agent memory, recall callbacks, dynamic skill discovery, loaded-skill state, and used-skill tracking."
-version: "24.0.10"
+version: "24.0.12"
 ---
 # AxAgent Memory And Skills For Python
 

--- a/website/static/python/.well-known/agent-skills/ax-python-agent-observability/SKILL.md
+++ b/website/static/python/.well-known/agent-skills/ax-python-agent-observability/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-python-agent-observability"
 description: "Use when writing Python code with `axllm` for agent tracing, centralized and multi-tenant usage accounting, action logs, runtime diagnostics, replay, and production debugging."
-version: "24.0.10"
+version: "24.0.12"
 ---
 # AxAgent Observability For Python
 

--- a/website/static/python/.well-known/agent-skills/ax-python-agent-optimize/SKILL.md
+++ b/website/static/python/.well-known/agent-skills/ax-python-agent-optimize/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-python-agent-optimize"
 description: "Use when writing Python code with `axllm` for agent optimization, verified agent-playbook evolution, evaluators, judges, optimizer artifacts, BootstrapFewShot, and GEPA."
-version: "24.0.10"
+version: "24.0.12"
 ---
 # AxAgent Optimize For Python
 

--- a/website/static/python/.well-known/agent-skills/ax-python-agent-rlm/SKILL.md
+++ b/website/static/python/.well-known/agent-skills/ax-python-agent-rlm/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-python-agent-rlm"
 description: "Use when writing Python code with `axllm` for RLM executor loops, AxCodeRuntime sessions, runtime envelopes, process runtimes, and optional runtime profiles."
-version: "24.0.10"
+version: "24.0.12"
 ---
 # AxAgent RLM Runtime For Python
 

--- a/website/static/python/.well-known/agent-skills/ax-python-agent/SKILL.md
+++ b/website/static/python/.well-known/agent-skills/ax-python-agent/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-python-agent"
 description: "Use when writing Python code with `axllm` for agents, child delegation, tools, MCP, citations, persistent playbook learning, stage instructions, runtime state, final typed responses, and direct-respond executor skipping."
-version: "24.0.10"
+version: "24.0.12"
 ---
 # AxAgent For Python
 

--- a/website/static/python/.well-known/agent-skills/ax-python-ai/SKILL.md
+++ b/website/static/python/.well-known/agent-skills/ax-python-ai/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-python-ai"
 description: "Use when writing Python code with `axllm` for named deployment profiles, generic provider clients, model selection, OpenAI-compatible calls, Responses, Gemini, Anthropic, routers, and balancers."
-version: "24.0.10"
+version: "24.0.12"
 ---
 # AxAI Providers For Python
 

--- a/website/static/python/.well-known/agent-skills/ax-python-audio/SKILL.md
+++ b/website/static/python/.well-known/agent-skills/ax-python-audio/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-python-audio"
 description: "Use when writing Python code with `axllm` for audio input/output, OpenAI Responses audio mapping, realtime event folding, and generated package audio examples."
-version: "24.0.10"
+version: "24.0.12"
 ---
 # Ax Audio And Realtime For Python
 

--- a/website/static/python/.well-known/agent-skills/ax-python-flow/SKILL.md
+++ b/website/static/python/.well-known/agent-skills/ax-python-flow/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-python-flow"
 description: "Use when writing Python code with `axllm` for flows, nodes, program graphs, nested programs, dynamic options, caching, and optimizer components."
-version: "24.0.10"
+version: "24.0.12"
 ---
 # AxFlow For Python
 

--- a/website/static/python/.well-known/agent-skills/ax-python-gen/SKILL.md
+++ b/website/static/python/.well-known/agent-skills/ax-python-gen/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-python-gen"
 description: "Use when writing Python code with `axllm` for AxGen programs, forward calls, indexed multi-sampling, result pickers, streaming, tools, assertions, traces, usage, and output parsing."
-version: "24.0.10"
+version: "24.0.12"
 ---
 # AxGen Structured Generation For Python
 

--- a/website/static/python/.well-known/agent-skills/ax-python-gepa/SKILL.md
+++ b/website/static/python/.well-known/agent-skills/ax-python-gepa/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-python-gepa"
 description: "Use when writing Python code with `axllm` for GEPA, Pareto tradeoffs, reflection clients, metric budgets, optimizer state, and artifacts."
-version: "24.0.10"
+version: "24.0.12"
 ---
 # Ax GEPA For Python
 

--- a/website/static/python/.well-known/agent-skills/ax-python-llm/SKILL.md
+++ b/website/static/python/.well-known/agent-skills/ax-python-llm/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-python-llm"
 description: "Use when writing Python code with `axllm` for using the generated Ax package, factory functions, package docs, examples, and API reference."
-version: "24.0.10"
+version: "24.0.12"
 ---
 # Ax LLM Quick Reference For Python
 

--- a/website/static/python/.well-known/agent-skills/ax-python-playbook/SKILL.md
+++ b/website/static/python/.well-known/agent-skills/ax-python-playbook/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-python-playbook"
 description: "Use when writing Python code with `axllm` for the playbook() context-engineering surface, agent-bound verified evolution, run-end learning, online updates, and rendering a playbook into a program."
-version: "24.0.10"
+version: "24.0.12"
 ---
 # Ax Playbook For Python
 

--- a/website/static/python/.well-known/agent-skills/ax-python-refine/SKILL.md
+++ b/website/static/python/.well-known/agent-skills/ax-python-refine/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-python-refine"
 description: "Use when writing Python code with `axllm` for reward-scored generation, iterative candidate improvement, evaluator feedback, and optimizer-backed refinement patterns."
-version: "24.0.10"
+version: "24.0.12"
 ---
 # Ax Refinement Patterns For Python
 

--- a/website/static/python/.well-known/agent-skills/ax-python-signature/SKILL.md
+++ b/website/static/python/.well-known/agent-skills/ax-python-signature/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-python-signature"
 description: "Use when writing Python code with `axllm` for string signatures, field descriptors, JSON schema output, validation, and typed tool argument shapes."
-version: "24.0.10"
+version: "24.0.12"
 ---
 # Ax Signatures For Python
 

--- a/website/static/python/.well-known/agent-skills/index.json
+++ b/website/static/python/.well-known/agent-skills/index.json
@@ -6,105 +6,105 @@
       "type": "skill-md",
       "description": "Use when writing Python code with `axllm` for using the generated Ax package, factory functions, package docs, examples, and API reference.",
       "url": "ax-python-llm/SKILL.md",
-      "digest": "sha256:60d2c33d3e6f490fa96bc423d2cbfb8b37ae8947ff6dec0a9744fc960f087260"
+      "digest": "sha256:9a78065f3cd6e1865bf08a13dddd472ff176b028566a26c14bc87d0a6b713457"
     },
     {
       "name": "ax-python-ai",
       "type": "skill-md",
       "description": "Use when writing Python code with `axllm` for named deployment profiles, generic provider clients, model selection, OpenAI-compatible calls, Responses, Gemini, Anthropic, routers, and balancers.",
       "url": "ax-python-ai/SKILL.md",
-      "digest": "sha256:cd201ba5ba50523a73eb80ed55f1729c796263328705cd11b9ca9f8602e84816"
+      "digest": "sha256:f206536c571f4745b1a3dd9c565fd1dff35b6a18108415902b5c66e56fb80d7f"
     },
     {
       "name": "ax-python-audio",
       "type": "skill-md",
       "description": "Use when writing Python code with `axllm` for audio input/output, OpenAI Responses audio mapping, realtime event folding, and generated package audio examples.",
       "url": "ax-python-audio/SKILL.md",
-      "digest": "sha256:bcef1a95e4c8aa2b210fb07bebc29392e5b436ca28758ab6e4ea8ed0fcfb38f6"
+      "digest": "sha256:cdbc6a34b7848cb1a40d27a0c642c466eccc96d623758dfcf9466817dc6db65f"
     },
     {
       "name": "ax-python-signature",
       "type": "skill-md",
       "description": "Use when writing Python code with `axllm` for string signatures, field descriptors, JSON schema output, validation, and typed tool argument shapes.",
       "url": "ax-python-signature/SKILL.md",
-      "digest": "sha256:7fdbd4a4d7bd3c9532a797ad28844691029ee6050067be91931d1d312e4e793c"
+      "digest": "sha256:8c6a2d6755198a7f68c8281602dca63c5325ef6bbaebed9555651cb3b0513221"
     },
     {
       "name": "ax-python-gen",
       "type": "skill-md",
       "description": "Use when writing Python code with `axllm` for AxGen programs, forward calls, indexed multi-sampling, result pickers, streaming, tools, assertions, traces, usage, and output parsing.",
       "url": "ax-python-gen/SKILL.md",
-      "digest": "sha256:d6a704db74b929c84ba7bf5b52c950455e1a74f2739bd8543d818ea520ee1248"
+      "digest": "sha256:2162fea8ca69521b2b33783ddc3256ca7b2aff3ec50ebf33f06de91d297f821a"
     },
     {
       "name": "ax-python-flow",
       "type": "skill-md",
       "description": "Use when writing Python code with `axllm` for flows, nodes, program graphs, nested programs, dynamic options, caching, and optimizer components.",
       "url": "ax-python-flow/SKILL.md",
-      "digest": "sha256:a5dfc25c5fc681af7eed9fa4a28903cae25c71de503f099f97940261c386fdb0"
+      "digest": "sha256:931e56ca01029a1f6a8918fc679f7c4ab81297f3d85d308241d71c7153ff3de4"
     },
     {
       "name": "ax-python-agent",
       "type": "skill-md",
       "description": "Use when writing Python code with `axllm` for agents, child delegation, tools, MCP, citations, persistent playbook learning, stage instructions, runtime state, final typed responses, and direct-respond executor skipping.",
       "url": "ax-python-agent/SKILL.md",
-      "digest": "sha256:0b6079fc1a07201beb9fd70631f1ba3c45a9a400516a2a95d61058ee2b8ecb5a"
+      "digest": "sha256:5ae5492658c107d2a1f1284290db91cd94f0dfb9ce41154c646de6dad852242d"
     },
     {
       "name": "ax-python-agent-rlm",
       "type": "skill-md",
       "description": "Use when writing Python code with `axllm` for RLM executor loops, AxCodeRuntime sessions, runtime envelopes, process runtimes, and optional runtime profiles.",
       "url": "ax-python-agent-rlm/SKILL.md",
-      "digest": "sha256:f186828332d6a5a1bd5db82edeaee79ba24a5a873868edba8f0631d7d320057b"
+      "digest": "sha256:ec24e4ee15f1d34c3837a7498b7c68156f7b53946e3af1242323c8e515bb87f9"
     },
     {
       "name": "ax-python-agent-memory-skills",
       "type": "skill-md",
       "description": "Use when writing Python code with `axllm` for agent memory, recall callbacks, dynamic skill discovery, loaded-skill state, and used-skill tracking.",
       "url": "ax-python-agent-memory-skills/SKILL.md",
-      "digest": "sha256:db448a5483659bf1103ec0e5b0847ab50a3e93e206e09d621043943479382706"
+      "digest": "sha256:28e4918e7da1e5b2ba32001148b839a8e872c7020254b42b8435a851def9b5e9"
     },
     {
       "name": "ax-python-agent-observability",
       "type": "skill-md",
       "description": "Use when writing Python code with `axllm` for agent tracing, centralized and multi-tenant usage accounting, action logs, runtime diagnostics, replay, and production debugging.",
       "url": "ax-python-agent-observability/SKILL.md",
-      "digest": "sha256:bfbb0bcc9330bb58cedae3fbe8aeaf67a59ab43a8ad0c090184c937c47f0a12d"
+      "digest": "sha256:1ba4600a3cc775383fd40c25503aacef528755a89188055169aa2a1c5f69c1ba"
     },
     {
       "name": "ax-python-agent-optimize",
       "type": "skill-md",
       "description": "Use when writing Python code with `axllm` for agent optimization, verified agent-playbook evolution, evaluators, judges, optimizer artifacts, BootstrapFewShot, and GEPA.",
       "url": "ax-python-agent-optimize/SKILL.md",
-      "digest": "sha256:5fdf4c5a202ca2de3ee270d9535f69f58f06faf7d1d20836571898a15894ec8d"
+      "digest": "sha256:10eb37d4b8f6e0770ba3e5644fa51dba9e2cfc0b7fcdf05a2a4799a92a3d76af"
     },
     {
       "name": "ax-python-agent-context",
       "type": "skill-md",
       "description": "Use when writing Python code with `axllm` for deciding between context maps, trajectory context policy, offline optimization (ACE/GEPA), and memory recall for long-context agents.",
       "url": "ax-python-agent-context/SKILL.md",
-      "digest": "sha256:299b34577caf431a6fd0abe9a01171f835ccb14f902d79051cf2c87351b3d1e4"
+      "digest": "sha256:e9536f48cae9d6c30e2965bd9382c68e30820a94915abbf8043f10810ffcb6b1"
     },
     {
       "name": "ax-python-gepa",
       "type": "skill-md",
       "description": "Use when writing Python code with `axllm` for GEPA, Pareto tradeoffs, reflection clients, metric budgets, optimizer state, and artifacts.",
       "url": "ax-python-gepa/SKILL.md",
-      "digest": "sha256:495c303a09f1e67829a7d88236e0890ba188a4ba9ec66a0fb5495b19eda21134"
+      "digest": "sha256:390593343f7804d5fd93a0d9f894aae557d29fbefb1c70add0c2002aa795b3fd"
     },
     {
       "name": "ax-python-refine",
       "type": "skill-md",
       "description": "Use when writing Python code with `axllm` for reward-scored generation, iterative candidate improvement, evaluator feedback, and optimizer-backed refinement patterns.",
       "url": "ax-python-refine/SKILL.md",
-      "digest": "sha256:19f4f55d7585aac96d01511313ed4d7d6c449ae2c4d2852268627414b3a499a3"
+      "digest": "sha256:ca6571853c04e19d1dc434967086b2fc6aa50c417d9dc69a62bc8505d51b9393"
     },
     {
       "name": "ax-python-playbook",
       "type": "skill-md",
       "description": "Use when writing Python code with `axllm` for the playbook() context-engineering surface, agent-bound verified evolution, run-end learning, online updates, and rendering a playbook into a program.",
       "url": "ax-python-playbook/SKILL.md",
-      "digest": "sha256:0df246126e5ec1c98d58cd501bf5614dc23dbcd13040dde5feab2c9415e87aa3"
+      "digest": "sha256:6eaa2e32ae66be33325247959c52f86a77200bda8c6ed3162ca1fe7a337113f2"
     }
   ]
 }

--- a/website/static/rust/.well-known/agent-skills/ax-rust-agent-context/SKILL.md
+++ b/website/static/rust/.well-known/agent-skills/ax-rust-agent-context/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-rust-agent-context"
 description: "Use when writing Rust code with `axllm` for deciding between context maps, trajectory context policy, offline optimization (ACE/GEPA), and memory recall for long-context agents."
-version: "24.0.10"
+version: "24.0.12"
 ---
 # AxAgent Context Selection For Rust
 

--- a/website/static/rust/.well-known/agent-skills/ax-rust-agent-memory-skills/SKILL.md
+++ b/website/static/rust/.well-known/agent-skills/ax-rust-agent-memory-skills/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-rust-agent-memory-skills"
 description: "Use when writing Rust code with `axllm` for agent memory, recall callbacks, dynamic skill discovery, loaded-skill state, and used-skill tracking."
-version: "24.0.10"
+version: "24.0.12"
 ---
 # AxAgent Memory And Skills For Rust
 

--- a/website/static/rust/.well-known/agent-skills/ax-rust-agent-observability/SKILL.md
+++ b/website/static/rust/.well-known/agent-skills/ax-rust-agent-observability/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-rust-agent-observability"
 description: "Use when writing Rust code with `axllm` for agent tracing, centralized and multi-tenant usage accounting, action logs, runtime diagnostics, replay, and production debugging."
-version: "24.0.10"
+version: "24.0.12"
 ---
 # AxAgent Observability For Rust
 

--- a/website/static/rust/.well-known/agent-skills/ax-rust-agent-optimize/SKILL.md
+++ b/website/static/rust/.well-known/agent-skills/ax-rust-agent-optimize/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-rust-agent-optimize"
 description: "Use when writing Rust code with `axllm` for agent optimization, verified agent-playbook evolution, evaluators, judges, optimizer artifacts, BootstrapFewShot, and GEPA."
-version: "24.0.10"
+version: "24.0.12"
 ---
 # AxAgent Optimize For Rust
 

--- a/website/static/rust/.well-known/agent-skills/ax-rust-agent-rlm/SKILL.md
+++ b/website/static/rust/.well-known/agent-skills/ax-rust-agent-rlm/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-rust-agent-rlm"
 description: "Use when writing Rust code with `axllm` for RLM executor loops, AxCodeRuntime sessions, runtime envelopes, process runtimes, and optional runtime profiles."
-version: "24.0.10"
+version: "24.0.12"
 ---
 # AxAgent RLM Runtime For Rust
 

--- a/website/static/rust/.well-known/agent-skills/ax-rust-agent/SKILL.md
+++ b/website/static/rust/.well-known/agent-skills/ax-rust-agent/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-rust-agent"
 description: "Use when writing Rust code with `axllm` for agents, child delegation, tools, MCP, citations, persistent playbook learning, stage instructions, runtime state, final typed responses, and direct-respond executor skipping."
-version: "24.0.10"
+version: "24.0.12"
 ---
 # AxAgent For Rust
 

--- a/website/static/rust/.well-known/agent-skills/ax-rust-ai/SKILL.md
+++ b/website/static/rust/.well-known/agent-skills/ax-rust-ai/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-rust-ai"
 description: "Use when writing Rust code with `axllm` for named deployment profiles, generic provider clients, model selection, OpenAI-compatible calls, Responses, Gemini, Anthropic, routers, and balancers."
-version: "24.0.10"
+version: "24.0.12"
 ---
 # AxAI Providers For Rust
 

--- a/website/static/rust/.well-known/agent-skills/ax-rust-audio/SKILL.md
+++ b/website/static/rust/.well-known/agent-skills/ax-rust-audio/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-rust-audio"
 description: "Use when writing Rust code with `axllm` for audio input/output, OpenAI Responses audio mapping, realtime event folding, and generated package audio examples."
-version: "24.0.10"
+version: "24.0.12"
 ---
 # Ax Audio And Realtime For Rust
 

--- a/website/static/rust/.well-known/agent-skills/ax-rust-flow/SKILL.md
+++ b/website/static/rust/.well-known/agent-skills/ax-rust-flow/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-rust-flow"
 description: "Use when writing Rust code with `axllm` for flows, nodes, program graphs, nested programs, dynamic options, caching, and optimizer components."
-version: "24.0.10"
+version: "24.0.12"
 ---
 # AxFlow For Rust
 

--- a/website/static/rust/.well-known/agent-skills/ax-rust-gen/SKILL.md
+++ b/website/static/rust/.well-known/agent-skills/ax-rust-gen/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-rust-gen"
 description: "Use when writing Rust code with `axllm` for AxGen programs, forward calls, indexed multi-sampling, result pickers, streaming, tools, assertions, traces, usage, and output parsing."
-version: "24.0.10"
+version: "24.0.12"
 ---
 # AxGen Structured Generation For Rust
 

--- a/website/static/rust/.well-known/agent-skills/ax-rust-gepa/SKILL.md
+++ b/website/static/rust/.well-known/agent-skills/ax-rust-gepa/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-rust-gepa"
 description: "Use when writing Rust code with `axllm` for GEPA, Pareto tradeoffs, reflection clients, metric budgets, optimizer state, and artifacts."
-version: "24.0.10"
+version: "24.0.12"
 ---
 # Ax GEPA For Rust
 

--- a/website/static/rust/.well-known/agent-skills/ax-rust-llm/SKILL.md
+++ b/website/static/rust/.well-known/agent-skills/ax-rust-llm/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-rust-llm"
 description: "Use when writing Rust code with `axllm` for using the generated Ax package, factory functions, package docs, examples, and API reference."
-version: "24.0.10"
+version: "24.0.12"
 ---
 # Ax LLM Quick Reference For Rust
 

--- a/website/static/rust/.well-known/agent-skills/ax-rust-playbook/SKILL.md
+++ b/website/static/rust/.well-known/agent-skills/ax-rust-playbook/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-rust-playbook"
 description: "Use when writing Rust code with `axllm` for the playbook() context-engineering surface, agent-bound verified evolution, run-end learning, online updates, and rendering a playbook into a program."
-version: "24.0.10"
+version: "24.0.12"
 ---
 # Ax Playbook For Rust
 

--- a/website/static/rust/.well-known/agent-skills/ax-rust-refine/SKILL.md
+++ b/website/static/rust/.well-known/agent-skills/ax-rust-refine/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-rust-refine"
 description: "Use when writing Rust code with `axllm` for reward-scored generation, iterative candidate improvement, evaluator feedback, and optimizer-backed refinement patterns."
-version: "24.0.10"
+version: "24.0.12"
 ---
 # Ax Refinement Patterns For Rust
 

--- a/website/static/rust/.well-known/agent-skills/ax-rust-signature/SKILL.md
+++ b/website/static/rust/.well-known/agent-skills/ax-rust-signature/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-rust-signature"
 description: "Use when writing Rust code with `axllm` for string signatures, field descriptors, JSON schema output, validation, and typed tool argument shapes."
-version: "24.0.10"
+version: "24.0.12"
 ---
 # Ax Signatures For Rust
 

--- a/website/static/rust/.well-known/agent-skills/index.json
+++ b/website/static/rust/.well-known/agent-skills/index.json
@@ -6,105 +6,105 @@
       "type": "skill-md",
       "description": "Use when writing Rust code with `axllm` for using the generated Ax package, factory functions, package docs, examples, and API reference.",
       "url": "ax-rust-llm/SKILL.md",
-      "digest": "sha256:e8520e6960481b22fc83e28400a1e250ddbaba46b5461c23b9a8c97b0741f22b"
+      "digest": "sha256:6b2fffce1b376963ae8765bc428810e829817f81baac490be071e5a7694bfdc0"
     },
     {
       "name": "ax-rust-ai",
       "type": "skill-md",
       "description": "Use when writing Rust code with `axllm` for named deployment profiles, generic provider clients, model selection, OpenAI-compatible calls, Responses, Gemini, Anthropic, routers, and balancers.",
       "url": "ax-rust-ai/SKILL.md",
-      "digest": "sha256:22b32cfd2cc9595814e058139bbe7a80a24e0c4bbcbbfcadb5b25c191e91cd16"
+      "digest": "sha256:7efed152c77f63bd1701aa6b02cb327406b5c3856abcd753c03d06ad2e26ced4"
     },
     {
       "name": "ax-rust-audio",
       "type": "skill-md",
       "description": "Use when writing Rust code with `axllm` for audio input/output, OpenAI Responses audio mapping, realtime event folding, and generated package audio examples.",
       "url": "ax-rust-audio/SKILL.md",
-      "digest": "sha256:5fb85dfefd878fe31f3d1cbda41d7322904aec559acf9a079ec69db6fb6f2a25"
+      "digest": "sha256:af51d69c8486d360369da1697bbe0f4dbc69a31174e6766a00c208035c2ea643"
     },
     {
       "name": "ax-rust-signature",
       "type": "skill-md",
       "description": "Use when writing Rust code with `axllm` for string signatures, field descriptors, JSON schema output, validation, and typed tool argument shapes.",
       "url": "ax-rust-signature/SKILL.md",
-      "digest": "sha256:f2a9d3253151152170b16bc77db2fe990d29239e32d820e2635ce427572a7f1f"
+      "digest": "sha256:25e32859b65e156f76c0bc62fead6c1505df4712ac4662ac4638e284878e9bc3"
     },
     {
       "name": "ax-rust-gen",
       "type": "skill-md",
       "description": "Use when writing Rust code with `axllm` for AxGen programs, forward calls, indexed multi-sampling, result pickers, streaming, tools, assertions, traces, usage, and output parsing.",
       "url": "ax-rust-gen/SKILL.md",
-      "digest": "sha256:fa024ab8883080fffa9b66e6a8836b236b5c8ce0e59d80ee80de6261a114d67f"
+      "digest": "sha256:2707ee39562d23f47ae13e4150747791236408c491818085dc55c8f0aab9406c"
     },
     {
       "name": "ax-rust-flow",
       "type": "skill-md",
       "description": "Use when writing Rust code with `axllm` for flows, nodes, program graphs, nested programs, dynamic options, caching, and optimizer components.",
       "url": "ax-rust-flow/SKILL.md",
-      "digest": "sha256:929b1b959fe8159e5cb9df7aa1e1b5c0245c5925e0b3a12283b0309732f7a6c6"
+      "digest": "sha256:41813034e6455fa2038cbdfde303101c1d44a54140f5d071d19d10f6e8706add"
     },
     {
       "name": "ax-rust-agent",
       "type": "skill-md",
       "description": "Use when writing Rust code with `axllm` for agents, child delegation, tools, MCP, citations, persistent playbook learning, stage instructions, runtime state, final typed responses, and direct-respond executor skipping.",
       "url": "ax-rust-agent/SKILL.md",
-      "digest": "sha256:793de1366c3f2796c7e7afd4f673f99f422acca15ab92d7130dc95a46e29f2cd"
+      "digest": "sha256:edc81c237f32d4303c4405e4bf353562bc9b1df54456d421f9496de48b70fb45"
     },
     {
       "name": "ax-rust-agent-rlm",
       "type": "skill-md",
       "description": "Use when writing Rust code with `axllm` for RLM executor loops, AxCodeRuntime sessions, runtime envelopes, process runtimes, and optional runtime profiles.",
       "url": "ax-rust-agent-rlm/SKILL.md",
-      "digest": "sha256:5062ceff86b3135f92522c21d7fb94280b5837f8807a60779ff4177165730978"
+      "digest": "sha256:a0bd7654c5ad65d62232cac6047501e1264314a12493899c7aa67125a8fcb1d1"
     },
     {
       "name": "ax-rust-agent-memory-skills",
       "type": "skill-md",
       "description": "Use when writing Rust code with `axllm` for agent memory, recall callbacks, dynamic skill discovery, loaded-skill state, and used-skill tracking.",
       "url": "ax-rust-agent-memory-skills/SKILL.md",
-      "digest": "sha256:0cd4063704126016da60ba42adafe837dbde047a09b0146fae5ca9e54a6ddcad"
+      "digest": "sha256:8acaa749d49d2d15ce5646ce7c2b9fcc40f4c42ad52757c0a7a1e7dbb0367d4b"
     },
     {
       "name": "ax-rust-agent-observability",
       "type": "skill-md",
       "description": "Use when writing Rust code with `axllm` for agent tracing, centralized and multi-tenant usage accounting, action logs, runtime diagnostics, replay, and production debugging.",
       "url": "ax-rust-agent-observability/SKILL.md",
-      "digest": "sha256:fb3f4a848e4b2302c28a0a2db6340b4d29f65faac34ca1a85bb9da6c9fafc928"
+      "digest": "sha256:d268002e3f6ade7542344e255a32cee0d88ef00ddad286fa76c9ceb5666504a7"
     },
     {
       "name": "ax-rust-agent-optimize",
       "type": "skill-md",
       "description": "Use when writing Rust code with `axllm` for agent optimization, verified agent-playbook evolution, evaluators, judges, optimizer artifacts, BootstrapFewShot, and GEPA.",
       "url": "ax-rust-agent-optimize/SKILL.md",
-      "digest": "sha256:e86c8a3500e721632f3f326e19e1d1672c90f281bc073d49497f629f0da1a846"
+      "digest": "sha256:485bfa1de9d160871d80b798f5a50164d602eebed31ee1b6ff22dd816b71615a"
     },
     {
       "name": "ax-rust-agent-context",
       "type": "skill-md",
       "description": "Use when writing Rust code with `axllm` for deciding between context maps, trajectory context policy, offline optimization (ACE/GEPA), and memory recall for long-context agents.",
       "url": "ax-rust-agent-context/SKILL.md",
-      "digest": "sha256:e36997f12caaeefdeae0b07b1080417d1fad3ed4b18279caf128ed9a1aabb58b"
+      "digest": "sha256:196411a4fb79ee73ec93ec101174311208988a9c85176118b1a53349c5990fdf"
     },
     {
       "name": "ax-rust-gepa",
       "type": "skill-md",
       "description": "Use when writing Rust code with `axllm` for GEPA, Pareto tradeoffs, reflection clients, metric budgets, optimizer state, and artifacts.",
       "url": "ax-rust-gepa/SKILL.md",
-      "digest": "sha256:71c55635c528194f3cf50e4dc1e30584acb4d9b21412107b64fc39988b02e2ae"
+      "digest": "sha256:6d3d68ff4602486d239fc6c39deb105f7840883724ff5a7f1a4dd75c4e1bff9e"
     },
     {
       "name": "ax-rust-refine",
       "type": "skill-md",
       "description": "Use when writing Rust code with `axllm` for reward-scored generation, iterative candidate improvement, evaluator feedback, and optimizer-backed refinement patterns.",
       "url": "ax-rust-refine/SKILL.md",
-      "digest": "sha256:65113fa75f3ce953d8815e1b52b59796befe8aebe071d80b14b766b2532bd062"
+      "digest": "sha256:98c5d48f51df87a93ca12f41d07c90f5ca8fbcaa488297db4fba9e59db90fe37"
     },
     {
       "name": "ax-rust-playbook",
       "type": "skill-md",
       "description": "Use when writing Rust code with `axllm` for the playbook() context-engineering surface, agent-bound verified evolution, run-end learning, online updates, and rendering a playbook into a program.",
       "url": "ax-rust-playbook/SKILL.md",
-      "digest": "sha256:c2324039a2595ce999d8270f026448061925a44af3f58232dbdc3dab604dbad4"
+      "digest": "sha256:39ae805a7d33c3f21720e9cec6c1222c8f3b3d5718381911d41ef0cf35d0c2f0"
     }
   ]
 }

--- a/website/static/typescript/.well-known/agent-skills/ax-agent-context/SKILL.md
+++ b/website/static/typescript/.well-known/agent-skills/ax-agent-context/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: ax-agent-context
 description: This skill helps an LLM pick the right AxAgent context tool for a job - contextMap for recurring corpora, contextPolicy presets for within-run trajectory compaction, agent.optimize for offline GEPA instruction/demo tuning, agent.playbook for an evolving context playbook (offline evolve + online update), and recall/memories + skills for per-turn retrieval. Use when the user asks "which context feature should I use", confuses contextMap with contextPolicy or memory, or wants a decision guide for long-context agents. For contextPolicy/contextMap codegen use ax-agent-rlm; for recall/skills use ax-agent-memory-skills; for agent.optimize or agent.playbook use ax-agent-optimize.
-version: "24.0.10"
+version: "24.0.12"
 ---
 
 # AxAgent Context Selection (@ax-llm/ax)

--- a/website/static/typescript/.well-known/agent-skills/ax-agent-memory-skills/SKILL.md
+++ b/website/static/typescript/.well-known/agent-skills/ax-agent-memory-skills/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: ax-agent-memory-skills
 description: This skill helps an LLM generate correct AxAgent memory retrieval, context-map, and dynamic skill-loading code using @ax-llm/ax. Use when the user asks about contextMap, AxAgentContextMap, onMemoriesSearch, memoriesCatalog, recall(...), inputs.memories, onLoadedMemories, onUsedMemories, onSkillsSearch, skillsCatalog, AxAgentCatalogSkill, discover({ skills }), onLoadedSkills, onUsedSkills, preloaded skills, preloading memories at forward time, relevanceRanking hints, loaded memory/skill IDs, or carrying memories across forward() calls.
-version: "24.0.10"
+version: "24.0.12"
 ---
 
 # AxAgent Memory And Skills Rules (@ax-llm/ax)

--- a/website/static/typescript/.well-known/agent-skills/ax-agent-observability/SKILL.md
+++ b/website/static/typescript/.well-known/agent-skills/ax-agent-observability/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: ax-agent-observability
 description: This skill helps an LLM generate correct AxAgent observability code using @ax-llm/ax. Use when the user asks about axGlobals.onUsage, usageContext, centralized or multi-tenant usage accounting, actorTurnCallback, onContextEvent, agentStatusCallback, onFunctionCall, reportSuccess, reportFailure, getChatLog(), getUsage(), resetUsage(), debug traces, progress updates, or telemetry for AxAgent runs.
-version: "24.0.10"
+version: "24.0.12"
 ---
 
 # AxAgent Observability Rules (@ax-llm/ax)

--- a/website/static/typescript/.well-known/agent-skills/ax-agent-optimize/SKILL.md
+++ b/website/static/typescript/.well-known/agent-skills/ax-agent-optimize/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: ax-agent-optimize
 description: This skill helps an LLM generate correct AxAgent tuning and evaluation code using @ax-llm/ax. Use when the user asks about agent.optimize(...), judgeOptions, eval datasets, optimization targets, saved optimizedProgram artifacts, or agent optimization guidance.
-version: "24.0.10"
+version: "24.0.12"
 ---
 
 # AxAgent Optimize Codegen Rules (@ax-llm/ax)

--- a/website/static/typescript/.well-known/agent-skills/ax-agent-rlm/SKILL.md
+++ b/website/static/typescript/.well-known/agent-skills/ax-agent-rlm/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: ax-agent-rlm
 description: This skill helps an LLM generate correct AxAgent RLM/runtime code using @ax-llm/ax. Use when the user asks about RLM code execution, AxJSRuntime, contextFields, contextPolicy, liveRuntimeState, promptLevel, stage prompt controls, executorModelPolicy, maxRuntimeChars, agent.test(...), llmQuery(...), recursionOptions, or long-running agent runtime behavior.
-version: "24.0.10"
+version: "24.0.12"
 ---
 
 # AxAgent RLM Runtime Rules (@ax-llm/ax)

--- a/website/static/typescript/.well-known/agent-skills/ax-agent/SKILL.md
+++ b/website/static/typescript/.well-known/agent-skills/ax-agent/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: ax-agent
 description: This skill helps an LLM generate correct core AxAgent code using @ax-llm/ax. Use when the user asks about agent(), child agents, namespaced functions, discovery mode, clarification, bubbleErrors, host-side final/clarification protocol, or ordinary agent runtime behavior. For MCP clients, native runtime modules, subscriptions, tasks, or authentication use ax-mcp alongside this skill. For RLM/code-runtime work use ax-agent-rlm; for callbacks and telemetry use ax-agent-observability; for recall/memory/skill loading use ax-agent-memory-skills; for agent.optimize(...) use ax-agent-optimize.
-version: "24.0.10"
+version: "24.0.12"
 ---
 
 # AxAgent Codegen Rules (@ax-llm/ax)

--- a/website/static/typescript/.well-known/agent-skills/ax-ai/SKILL.md
+++ b/website/static/typescript/.well-known/agent-skills/ax-ai/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: ax-ai
 description: This skill helps an LLM generate correct AI provider setup and configuration code using @ax-llm/ax. Use when the user asks about ai(), providers, models, routing, adaptive balancing, presets, embeddings, batch audio with ai.transcribe() or ai.speak(), extended thinking, context caching, or mentions OpenAI/Anthropic/Google/Azure/DeepSeek/Mistral/Cohere/Reka/Grok with @ax-llm/ax.
-version: "24.0.10"
+version: "24.0.12"
 ---
 
 # AI Provider Codegen Rules (@ax-llm/ax)
@@ -401,14 +401,26 @@ console.log(res.results[0]?.content);
 
 ### Budget Levels
 
-| Level | Anthropic (tokens) | Gemini (tokens) |
-|---|---|---|
-| `'none'` | disabled | minimal |
-| `'minimal'` | 1,024 | 200 |
-| `'low'` | 5,000 | 800 |
-| `'medium'` | 10,000 | 5,000 |
-| `'high'` | 20,000 | 10,000 |
-| `'highest'` | 32,000 | 24,500 |
+| Level | Anthropic (tokens) | Gemini 2.5 (tokens) | Gemini 3 level |
+|---|---|---|---|
+| `'none'` | disabled | 0 on Flash/Lite; minimum on Pro | lowest supported, thoughts hidden |
+| `'minimal'` | 1,024 | 200 | `minimal`, or `low` when `minimal` is unsupported |
+| `'low'` | 5,000 | 800 | `low` |
+| `'medium'` | 10,000 | 5,000 | `medium`, or the nearest image/legacy level |
+| `'high'` | 20,000 | 10,000 | `high` |
+| `'highest'` | 32,000 | 24,500 | `high` |
+
+Gemini 3 uses `thinkingLevel`; Gemini 2.5 and older models use numeric
+`thinkingBudget`. Ax selects the wire field after resolving a named model
+preset to its real model. Gemini 3.7 Flash and Gemini 3.1 Pro clamp `minimal`
+to `low`; image and legacy Gemini 3 models clamp to their documented two-level
+sets. Numeric Gemini 3 budgets fail locally. `none` always hides returned
+thoughts, even when the model must still perform its minimum amount of thinking.
+
+The native `google-gemini` deployment profile and its aliases use these Gemini
+rules, including when configured for Vertex with `projectId` and `region`. The
+separate OpenAI-compatible `vertex-ai` profile keeps its own request rules and
+does not inherit native Gemini fields from a Gemini-looking model ID.
 
 For GPT-5.6, these map to `none`, `low`, `low`, `medium`, `high`, and a top rung
 that depends on the API surface: `xhigh` on Chat Completions, which rejects

--- a/website/static/typescript/.well-known/agent-skills/ax-audio/SKILL.md
+++ b/website/static/typescript/.well-known/agent-skills/ax-audio/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: ax-audio
 description: This skill helps an LLM generate correct audio code with @ax-llm/ax. Use when the user asks about ai.transcribe(), ai.speak(), signature audio inputs or outputs, agent audio behavior, .chat() conversational audio, OpenAI audio or realtime models, Gemini Live native audio, Grok Voice Agent models, voices, formats, transcripts, or how audio fits with structured outputs.
-version: "24.0.10"
+version: "24.0.12"
 ---
 
 # Audio I/O Codegen Rules (@ax-llm/ax)

--- a/website/static/typescript/.well-known/agent-skills/ax-flow/SKILL.md
+++ b/website/static/typescript/.well-known/agent-skills/ax-flow/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: ax-flow
 description: This skill helps an LLM generate correct AxFlow workflow code using @ax-llm/ax. Use when the user asks about flow(), AxFlow, workflow orchestration, parallel execution, DAG workflows, conditional routing, map/reduce patterns, or multi-node AI pipelines.
-version: "24.0.10"
+version: "24.0.12"
 ---
 
 # AxFlow Codegen Rules (@ax-llm/ax)

--- a/website/static/typescript/.well-known/agent-skills/ax-gen/SKILL.md
+++ b/website/static/typescript/.well-known/agent-skills/ax-gen/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: ax-gen
 description: This skill helps an LLM generate correct AxGen code using @ax-llm/ax. Use when the user asks about ax(), AxGen, generators, forward(), streamingForward(), validation, assertions, streaming assertions, field processors, step hooks, self-tuning, or structured outputs. For MCP clients, transports, prompts, resources, tasks, subscriptions, or authentication use ax-mcp alongside this skill.
-version: "24.0.10"
+version: "24.0.12"
 ---
 
 # AxGen Codegen Rules (@ax-llm/ax)
@@ -321,7 +321,10 @@ console.log(result.thought);
 
 Rules:
 
-- `thinkingTokenBudget` can be `'low'`, `'medium'`, `'high'`, or a number.
+- `thinkingTokenBudget` accepts `'none'`, `'minimal'`, `'low'`, `'medium'`,
+  `'high'`, or `'highest'`. Provider-specific numeric configuration is only for
+  models such as Gemini 2.5 that expose a numeric thinking budget; Gemini 3 uses
+  model-aware thinking levels instead.
 - Set `showThoughts: true` to include the model's reasoning in `result.thought`.
 
 ## Structured Outputs

--- a/website/static/typescript/.well-known/agent-skills/ax-gepa/SKILL.md
+++ b/website/static/typescript/.well-known/agent-skills/ax-gepa/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: ax-gepa
 description: This skill helps an LLM generate correct AxGEPA optimization code using @ax-llm/ax. Use when the user asks about AxGEPA, GEPA, Pareto optimization, multi-objective prompt tuning, reflective prompt evolution, validationExamples, maxMetricCalls, or optimizing a generator, flow, or agent tree.
-version: "24.0.10"
+version: "24.0.12"
 ---
 
 # GEPA Optimization Codegen Rules (@ax-llm/ax)

--- a/website/static/typescript/.well-known/agent-skills/ax-llm/SKILL.md
+++ b/website/static/typescript/.well-known/agent-skills/ax-llm/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: ax-llm
 description: This skill helps with using the @ax-llm/ax TypeScript library for building LLM applications. Use when the user asks about ax(), ai(), f(), s(), agent(), flow(), AxGen, AxAgent, AxFlow, signatures, streaming, or mentions @ax-llm/ax.
-version: "24.0.10"
+version: "24.0.12"
 ---
 
 # Ax Library (@ax-llm/ax) Quick Reference

--- a/website/static/typescript/.well-known/agent-skills/ax-mcp/SKILL.md
+++ b/website/static/typescript/.well-known/agent-skills/ax-mcp/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: ax-mcp
 description: This skill helps an LLM build correct native Model Context Protocol integrations with @ax-llm/ax. Use when the user asks about AxMCPClient, MCP transports, tools, prompts, resources, subscriptions, tasks, sampling, elicitation, roots, authentication, OAuth, MCP Apps, recording/replay, or MCP integration with AxGen, AxAgent, AxFlow, chat, optimization, and AxEventRuntime.
-version: "24.0.10"
+version: "24.0.12"
 ---
 
 # Native MCP With Ax

--- a/website/static/typescript/.well-known/agent-skills/ax-playbook/SKILL.md
+++ b/website/static/typescript/.well-known/agent-skills/ax-playbook/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: ax-playbook
 description: This skill helps an LLM generate correct playbook code using @ax-llm/ax. Use when the user asks about playbook(), AxPlaybook, context playbooks, evolving context, ACE / Agentic Context Engineering, agent.playbook(), or growing/applying task knowledge offline and online with evolve() and update().
-version: "24.0.10"
+version: "24.0.12"
 ---
 
 # Playbook Codegen Rules (@ax-llm/ax)

--- a/website/static/typescript/.well-known/agent-skills/ax-refine/SKILL.md
+++ b/website/static/typescript/.well-known/agent-skills/ax-refine/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: ax-refine
 description: Use this skill when writing or reviewing Ax bestOfN/refine code, reward functions, thresholds, native sample selection, serial attempts, generated advice, and attempt diagnostics.
-version: "24.0.10"
+version: "24.0.12"
 ---
 
 # Ax Refine And BestOfN

--- a/website/static/typescript/.well-known/agent-skills/ax-signature/SKILL.md
+++ b/website/static/typescript/.well-known/agent-skills/ax-signature/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: ax-signature
 description: This skill helps an LLM generate correct DSPy signature code using @ax-llm/ax. Use when the user asks about signatures, s(), f(), field types, string syntax, fluent builder API, validation constraints, or type-safe inputs/outputs.
-version: "24.0.10"
+version: "24.0.12"
 ---
 
 # Ax Signature Reference

--- a/website/static/typescript/.well-known/agent-skills/index.json
+++ b/website/static/typescript/.well-known/agent-skills/index.json
@@ -6,91 +6,91 @@
       "type": "skill-md",
       "description": "This skill helps with using the @ax-llm/ax TypeScript library for building LLM applications. Use when the user asks about ax(), ai(), f(), s(), agent(), flow(), AxGen, AxAgent, AxFlow, signatures, streaming, or mentions @ax-llm/ax.",
       "url": "ax-llm/SKILL.md",
-      "digest": "sha256:cf16c4c73a7d60713c5cab6f678abca1155eb20f44b8051043b387fc95eec8eb"
+      "digest": "sha256:2b1e7dc8b90269cabdca3665bc2c6400d2685870e76d82a991c82020579d5259"
     },
     {
       "name": "ax-ai",
       "type": "skill-md",
       "description": "This skill helps an LLM generate correct AI provider setup and configuration code using @ax-llm/ax. Use when the user asks about ai(), providers, models, routing, adaptive balancing, presets, embeddings, batch audio with ai.transcribe() or ai.speak(), extended thinking, context caching, or mentions OpenAI/Anthropic/Google/Azure/DeepSeek/Mistral/Cohere/Reka/Grok with @ax-llm/ax.",
       "url": "ax-ai/SKILL.md",
-      "digest": "sha256:ece2e348517c2adf8a705f04e9b5c709bead47a675866dde2aa15e4413b3ce77"
+      "digest": "sha256:0377385716f427a34bf5d04cd6e24ebe58a9a4e568d2e2981ef59c10c851ab97"
     },
     {
       "name": "ax-audio",
       "type": "skill-md",
       "description": "This skill helps an LLM generate correct audio code with @ax-llm/ax. Use when the user asks about ai.transcribe(), ai.speak(), signature audio inputs or outputs, agent audio behavior, .chat() conversational audio, OpenAI audio or realtime models, Gemini Live native audio, Grok Voice Agent models, voices, formats, transcripts, or how audio fits with structured outputs.",
       "url": "ax-audio/SKILL.md",
-      "digest": "sha256:a985d9c09dc976ffbf0999b53c2a470fb8b49441ddc18fd55774087a26f716c3"
+      "digest": "sha256:4989db84b1c5608925431bf30629e74a335864c76dc93411231495eafe4b8065"
     },
     {
       "name": "ax-signature",
       "type": "skill-md",
       "description": "This skill helps an LLM generate correct DSPy signature code using @ax-llm/ax. Use when the user asks about signatures, s(), f(), field types, string syntax, fluent builder API, validation constraints, or type-safe inputs/outputs.",
       "url": "ax-signature/SKILL.md",
-      "digest": "sha256:2cdce143b3776df711d43e4c42082bfd4813bacddcbcf233f9553ef4a4c32872"
+      "digest": "sha256:981d7314a70cab679ebf25c6a7cb252b40c009b5c179fdbe2039f9a16e58ce52"
     },
     {
       "name": "ax-gen",
       "type": "skill-md",
       "description": "This skill helps an LLM generate correct AxGen code using @ax-llm/ax. Use when the user asks about ax(), AxGen, generators, forward(), streamingForward(), validation, assertions, streaming assertions, field processors, step hooks, self-tuning, or structured outputs. For MCP clients, transports, prompts, resources, tasks, subscriptions, or authentication use ax-mcp alongside this skill.",
       "url": "ax-gen/SKILL.md",
-      "digest": "sha256:7ccc206138d3fa32a9a56ea59018ea48d6d8636dd009c0b18527d8050142fec6"
+      "digest": "sha256:f968f05b589dcc61b2b9abe0eb57d711d408ba88525fdf0c320bc6826414a625"
     },
     {
       "name": "ax-mcp",
       "type": "skill-md",
       "description": "This skill helps an LLM build correct native Model Context Protocol integrations with @ax-llm/ax. Use when the user asks about AxMCPClient, MCP transports, tools, prompts, resources, subscriptions, tasks, sampling, elicitation, roots, authentication, OAuth, MCP Apps, recording/replay, or MCP integration with AxGen, AxAgent, AxFlow, chat, optimization, and AxEventRuntime.",
       "url": "ax-mcp/SKILL.md",
-      "digest": "sha256:e8fc1a1d91fa9bb11d12f83896db4ef79005eb6406ccabc187c27535b0dd758e"
+      "digest": "sha256:52cd6fbbb317c99803e207c7f28d22d8a8611d1041bed13de595f516a5e8c35f"
     },
     {
       "name": "ax-flow",
       "type": "skill-md",
       "description": "This skill helps an LLM generate correct AxFlow workflow code using @ax-llm/ax. Use when the user asks about flow(), AxFlow, workflow orchestration, parallel execution, DAG workflows, conditional routing, map/reduce patterns, or multi-node AI pipelines.",
       "url": "ax-flow/SKILL.md",
-      "digest": "sha256:62367f88e68221f527c33ea6523a026c9038d2c5a1ec2f5e9cb077f466465939"
+      "digest": "sha256:fab5b14eba0c60c07fa7bd15240d98120f6fc3af2740b02dc919b9c68c200c4a"
     },
     {
       "name": "ax-agent",
       "type": "skill-md",
       "description": "This skill helps an LLM generate correct core AxAgent code using @ax-llm/ax. Use when the user asks about agent(), child agents, namespaced functions, discovery mode, clarification, bubbleErrors, host-side final/clarification protocol, or ordinary agent runtime behavior. For MCP clients, native runtime modules, subscriptions, tasks, or authentication use ax-mcp alongside this skill. For RLM/code-runtime work use ax-agent-rlm; for callbacks and telemetry use ax-agent-observability; for recall/memory/skill loading use ax-agent-memory-skills; for agent.optimize(...) use ax-agent-optimize.",
       "url": "ax-agent/SKILL.md",
-      "digest": "sha256:818970360fa91de22438554c57a33fd83ca763bb32d7d011fba476b96e266759"
+      "digest": "sha256:bc685bbba9ac853efc025418740eff56e48aade5afccd0efe393d56667246049"
     },
     {
       "name": "ax-agent-rlm",
       "type": "skill-md",
       "description": "This skill helps an LLM generate correct AxAgent RLM/runtime code using @ax-llm/ax. Use when the user asks about RLM code execution, AxJSRuntime, contextFields, contextPolicy, liveRuntimeState, promptLevel, stage prompt controls, executorModelPolicy, maxRuntimeChars, agent.test(...), llmQuery(...), recursionOptions, or long-running agent runtime behavior.",
       "url": "ax-agent-rlm/SKILL.md",
-      "digest": "sha256:3a6ebbb8312a0cc09f4746c16f6423545ed210de23091bcd71bf9aba1d718770"
+      "digest": "sha256:e9e3f984b94c35c862b2579e07b4ab3debf052f2ab7870303b197bf51069bf0c"
     },
     {
       "name": "ax-agent-memory-skills",
       "type": "skill-md",
       "description": "This skill helps an LLM generate correct AxAgent memory retrieval, context-map, and dynamic skill-loading code using @ax-llm/ax. Use when the user asks about contextMap, AxAgentContextMap, onMemoriesSearch, memoriesCatalog, recall(...), inputs.memories, onLoadedMemories, onUsedMemories, onSkillsSearch, skillsCatalog, AxAgentCatalogSkill, discover({ skills }), onLoadedSkills, onUsedSkills, preloaded skills, preloading memories at forward time, relevanceRanking hints, loaded memory/skill IDs, or carrying memories across forward() calls.",
       "url": "ax-agent-memory-skills/SKILL.md",
-      "digest": "sha256:68b553800d2fe35784e4ec2327f2117e9843dac3d0f0f15d0e1e4f6b4a1b2fe1"
+      "digest": "sha256:7f86531a141462187b974fa6b08880edd01c9e5785c90b2efc14eb436bfa59f3"
     },
     {
       "name": "ax-agent-observability",
       "type": "skill-md",
       "description": "This skill helps an LLM generate correct AxAgent observability code using @ax-llm/ax. Use when the user asks about axGlobals.onUsage, usageContext, centralized or multi-tenant usage accounting, actorTurnCallback, onContextEvent, agentStatusCallback, onFunctionCall, reportSuccess, reportFailure, getChatLog(), getUsage(), resetUsage(), debug traces, progress updates, or telemetry for AxAgent runs.",
       "url": "ax-agent-observability/SKILL.md",
-      "digest": "sha256:8bd291d8f4abe3f5af8405c461d71b800a0bdee30e15ec803535367e7c2b085f"
+      "digest": "sha256:639cd414acaaad70f798aa7ec95bb510c2f37b36dcc31060ac083add7caf66c7"
     },
     {
       "name": "ax-agent-optimize",
       "type": "skill-md",
       "description": "This skill helps an LLM generate correct AxAgent tuning and evaluation code using @ax-llm/ax. Use when the user asks about agent.optimize(...), judgeOptions, eval datasets, optimization targets, saved optimizedProgram artifacts, or agent optimization guidance.",
       "url": "ax-agent-optimize/SKILL.md",
-      "digest": "sha256:af6715db8ced56acfa2bb6e74c9ea40a69684d2043fe23baf6f84456942018c0"
+      "digest": "sha256:259600165ab0d33f1e609ea6bf94bb629662cbf16334e003d5912642d6ebe240"
     },
     {
       "name": "ax-agent-context",
       "type": "skill-md",
       "description": "This skill helps an LLM pick the right AxAgent context tool for a job - contextMap for recurring corpora, contextPolicy presets for within-run trajectory compaction, agent.optimize for offline GEPA instruction/demo tuning, agent.playbook for an evolving context playbook (offline evolve + online update), and recall/memories + skills for per-turn retrieval. Use when the user asks \"which context feature should I use\", confuses contextMap with contextPolicy or memory, or wants a decision guide for long-context agents. For contextPolicy/contextMap codegen use ax-agent-rlm; for recall/skills use ax-agent-memory-skills; for agent.optimize or agent.playbook use ax-agent-optimize.",
       "url": "ax-agent-context/SKILL.md",
-      "digest": "sha256:64f4b59772864df46300d4eeb43421004908c465e0028b1f1643c63d7789f2d8"
+      "digest": "sha256:a7a9c01fb1aa1e6d9c6dcd36fc1902b581d19caa755ce3d90bb5da10f466ce18"
     },
     {
       "name": "ax-event-runtime",
@@ -104,21 +104,21 @@
       "type": "skill-md",
       "description": "This skill helps an LLM generate correct AxGEPA optimization code using @ax-llm/ax. Use when the user asks about AxGEPA, GEPA, Pareto optimization, multi-objective prompt tuning, reflective prompt evolution, validationExamples, maxMetricCalls, or optimizing a generator, flow, or agent tree.",
       "url": "ax-gepa/SKILL.md",
-      "digest": "sha256:d3ad5a447902a76894e5817841cf45594fa366da2fd371672a395907d516040c"
+      "digest": "sha256:d1bc6ab952ffa13892e5b108c5fceca6ad803a047637f1e269fe023a730bd305"
     },
     {
       "name": "ax-refine",
       "type": "skill-md",
       "description": "Use this skill when writing or reviewing Ax bestOfN/refine code, reward functions, thresholds, native sample selection, serial attempts, generated advice, and attempt diagnostics.",
       "url": "ax-refine/SKILL.md",
-      "digest": "sha256:84ad1bfca1524a078b729eb3f1550d60b8e860175f177a9aa8aa8cded9f09277"
+      "digest": "sha256:57e7a628ad98f39742703bfe09c928c6f1345f739c41c8f82843f145d6514214"
     },
     {
       "name": "ax-playbook",
       "type": "skill-md",
       "description": "This skill helps an LLM generate correct playbook code using @ax-llm/ax. Use when the user asks about playbook(), AxPlaybook, context playbooks, evolving context, ACE / Agentic Context Engineering, agent.playbook(), or growing/applying task knowledge offline and online with evolve() and update().",
       "url": "ax-playbook/SKILL.md",
-      "digest": "sha256:2daa3c1222c329dcd9b8a9e828908872b07b25751e0c451a2965b74625713a13"
+      "digest": "sha256:114a048a1cd86b6808c69421ca94d3a22112636c12408f31ad0f22a2a35c7791"
     }
   ]
 }


### PR DESCRIPTION
`thinkingTokenBudget` carries either a token count or an effort level, and Gemini takes the two in different fields: `thinkingBudget` is an `int32` and rejects a level outright, while `thinkingLevel` is what the Gemini 3 family documents.

The port forwarded both to `thinkingBudget`, so a caller asking for high-effort reasoning got this on **every** request instead of the reasoning it asked for — verified against the live API:

```
HTTP 400 — Invalid value at 'generation_config.thinking_config.thinking_budget' (TYPE_INT32)
```

Before #620 the value never reached the wire at all, so adding that mapping is what armed this. No released configuration sets a level, which is why it went unnoticed.

## The mapping

TypeScript routes the same two shapes the same way — `api.ts:1043` for the count, `:1065` for the level — including its two remappings, which this mirrors:

| `thinkingTokenBudget` | sent as |
|---|---|
| `none` | `thinkingLevel: minimal` — Gemini 3 cannot disable thinking |
| `minimal` / `low` / `medium` / `high` | `thinkingLevel: <same>` |
| `highest` | `thinkingLevel: high` |
| a number | `thinkingBudget: <number>` — unchanged |

## Coverage

`gemini-thinking-level-routes-away-from-the-budget` asserts a level lands in `thinkingLevel`. Validated against the unfixed builder first:

```
panic: gemini-thinking-level-routes-away-from-the-budget: transport request subset mismatch
```

`npm run test:axir` is green; both thinking fixtures run and pass in all five languages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)