### PR TITLE
fix(axir): map Responses forced tool choices

### DIFF
--- a/ir/axcore/provider.axir
+++ b/ir/axcore/provider.axir
@@ -4262,8 +4262,12 @@ module @ax.provider version "0.1" {
           core.append %tools, %tool
         }
         core.set %payload["tools"] = %tools
-        %tool_choice = core.get %request["function_call"] default "auto"
-        core.set %payload["tool_choice"] = %tool_choice
+        %function_call = core.get %request["function_call"] default "auto"
+        %tool_choice = core.call @openai_responses_tool_choice_impl(%function_call)
+        %has_tool_choice = core.call intrinsic.is_not_none(%tool_choice)
+        core.if %has_tool_choice {
+          core.set %payload["tool_choice"] = %tool_choice
+        }
       }
       %response_format = core.get %request["response_format"]
       %has_response_format = core.call intrinsic.truthy(%response_format)
@@ -4363,6 +4367,49 @@ module @ax.provider version "0.1" {
       core.set %tool["description"] = %description
       core.set %tool["parameters"] = %parameters
       core.return %tool
+    }
+  }
+
+  op ax.provider.semantic @openai_responses_tool_choice_impl {
+    attr core_kind = "func"
+    attr emit_module = "ai"
+    attr private = true
+    tag "openai-responses-tool-choice-core-helper"
+    type signature = "(json) -> json"
+    body @entry(%function_call: json) {
+      %is_none = core.call intrinsic.eq(%function_call, "none")
+      core.if %is_none {
+        core.return %function_call
+      }
+      %is_auto = core.call intrinsic.eq(%function_call, "auto")
+      core.if %is_auto {
+        core.return %function_call
+      }
+      %is_required = core.call intrinsic.eq(%function_call, "required")
+      core.if %is_required {
+        core.return %function_call
+      }
+      %is_object = core.type_is %function_call type "object"
+      core.if %is_object {
+        %type = core.get %function_call["type"] default ""
+        %is_function_choice = core.call intrinsic.eq(%type, "function")
+        core.if %is_function_choice {
+          %function = core.get %function_call["function"]
+          %function_is_object = core.type_is %function type "object"
+          core.if %function_is_object {
+            %name = core.get %function["name"]
+            %has_name = core.call intrinsic.truthy(%name)
+            core.if %has_name {
+              %choice = core.map
+              core.set %choice["type"] = "function"
+              core.set %choice["name"] = %name
+              core.return %choice
+            }
+          }
+        }
+      }
+      %none = core.call intrinsic.none()
+      core.return %none
     }
   }
 

--- a/ir/conformance/axai/responses-forced-function-tool-choice.json
+++ b/ir/conformance/axai/responses-forced-function-tool-choice.json
@@ -1,0 +1,104 @@
+{
+  "expected_output": {
+    "model_usage": null,
+    "remote_id": "resp_forced_tool",
+    "results": [
+      {
+        "content": "",
+        "finish_reason": "function_call",
+        "function_calls": [
+          {
+            "function": {
+              "name": "search",
+              "params": {
+                "query": "Search docs"
+              }
+            },
+            "id": "call_forced",
+            "type": "function"
+          }
+        ],
+        "id": "fc_forced",
+        "index": 0
+      }
+    ]
+  },
+  "expected_transport_json_absent": ["tool_choice.function"],
+  "expected_transport_request": {
+    "json": {
+      "tool_choice": {
+        "name": "search",
+        "type": "function"
+      },
+      "tools": [
+        {
+          "description": "Search docs",
+          "name": "search",
+          "parameters": {
+            "properties": {
+              "query": {
+                "type": "string"
+              }
+            },
+            "required": ["query"],
+            "type": "object"
+          },
+          "type": "function"
+        }
+      ]
+    }
+  },
+  "kind": "ai_chat",
+  "name": "responses-forced-function-tool-choice",
+  "provider": "openai-responses",
+  "request": {
+    "chat_prompt": [
+      {
+        "content": "Search docs",
+        "role": "user"
+      }
+    ],
+    "function_call": {
+      "function": {
+        "name": "search"
+      },
+      "type": "function"
+    },
+    "functions": [
+      {
+        "description": "Search docs",
+        "name": "search",
+        "parameters": {
+          "properties": {
+            "query": {
+              "type": "string"
+            }
+          },
+          "required": ["query"],
+          "type": "object"
+        }
+      }
+    ],
+    "model_config": {
+      "stream": false
+    }
+  },
+  "transport_responses": [
+    {
+      "json": {
+        "id": "resp_forced_tool",
+        "model": "gpt-5-mini",
+        "output": [
+          {
+            "arguments": "{\"query\":\"Search docs\"}",
+            "call_id": "call_forced",
+            "id": "fc_forced",
+            "name": "search",
+            "type": "function_call"
+          }
+        ]
+      },
+      "status": 200
+    }
+  ]
+}

--- a/ir/conformance/axgen/structured-output-function-rung-and-legacy-replay.json
+++ b/ir/conformance/axgen/structured-output-function-rung-and-legacy-replay.json
@@ -17,6 +17,12 @@
     }
   ],
   "expected_output": { "answer": "A framework", "confidence": 0.9 },
+  "expected_request": {
+    "function_call": {
+      "type": "function",
+      "function": { "name": "__axOutput" }
+    }
+  },
   "expected_request_contains": [
     "__axOutput",
     "structured_output_rung",

--- a/packages/cpp/axir-provenance.json
+++ b/packages/cpp/axir-provenance.json
@@ -1,11 +1,11 @@
 {
   "target": "cpp",
   "enforced": true,
-  "emitted_functions": 593,
+  "emitted_functions": 594,
   "files": {
     "axllm/axllm.cpp": {
-      "emitted_lines": 24546,
-      "total_lines": 31282
+      "emitted_lines": 24587,
+      "total_lines": 31323
     }
   }
 }

--- a/packages/cpp/axllm/axllm.cpp
+++ b/packages/cpp/axllm/axllm.cpp
@@ -8497,8 +8497,12 @@ Value Core::openai_responses_build_chat_request(Value request) {
       Core::append(tools, tool);
     }
     Core::set(payload, Value("tools"), tools);
-    Value tool_choice = Core::get(request, Value("function_call"), Value("auto"));
-    Core::set(payload, Value("tool_choice"), tool_choice);
+    Value function_call = Core::get(request, Value("function_call"), Value("auto"));
+    Value tool_choice = Core::_openai_responses_tool_choice_impl(function_call);
+    Value has_tool_choice = Core::is_not_none(tool_choice);
+    if (Core::truthy(has_tool_choice)) {
+      Core::set(payload, Value("tool_choice"), tool_choice);
+    }
   }
   Value response_format = Core::get(request, Value("response_format"), Value());
   Value has_response_format = Core::truthy_value(response_format);
@@ -8588,6 +8592,43 @@ Value Core::_openai_responses_tool_spec_impl(Value fn) {
   Core::set(tool, Value("description"), description);
   Core::set(tool, Value("parameters"), parameters);
   return tool;
+}
+
+Value Core::_openai_responses_tool_choice_impl(Value function_call) {
+  axir_coverage_mark("_openai_responses_tool_choice_impl");
+  Value is_none = Core::eq(function_call, Value("none"));
+  if (Core::truthy(is_none)) {
+    return function_call;
+  }
+  Value is_auto = Core::eq(function_call, Value("auto"));
+  if (Core::truthy(is_auto)) {
+    return function_call;
+  }
+  Value is_required = Core::eq(function_call, Value("required"));
+  if (Core::truthy(is_required)) {
+    return function_call;
+  }
+  Value is_object = Core::type_is(function_call, Value("object"));
+  if (Core::truthy(is_object)) {
+    Value type = Core::get(function_call, Value("type"), Value(""));
+    Value is_function_choice = Core::eq(type, Value("function"));
+    if (Core::truthy(is_function_choice)) {
+      Value function = Core::get(function_call, Value("function"), Value());
+      Value function_is_object = Core::type_is(function, Value("object"));
+      if (Core::truthy(function_is_object)) {
+        Value name = Core::get(function, Value("name"), Value());
+        Value has_name = Core::truthy_value(name);
+        if (Core::truthy(has_name)) {
+          Value choice = Value::object();
+          Core::set(choice, Value("type"), Value("function"));
+          Core::set(choice, Value("name"), name);
+          return choice;
+        }
+      }
+    }
+  }
+  Value none = Core::none();
+  return none;
 }
 
 Value Core::_openai_responses_input_item_impl(Value message) {

--- a/packages/cpp/axllm/axllm.hpp
+++ b/packages/cpp/axllm/axllm.hpp
@@ -489,6 +489,7 @@ struct Core {
   static Value openai_responses_build_chat_request(Value request);
   static Value _openai_responses_apply_model_config_impl(Value payload, Value model_config);
   static Value _openai_responses_tool_spec_impl(Value fn);
+  static Value _openai_responses_tool_choice_impl(Value function_call);
   static Value _openai_responses_input_item_impl(Value message);
   static Value _openai_responses_content_parts_impl(Value content, Value role);
   static Value _openai_responses_content_part_impl(Value part, Value role);

--- a/packages/go/axir-provenance.json
+++ b/packages/go/axir-provenance.json
@@ -1,11 +1,11 @@
 {
   "target": "go",
   "enforced": true,
-  "emitted_functions": 593,
+  "emitted_functions": 594,
   "files": {
     "axllm.go": {
-      "emitted_lines": 51268,
-      "total_lines": 63826
+      "emitted_lines": 51354,
+      "total_lines": 63912
     }
   }
 }

--- a/packages/go/axllm.go
+++ b/packages/go/axllm.go
@@ -15134,6 +15134,7 @@ func openai_responses_build_chat_request(args ...Value) (Value, error) {
 	var v_has_reasoning Value
 	var v_has_response_format Value
 	var v_has_thought Value
+	var v_has_tool_choice Value
 	var v_include Value
 	var v_input Value
 	var v_instructions Value
@@ -15188,6 +15189,7 @@ func openai_responses_build_chat_request(args ...Value) (Value, error) {
 	_ = v_has_reasoning
 	_ = v_has_response_format
 	_ = v_has_thought
+	_ = v_has_tool_choice
 	_ = v_include
 	_ = v_input
 	_ = v_instructions
@@ -15296,8 +15298,14 @@ func openai_responses_build_chat_request(args ...Value) (Value, error) {
 			v_tools = coreAppend(v_tools, v_tool)
 		}
 		if err := coreSet(v_payload, "tools", v_tools); err != nil { return nil, err }
-		v_tool_choice = coreGet(v_request, "function_call", "auto")
-		if err := coreSet(v_payload, "tool_choice", v_tool_choice); err != nil { return nil, err }
+		v_function_call = coreGet(v_request, "function_call", "auto")
+		{ v, err := _openai_responses_tool_choice_impl(v_function_call); if err != nil { return nil, err }; v_tool_choice = v }
+		v_has_tool_choice = _core_is_not_none(v_tool_choice)
+		if coreTruthy(v_has_tool_choice) {
+			if err := coreSet(v_payload, "tool_choice", v_tool_choice); err != nil { return nil, err }
+		} else {
+		// empty
+		}
 	} else {
 	// empty
 	}
@@ -15436,6 +15444,84 @@ func _openai_responses_tool_spec_impl(args ...Value) (Value, error) {
 	if err := coreSet(v_tool, "description", v_description); err != nil { return nil, err }
 	if err := coreSet(v_tool, "parameters", v_parameters); err != nil { return nil, err }
 	return v_tool, nil
+}
+
+func _openai_responses_tool_choice_impl(args ...Value) (Value, error) {
+	axirCoverageMark("_openai_responses_tool_choice_impl")
+	var v_function_call Value
+	var v_choice Value
+	var v_function Value
+	var v_function_is_object Value
+	var v_has_name Value
+	var v_is_auto Value
+	var v_is_function_choice Value
+	var v_is_none Value
+	var v_is_object Value
+	var v_is_required Value
+	var v_name Value
+	var v_none Value
+	var v_type Value
+	if len(args) > 0 { v_function_call = args[0] }
+	_ = v_function_call
+	_ = v_choice
+	_ = v_function
+	_ = v_function_is_object
+	_ = v_has_name
+	_ = v_is_auto
+	_ = v_is_function_choice
+	_ = v_is_none
+	_ = v_is_object
+	_ = v_is_required
+	_ = v_name
+	_ = v_none
+	_ = v_type
+	v_is_none = _core_eq(v_function_call, "none")
+	if coreTruthy(v_is_none) {
+		return v_function_call, nil
+	} else {
+	// empty
+	}
+	v_is_auto = _core_eq(v_function_call, "auto")
+	if coreTruthy(v_is_auto) {
+		return v_function_call, nil
+	} else {
+	// empty
+	}
+	v_is_required = _core_eq(v_function_call, "required")
+	if coreTruthy(v_is_required) {
+		return v_function_call, nil
+	} else {
+	// empty
+	}
+	v_is_object = coreTypeIs(v_function_call, "object")
+	if coreTruthy(v_is_object) {
+		v_type = coreGet(v_function_call, "type", "")
+		v_is_function_choice = _core_eq(v_type, "function")
+		if coreTruthy(v_is_function_choice) {
+			v_function = coreGet(v_function_call, "function", nil)
+			v_function_is_object = coreTypeIs(v_function, "object")
+			if coreTruthy(v_function_is_object) {
+				v_name = coreGet(v_function, "name", nil)
+				v_has_name = _core_truthy(v_name)
+				if coreTruthy(v_has_name) {
+					v_choice = Object()
+					if err := coreSet(v_choice, "type", "function"); err != nil { return nil, err }
+					if err := coreSet(v_choice, "name", v_name); err != nil { return nil, err }
+					return v_choice, nil
+				} else {
+				// empty
+				}
+			} else {
+			// empty
+			}
+		} else {
+		// empty
+		}
+	} else {
+	// empty
+	}
+	v_none = _core_none()
+	return v_none, nil
 }
 
 func _openai_responses_input_item_impl(args ...Value) (Value, error) {

--- a/packages/java/axir-provenance.json
+++ b/packages/java/axir-provenance.json
@@ -1,11 +1,11 @@
 {
   "target": "java",
   "enforced": true,
-  "emitted_functions": 593,
+  "emitted_functions": 594,
   "files": {
     "dev/axllm/ax/Core.java": {
-      "emitted_lines": 24575,
-      "total_lines": 25885
+      "emitted_lines": 24616,
+      "total_lines": 25926
     }
   }
 }

--- a/packages/java/dev/axllm/ax/Core.java
+++ b/packages/java/dev/axllm/ax/Core.java
@@ -7428,8 +7428,12 @@ final class Core {
         Core.append(tools, tool);
       }
       Core.set(payload, "tools", tools);
-      Object tool_choice = Core.get(request, "function_call", "auto");
-      Core.set(payload, "tool_choice", tool_choice);
+      Object function_call = Core.get(request, "function_call", "auto");
+      Object tool_choice = Core._openai_responses_tool_choice_impl(function_call);
+      Object has_tool_choice = Core.isNotNone(tool_choice);
+      if (Core.truthy(has_tool_choice)) {
+        Core.set(payload, "tool_choice", tool_choice);
+      }
     }
     Object response_format = Core.get(request, "response_format", null);
     Object has_response_format = Core.truthyValue(response_format);
@@ -7519,6 +7523,43 @@ final class Core {
     Core.set(tool, "description", description);
     Core.set(tool, "parameters", parameters);
     return tool;
+  }
+
+  static Object _openai_responses_tool_choice_impl(Object function_call) {
+    axirCoverageMark("_openai_responses_tool_choice_impl");
+    Object is_none = Core.eq(function_call, "none");
+    if (Core.truthy(is_none)) {
+      return function_call;
+    }
+    Object is_auto = Core.eq(function_call, "auto");
+    if (Core.truthy(is_auto)) {
+      return function_call;
+    }
+    Object is_required = Core.eq(function_call, "required");
+    if (Core.truthy(is_required)) {
+      return function_call;
+    }
+    Object is_object = Core.typeIs(function_call, "object");
+    if (Core.truthy(is_object)) {
+      Object type = Core.get(function_call, "type", "");
+      Object is_function_choice = Core.eq(type, "function");
+      if (Core.truthy(is_function_choice)) {
+        Object function = Core.get(function_call, "function", null);
+        Object function_is_object = Core.typeIs(function, "object");
+        if (Core.truthy(function_is_object)) {
+          Object name = Core.get(function, "name", null);
+          Object has_name = Core.truthyValue(name);
+          if (Core.truthy(has_name)) {
+            Object choice = new java.util.LinkedHashMap<String, Object>();
+            Core.set(choice, "type", "function");
+            Core.set(choice, "name", name);
+            return choice;
+          }
+        }
+      }
+    }
+    Object none = Core.none();
+    return none;
   }
 
   static Object _openai_responses_input_item_impl(Object message) {

--- a/packages/python/axir-provenance.json
+++ b/packages/python/axir-provenance.json
@@ -1,15 +1,15 @@
 {
   "target": "python",
   "enforced": true,
-  "emitted_functions": 593,
+  "emitted_functions": 594,
   "files": {
     "axllm/agent.py": {
       "emitted_lines": 8338,
       "total_lines": 10722
     },
     "axllm/ai.py": {
-      "emitted_lines": 7048,
-      "total_lines": 9633
+      "emitted_lines": 7097,
+      "total_lines": 9682
     },
     "axllm/flow.py": {
       "emitted_lines": 2287,

--- a/packages/python/axllm/ai.py
+++ b/packages/python/axllm/ai.py
@@ -6900,8 +6900,13 @@ def openai_responses_build_chat_request(request: AxChatRequest) -> Any:
             tool = _openai_responses_tool_spec_impl(fn)
             tools.append(tool)
         payload["tools"] = tools
-        tool_choice = _core_get(request, "function_call", "auto")
-        payload["tool_choice"] = tool_choice
+        function_call = _core_get(request, "function_call", "auto")
+        tool_choice = _openai_responses_tool_choice_impl(function_call)
+        has_tool_choice = _core_is_not_none(tool_choice)
+        if has_tool_choice:
+            payload["tool_choice"] = tool_choice
+        else:
+            pass
     else:
         pass
     response_format = _core_get(request, "response_format", None)
@@ -6994,6 +6999,50 @@ def _openai_responses_tool_spec_impl(fn: Any) -> Any:
     tool["description"] = description
     tool["parameters"] = parameters
     return tool
+
+
+def _openai_responses_tool_choice_impl(function_call: Any) -> Any:
+    _core_coverage_mark("_openai_responses_tool_choice_impl")
+    is_none = _core_eq(function_call, "none")
+    if is_none:
+        return function_call
+    else:
+        pass
+    is_auto = _core_eq(function_call, "auto")
+    if is_auto:
+        return function_call
+    else:
+        pass
+    is_required = _core_eq(function_call, "required")
+    if is_required:
+        return function_call
+    else:
+        pass
+    is_object = _core_type_is(function_call, "object")
+    if is_object:
+        type = _core_get(function_call, "type", "")
+        is_function_choice = _core_eq(type, "function")
+        if is_function_choice:
+            function = _core_get(function_call, "function", None)
+            function_is_object = _core_type_is(function, "object")
+            if function_is_object:
+                name = _core_get(function, "name", None)
+                has_name = _core_truthy(name)
+                if has_name:
+                    choice = {}
+                    choice["type"] = "function"
+                    choice["name"] = name
+                    return choice
+                else:
+                    pass
+            else:
+                pass
+        else:
+            pass
+    else:
+        pass
+    none = _core_none()
+    return none
 
 
 def _openai_responses_input_item_impl(message: Any) -> Any:

--- a/packages/rust/axir-provenance.json
+++ b/packages/rust/axir-provenance.json
@@ -1,11 +1,11 @@
 {
   "target": "rust",
   "enforced": true,
-  "emitted_functions": 593,
+  "emitted_functions": 594,
   "files": {
     "src/lib.rs": {
-      "emitted_lines": 56628,
-      "total_lines": 80711
+      "emitted_lines": 56702,
+      "total_lines": 80785
     }
   }
 }

--- a/packages/rust/src/lib.rs
+++ b/packages/rust/src/lib.rs
@@ -38302,6 +38302,7 @@ fn openai_responses_build_chat_request(args: &[CoreValue]) -> Result<CoreValue, 
     let mut v_has_reasoning = CoreValue::Null;
     let mut v_has_response_format = CoreValue::Null;
     let mut v_has_thought = CoreValue::Null;
+    let mut v_has_tool_choice = CoreValue::Null;
     let mut v_include = CoreValue::Null;
     let mut v_input = CoreValue::Null;
     let mut v_instructions = CoreValue::Null;
@@ -38452,16 +38453,20 @@ fn openai_responses_build_chat_request(args: &[CoreValue]) -> Result<CoreValue, 
             core_append(&v_tools, v_tool.clone())?;
         }
         core_set(&v_payload, CoreValue::from("tools"), v_tools.clone())?;
-        v_tool_choice = core_get(
+        v_function_call = core_get(
             &v_request,
             &CoreValue::from("function_call"),
             CoreValue::from("auto"),
         );
-        core_set(
-            &v_payload,
-            CoreValue::from("tool_choice"),
-            v_tool_choice.clone(),
-        )?;
+        v_tool_choice = _openai_responses_tool_choice_impl(&[v_function_call.clone()])?;
+        v_has_tool_choice = core_is_not_none(&[v_tool_choice.clone()])?;
+        if core_truthy(&v_has_tool_choice) {
+            core_set(
+                &v_payload,
+                CoreValue::from("tool_choice"),
+                v_tool_choice.clone(),
+            )?;
+        }
     }
     v_response_format = core_get(
         &v_request,
@@ -38697,6 +38702,75 @@ fn _openai_responses_tool_spec_impl(args: &[CoreValue]) -> Result<CoreValue, AxE
     )?;
     core_set(&v_tool, CoreValue::from("parameters"), v_parameters.clone())?;
     return Ok(v_tool.clone());
+}
+
+#[allow(
+    unused_variables,
+    unused_assignments,
+    unused_mut,
+    unreachable_code,
+    clippy::all
+)]
+fn _openai_responses_tool_choice_impl(args: &[CoreValue]) -> Result<CoreValue, AxError> {
+    axir_coverage_mark("_openai_responses_tool_choice_impl");
+    let mut v_function_call = core_arg(args, 0);
+    let mut v_choice = CoreValue::Null;
+    let mut v_function = CoreValue::Null;
+    let mut v_function_is_object = CoreValue::Null;
+    let mut v_has_name = CoreValue::Null;
+    let mut v_is_auto = CoreValue::Null;
+    let mut v_is_function_choice = CoreValue::Null;
+    let mut v_is_none = CoreValue::Null;
+    let mut v_is_object = CoreValue::Null;
+    let mut v_is_required = CoreValue::Null;
+    let mut v_name = CoreValue::Null;
+    let mut v_none = CoreValue::Null;
+    let mut v_type = CoreValue::Null;
+    v_is_none = core_eq(&[v_function_call.clone(), CoreValue::from("none")])?;
+    if core_truthy(&v_is_none) {
+        return Ok(v_function_call.clone());
+    }
+    v_is_auto = core_eq(&[v_function_call.clone(), CoreValue::from("auto")])?;
+    if core_truthy(&v_is_auto) {
+        return Ok(v_function_call.clone());
+    }
+    v_is_required = core_eq(&[v_function_call.clone(), CoreValue::from("required")])?;
+    if core_truthy(&v_is_required) {
+        return Ok(v_function_call.clone());
+    }
+    v_is_object = core_type_is(&v_function_call, CoreValue::from("object"));
+    if core_truthy(&v_is_object) {
+        v_type = core_get(
+            &v_function_call,
+            &CoreValue::from("type"),
+            CoreValue::from(""),
+        );
+        v_is_function_choice = core_eq(&[v_type.clone(), CoreValue::from("function")])?;
+        if core_truthy(&v_is_function_choice) {
+            v_function = core_get(
+                &v_function_call,
+                &CoreValue::from("function"),
+                CoreValue::Null,
+            );
+            v_function_is_object = core_type_is(&v_function, CoreValue::from("object"));
+            if core_truthy(&v_function_is_object) {
+                v_name = core_get(&v_function, &CoreValue::from("name"), CoreValue::Null);
+                v_has_name = core_truthy_value(&[v_name.clone()])?;
+                if core_truthy(&v_has_name) {
+                    v_choice = CoreValue::new_map();
+                    core_set(
+                        &v_choice,
+                        CoreValue::from("type"),
+                        CoreValue::from("function"),
+                    )?;
+                    core_set(&v_choice, CoreValue::from("name"), v_name.clone())?;
+                    return Ok(v_choice.clone());
+                }
+            }
+        }
+    }
+    v_none = core_none(&[])?;
+    return Ok(v_none.clone());
 }
 
 #[allow(
@@ -80707,4 +80781,4 @@ fn mcp_oauth_validate_issuer(args: &[CoreValue]) -> Result<CoreValue, AxError> {
     return Ok(v_out.clone());
 }
 
-// END AXIR CORE EMITTED FUNCTIONS (593 of 593 core functions)
+// END AXIR CORE EMITTED FUNCTIONS (594 of 594 core functions)

--- a/tools/axir/extractors/axai-goldens.ts
+++ b/tools/axir/extractors/axai-goldens.ts
@@ -3305,6 +3305,85 @@ writeFixture('responses-tool-call', {
   },
 });
 
+writeFixture('responses-forced-function-tool-choice', {
+  kind: 'ai_chat',
+  provider: 'openai-responses',
+  request: {
+    chat_prompt: [{ role: 'user', content: 'Search docs' }],
+    functions: [
+      {
+        name: 'search',
+        description: 'Search docs',
+        parameters: {
+          type: 'object',
+          properties: { query: { type: 'string' } },
+          required: ['query'],
+        },
+      },
+    ],
+    function_call: {
+      type: 'function',
+      function: { name: 'search' },
+    },
+    model_config: { stream: false },
+  },
+  transport_responses: [
+    {
+      status: 200,
+      json: {
+        id: 'resp_forced_tool',
+        model: responsesDefaultModel,
+        output: [
+          {
+            id: 'fc_forced',
+            type: 'function_call',
+            call_id: 'call_forced',
+            name: 'search',
+            arguments: '{"query":"Search docs"}',
+          },
+        ],
+      },
+    },
+  ],
+  expected_output: {
+    results: [
+      {
+        index: 0,
+        id: 'fc_forced',
+        content: '',
+        function_calls: [
+          {
+            id: 'call_forced',
+            type: 'function',
+            function: { name: 'search', params: { query: 'Search docs' } },
+          },
+        ],
+        finish_reason: 'function_call',
+      },
+    ],
+    remote_id: 'resp_forced_tool',
+    model_usage: null,
+  },
+  expected_transport_request: {
+    json: {
+      tools: [
+        {
+          type: 'function',
+          name: 'search',
+          description: 'Search docs',
+          parameters: {
+            type: 'object',
+            properties: { query: { type: 'string' } },
+            required: ['query'],
+          },
+        },
+      ],
+      tool_choice: { type: 'function', name: 'search' },
+    },
+  },
+  expected_transport_json_absent: ['tool_choice.function'],
+});
+
 writeFixture('responses-streaming-text', {
   kind: 'ai_stream',
   provider: 'openai-responses',


### PR DESCRIPTION
## Summary
- preserve the canonical nested AxChatRequest function choice used by Chat
- flatten forced function choices only for the OpenAI Responses wire payload
- omit malformed object choices instead of emitting invalid JSON
- add exact AxGen and Responses conformance coverage across Python, Go, Java, C++, and Rust

## Validation
- npm run axir:conformance:check
- npm run axir:check-packages
- npm run test:axir
- npm run axir:semantic-parity
- npm run axir:backlog:validate
- npx vitest run src/ax/dsp/generate.fallback-function.test.ts
- npm run test:examples:generated
- npm run website:prepare
- npm run website:check
- git diff --check

Generated packages were regenerated twice with identical output. No public API, examples, capability claims, or documentation prose changed.