### PR TITLE
fix(util): share SSE parsing across runtimes

### DIFF
--- a/src/ax/util/apicall.test.ts
+++ b/src/ax/util/apicall.test.ts
@@ -555,26 +555,32 @@ describe('apiCall', () => {
     });
   });
 
-  describe('browser SSE streaming', () => {
-    // apicall.ts switches to its browser-optimized SSE reader when both
-    // `window` and `EventSource` are defined. Vitest runs in a node
-    // environment, so stub them to reach that branch.
-    const stubBrowserGlobals = () => {
-      vi.stubGlobal('window', {});
-      vi.stubGlobal('EventSource', vi.fn());
+  describe.each([
+    ['Node', false],
+    ['browser', true],
+  ] as const)('%s SSE streaming', (_runtime, browser) => {
+    const configureRuntime = () => {
+      if (browser) {
+        vi.stubGlobal('window', {});
+        vi.stubGlobal('EventSource', vi.fn());
+      }
     };
 
     afterEach(() => {
       vi.unstubAllGlobals();
     });
 
-    const sseResponse = (events: string | string[]): Response => {
+    const sseResponse = (
+      events: string | Array<string | Uint8Array>
+    ): Response => {
       const body = Array.isArray(events)
         ? new ReadableStream<Uint8Array>({
             start(controller) {
               const encoder = new TextEncoder();
               for (const event of events) {
-                controller.enqueue(encoder.encode(event));
+                controller.enqueue(
+                  typeof event === 'string' ? encoder.encode(event) : event
+                );
               }
               controller.close();
             },
@@ -587,7 +593,10 @@ describe('apiCall', () => {
       });
     };
 
-    const collectStream = async (events: string | string[]) => {
+    const collectStream = async (
+      events: string | Array<string | Uint8Array>
+    ) => {
+      configureRuntime();
       const mockFetch = vi.fn().mockResolvedValue(sseResponse(events));
 
       const stream = (await apiCall<{ test: string }, { index: number }>(
@@ -612,16 +621,12 @@ describe('apiCall', () => {
     };
 
     it('ends the stream when the provider sends no [DONE] sentinel', async () => {
-      stubBrowserGlobals();
-
       await expect(
         collectStream('data: {"index":0}\n\ndata: {"index":1}\n\n')
       ).resolves.toEqual([{ index: 0 }, { index: 1 }]);
     });
 
     it('ends the stream when the last event has no trailing blank line', async () => {
-      stubBrowserGlobals();
-
       await expect(
         collectStream('data: {"index":0}\n\ndata: {"index":1}')
       ).resolves.toEqual([{ index: 0 }, { index: 1 }]);
@@ -631,28 +636,20 @@ describe('apiCall', () => {
       ['terminated by a blank line', 'data: [DONE]\n\n'],
       ['sent as a trailing event', 'data: [DONE]'],
     ])('stops at the [DONE] sentinel %s', async (_label, sentinel) => {
-      stubBrowserGlobals();
-
       await expect(
         collectStream(`data: {"index":0}\n\ndata: {"index":1}\n\n${sentinel}`)
       ).resolves.toEqual([{ index: 0 }, { index: 1 }]);
     });
 
-    // The SSE spec allows \r\n line endings, and the Node SSEParser path in
-    // this same file normalizes them. Without normalization here the event
-    // boundary is never found, the buffer grows for the whole response, and
-    // only the last data: line of that one giant event survives.
+    // The SSE spec allows \r\n line endings. Without normalization the event
+    // boundary is never found and the buffer grows for the whole response.
     it('splits events on \\r\\n\\r\\n boundaries', async () => {
-      stubBrowserGlobals();
-
       await expect(
         collectStream('data: {"index":0}\r\n\r\ndata: {"index":1}\r\n\r\n')
       ).resolves.toEqual([{ index: 0 }, { index: 1 }]);
     });
 
     it('keeps CRLF boundaries whole when split across chunks', async () => {
-      stubBrowserGlobals();
-
       await expect(
         collectStream([
           'data: {"index":0}\r',
@@ -665,39 +662,41 @@ describe('apiCall', () => {
     });
 
     it('splits events on bare \\r boundaries', async () => {
-      stubBrowserGlobals();
-
       await expect(
         collectStream('data: {"index":0}\r\rdata: {"index":1}\r')
       ).resolves.toEqual([{ index: 0 }, { index: 1 }]);
     });
 
-    // The spec concatenates repeated data: fields with \n, which is how the
-    // Node SSEParser path already behaves.
+    // The spec concatenates repeated data: fields with \n.
     it('concatenates multi-line data fields', async () => {
-      stubBrowserGlobals();
-
       await expect(
         collectStream('data: {"index":\ndata: 0}\n\n')
       ).resolves.toEqual([{ index: 0 }]);
     });
 
-    // The space after the colon is optional in the SSE spec, and the Node
-    // SSEParser path accepts either form.
+    // The space after the colon is optional in the SSE spec.
     it('accepts data fields with no space after the colon', async () => {
-      stubBrowserGlobals();
-
       await expect(
         collectStream('data:{"index":0}\n\ndata:{"index":1}\n\n')
       ).resolves.toEqual([{ index: 0 }, { index: 1 }]);
     });
 
     it('stops at a [DONE] sentinel sent with \\r\\n line endings', async () => {
-      stubBrowserGlobals();
-
       await expect(
         collectStream('data: {"index":0}\r\n\r\ndata: [DONE]\r\n\r\n')
       ).resolves.toEqual([{ index: 0 }]);
+    });
+
+    it('decodes every UTF-8 byte boundary through the shared parser', async () => {
+      const body =
+        '\uFEFFdata: {"label":"snowman ☃",\r\ndata: "index":0}\r\n\r\ndata: [DONE]\r\n\r\n';
+      const chunks = Array.from(new TextEncoder().encode(body), (byte) =>
+        Uint8Array.of(byte)
+      );
+
+      await expect(collectStream(chunks)).resolves.toEqual([
+        { label: 'snowman ☃', index: 0 },
+      ]);
     });
   });
 });

--- a/src/ax/util/apicall.ts
+++ b/src/ax/util/apicall.ts
@@ -929,212 +929,38 @@ export const apiCall = async <TRequest = unknown, TResponse = unknown>(
       let lastChunk: TResponse | undefined;
       let chunkCount = 0;
 
-      // Detect if we're in a browser environment with EventSource support
-      const isBrowser =
-        typeof window !== 'undefined' && typeof EventSource !== 'undefined';
-
-      if (isBrowser) {
-        // Use browser-optimized SSE parsing that mimics EventSource behavior
-        // We can't use EventSource directly because:
-        // 1. It only supports GET requests (we need POST for LLM APIs)
-        // 2. It doesn't support custom headers (needed for auth)
-        // 3. It doesn't support request bodies (needed for prompts/config)
-        return new ReadableStream<TResponse>({
-          start(controller) {
-            const reader = res.body!.getReader();
-            const decoder = new TextDecoder();
-            let buffer = '';
-
-            // The SSE spec allows \r\n and \r line endings; the Node
-            // SSEParser path in this file normalizes them, so this one must
-            // too or a \r\n\r\n frame boundary is never found and the buffer
-            // grows for the whole response. A trailing \r may be the first
-            // half of a \r\n split across chunk boundaries, so hold it back
-            // until the next chunk shows what follows it; at end of stream
-            // nothing follows, so it is a terminator in its own right.
-            const normalizeBuffer = (isFinal: boolean): void => {
-              let pendingCarriageReturn = '';
-              if (!isFinal && buffer.endsWith('\r')) {
-                buffer = buffer.slice(0, -1);
-                pendingCarriageReturn = '\r';
-              }
-              buffer = buffer.replace(/\r\n|\r/g, '\n') + pendingCarriageReturn;
-            };
-
-            // Returns true if the caller should stop reading (e.g. saw [DONE]).
-            const processEvent = (event: string): boolean => {
-              if (!event.trim()) return false;
-
-              const lines = event.split('\n');
-              const dataLines: string[] = [];
-              let eventType = 'message';
-
-              for (const line of lines) {
-                // Comment line.
-                if (line.startsWith(':')) continue;
-
-                const colonIndex = line.indexOf(':');
-                if (colonIndex === -1) continue;
-
-                const field = line.slice(0, colonIndex);
-                let value = line.slice(colonIndex + 1);
-                // A single space after the colon is part of the delimiter,
-                // and `data:{...}` with no space at all is valid.
-                if (value.startsWith(' ')) value = value.slice(1);
-
-                if (field === 'data') {
-                  // Repeated data fields are one payload joined with \n, the
-                  // same way the Node SSEParser path assembles them.
-                  dataLines.push(value);
-                } else if (field === 'event') {
-                  eventType = value;
-                }
-              }
-
-              const data = dataLines.join('\n');
-              if (!data) return false;
-
-              if (data.trim() === '[DONE]') {
-                controller.close();
-                return true;
-              }
-
-              try {
-                const parsed = JSON.parse(data) as TResponse;
-                lastChunk = parsed;
-                chunkCount++;
-                metrics.streamChunks = chunkCount;
-                metrics.lastChunkTime = Date.now();
-
-                controller.enqueue(parsed);
-
-                api.span?.addEvent('stream.chunk', {
-                  'stream.chunks': chunkCount,
-                  'stream.duration': Date.now() - metrics.startTime,
-                  'response.retries': metrics.retryCount,
-                  'sse.event.type': eventType,
-                });
-              } catch (parseError) {
-                if (verbose) {
-                  console.warn('Skipping non-JSON SSE data:', data, parseError);
-                }
-              }
-              return false;
-            };
-
-            async function read() {
-              try {
-                while (true) {
-                  const { done, value } = await reader.read();
-                  if (done) {
-                    normalizeBuffer(true);
-                    // Flush any trailing event that wasn't terminated by \n\n.
-                    // Providers are allowed to end the stream without a final
-                    // blank line; the Node SSEParser path handles this via
-                    // handleFlush, so match that behavior here.
-                    let sawDone = false;
-                    if (buffer.length > 0) {
-                      sawDone = processEvent(buffer);
-                      buffer = '';
-                    }
-                    // processEvent already closed the controller if it saw
-                    // the [DONE] sentinel, so only close it here if it did not.
-                    if (!sawDone) {
-                      controller.close();
-                    }
-                    break;
-                  }
-
-                  buffer += decoder.decode(value, { stream: true });
-                  normalizeBuffer(false);
-
-                  const events = buffer.split('\n\n');
-                  buffer = events.pop() || '';
-
-                  for (const event of events) {
-                    if (processEvent(event)) return;
-                  }
-                }
-              } catch (e) {
-                const error = e as Error;
-                const streamMetrics = {
-                  ...metrics,
-                  streamDuration: Date.now() - metrics.startTime,
-                };
-
-                if (
-                  error.name === 'AbortError' ||
-                  error.message?.includes('aborted')
-                ) {
-                  controller.error(
-                    api.abortSignal?.aborted
-                      ? new AxAIServiceAbortedError(
-                          apiUrl.href,
-                          api.abortSignal.reason,
-                          json,
-                          { streamMetrics },
-                          includeBodyInErrors
-                        )
-                      : new AxAIServiceStreamTerminatedError(
-                          apiUrl.href,
-                          json,
-                          lastChunk,
-                          { streamMetrics },
-                          includeBodyInErrors
-                        )
-                  );
-                } else {
-                  controller.error(
-                    new AxAIServiceNetworkError(
-                      error,
-                      apiUrl.href,
-                      json,
-                      '[ReadableStream - consumed during streaming]',
-                      {
-                        streamMetrics,
-                      },
-                      includeBodyInErrors
-                    )
-                  );
-                }
-              } finally {
-                reader.releaseLock();
-              }
-            }
-
-            read();
-          },
-        });
-      }
-      // Use the existing Node.js SSEParser for server-side environments
-      const trackingStream = new TransformStream<TResponse, TResponse>({
-        transform(chunk, controller) {
-          lastChunk = chunk;
-          chunkCount++;
-          metrics.streamChunks = chunkCount;
-          metrics.lastChunkTime = Date.now();
-
-          controller.enqueue(chunk);
-
-          api.span?.addEvent('stream.chunk', {
-            'stream.chunks': chunkCount,
-            'stream.duration': Date.now() - metrics.startTime,
-            'response.retries': metrics.retryCount,
-          });
-        },
-      });
-
       // Flag to track if the controller is closed.
       let closed = false;
+      let streamReader: ReadableStreamDefaultReader<TResponse> | undefined;
 
       // Enhanced wrapped stream
       return new ReadableStream<TResponse>({
         start(controller) {
           const reader = res
             .body!.pipeThrough(new textDecoderStream())
-            .pipeThrough(new SSEParser<TResponse>())
-            .pipeThrough(trackingStream)
+            .pipeThrough(
+              new SSEParser<TResponse>({
+                // Ax accepts a final provider event without the SSE blank-line
+                // terminator. Keep that compatibility behavior identical in
+                // browsers and server runtimes.
+                emitIncompleteEventOnEof: true,
+                onEvent(chunk, event) {
+                  lastChunk = chunk;
+                  chunkCount++;
+                  metrics.streamChunks = chunkCount;
+                  metrics.lastChunkTime = Date.now();
+
+                  api.span?.addEvent('stream.chunk', {
+                    'stream.chunks': chunkCount,
+                    'stream.duration': Date.now() - metrics.startTime,
+                    'response.retries': metrics.retryCount,
+                    'sse.event.type': event.event,
+                  });
+                },
+              })
+            )
             .getReader();
+          streamReader = reader;
 
           async function read() {
             try {
@@ -1153,6 +979,8 @@ export const apiCall = async <TRequest = unknown, TResponse = unknown>(
                 controller.enqueue(value);
               }
             } catch (e) {
+              if (closed) return;
+
               const error = e as Error;
               const streamMetrics = {
                 ...metrics,
@@ -1215,14 +1043,16 @@ export const apiCall = async <TRequest = unknown, TResponse = unknown>(
                 clearTimeout(timeoutId);
               }
               reader.releaseLock();
+              if (streamReader === reader) streamReader = undefined;
             }
           }
 
           read();
         },
         // When the consumer cancels the stream, set our flag to stop processing further.
-        cancel() {
+        cancel(reason) {
           closed = true;
+          return streamReader?.cancel(reason);
         },
       });
     } catch (error) {

--- a/src/ax/util/sse.test.ts
+++ b/src/ax/util/sse.test.ts
@@ -2,12 +2,18 @@ import { describe, expect, it } from 'vitest';
 
 import { SSEParser } from './sse.js';
 
-const parse = async (chunks: string[]) => {
+interface ParseOptions<T> {
+  dataParser?: (data: string) => T;
+  emitIncompleteEventOnEof?: boolean;
+}
+
+const parse = async <T = unknown>(
+  chunks: string[],
+  options: ParseOptions<T> = {}
+) => {
   const source = new ReadableStream<string>({
     start(controller) {
-      for (const chunk of chunks) {
-        controller.enqueue(chunk);
-      }
+      for (const chunk of chunks) controller.enqueue(chunk);
       controller.close();
     },
   });
@@ -15,7 +21,8 @@ const parse = async (chunks: string[]) => {
   const dropped: string[] = [];
   const reader = source
     .pipeThrough(
-      new SSEParser<unknown>({
+      new SSEParser<T>({
+        ...options,
         onError: (_error, rawData) => {
           dropped.push(rawData);
         },
@@ -23,12 +30,10 @@ const parse = async (chunks: string[]) => {
     )
     .getReader();
 
-  const events: unknown[] = [];
+  const events: T[] = [];
   while (true) {
     const { done, value } = await reader.read();
-    if (done) {
-      break;
-    }
+    if (done) break;
     events.push(value);
   }
 
@@ -51,6 +56,13 @@ describe('SSEParser', () => {
     ).resolves.toEqual({ events: [{ index: 0 }], dropped: [] });
   });
 
+  it('emits a provider-compatible final event without a line terminator', async () => {
+    await expect(parse(['data: {"index":0}'])).resolves.toEqual({
+      events: [{ index: 0 }],
+      dropped: [],
+    });
+  });
+
   // Guards the flush path: at end of stream there is no following \n, so a
   // bare trailing \r is a real line terminator and must still be parsed.
   it('emits a trailing event terminated only by a bare \\r', async () => {
@@ -58,5 +70,66 @@ describe('SSEParser', () => {
       events: [{ index: 0 }],
       dropped: [],
     });
+  });
+
+  it('can discard an incomplete final event in strict SSE mode', async () => {
+    await expect(
+      parse(['data: {"index":0}\n'], { emitIncompleteEventOnEof: false })
+    ).resolves.toEqual({ events: [], dropped: [] });
+  });
+
+  it('preserves SSE field whitespace and empty data lines', async () => {
+    const dataParser = (data: string) => data;
+
+    await expect(
+      parse(['data:\ndata:  value  \n\n'], { dataParser })
+    ).resolves.toEqual({ events: ['\n value  '], dropped: [] });
+  });
+
+  it('compares field names literally and ignores unknown colonless fields', async () => {
+    await expect(
+      parse([' data: {"ignored":true}\nunknown\n\ndata: {"index":0}\n\n'])
+    ).resolves.toEqual({ events: [{ index: 0 }], dropped: [] });
+  });
+
+  it('processes a colonless data field as an empty data value', async () => {
+    await expect(
+      parse(['data\n\n'], { dataParser: (data) => data })
+    ).resolves.toEqual({ events: [''], dropped: [] });
+  });
+
+  it('strips one leading BOM before parsing fields', async () => {
+    await expect(parse(['\uFEFFdata: {"index":0}\n\n'])).resolves.toEqual({
+      events: [{ index: 0 }],
+      dropped: [],
+    });
+  });
+
+  it('terminates and cancels the upstream stream at [DONE]', async () => {
+    let resolveCancelled: (() => void) | undefined;
+    const cancelled = new Promise<void>((resolve) => {
+      resolveCancelled = resolve;
+    });
+    const source = new ReadableStream<string>({
+      start(controller) {
+        controller.enqueue(
+          'data: {"index":0}\n\ndata: [DONE]\n\ndata: {"index":1}\n\n'
+        );
+      },
+      cancel() {
+        resolveCancelled?.();
+      },
+    });
+    const reader = source.pipeThrough(new SSEParser()).getReader();
+
+    await expect(reader.read()).resolves.toEqual({
+      done: false,
+      value: { index: 0 },
+    });
+    await expect(reader.read()).resolves.toEqual({
+      done: true,
+      value: undefined,
+    });
+    await expect(cancelled).resolves.toBeUndefined();
   });
 });

--- a/src/ax/util/sse.test.ts
+++ b/src/ax/util/sse.test.ts
@@ -86,13 +86,13 @@ describe('SSEParser', () => {
     ).resolves.toEqual({ events: ['\n value  '], dropped: [] });
   });
 
-  it('compares field names literally and ignores unknown colonless fields', async () => {
+  it('compares field names literally and ignores unknown fields without colons', async () => {
     await expect(
       parse([' data: {"ignored":true}\nunknown\n\ndata: {"index":0}\n\n'])
     ).resolves.toEqual({ events: [{ index: 0 }], dropped: [] });
   });
 
-  it('processes a colonless data field as an empty data value', async () => {
+  it('processes a data field without a colon as an empty value', async () => {
     await expect(
       parse(['data\n\n'], { dataParser: (data) => data })
     ).resolves.toEqual({ events: [''], dropped: [] });

--- a/src/ax/util/sse.ts
+++ b/src/ax/util/sse.ts
@@ -2,21 +2,38 @@
 
 interface CurrentEventState {
   event?: string;
-  rawData: string;
-  id?: string;
+  dataLines: string[];
+}
+
+interface SSEEventMetadata {
+  event: string;
+  id: string;
   retry?: number;
 }
 
 interface SSEParserOptions<T> {
   dataParser?: (data: string) => T;
   onError?: (error: Error, rawData: string) => void;
+  onEvent?: (data: T, metadata: SSEEventMetadata) => void;
+  /**
+   * Provider streams occasionally omit the final SSE blank line. Keep Ax's
+   * compatibility behavior by default, while allowing strict SSE consumers to
+   * discard the incomplete final event as required by the HTML standard.
+   */
+  emitIncompleteEventOnEof?: boolean;
 }
 
 export class SSEParser<T = unknown> extends TransformStream<string, T> {
   private buffer = '';
-  private currentEvent: CurrentEventState = { rawData: '' };
+  private currentEvent: CurrentEventState = { dataLines: [] };
   private dataParser: (data: string) => T;
   private onError: (error: Error, rawData: string) => void;
+  private onEvent?: (data: T, metadata: SSEEventMetadata) => void;
+  private emitIncompleteEventOnEof: boolean;
+  private lastEventId = '';
+  private retry?: number;
+  private atStart = true;
+  private terminated = false;
 
   constructor(options: SSEParserOptions<T> = {}) {
     super({
@@ -31,6 +48,8 @@ export class SSEParser<T = unknown> extends TransformStream<string, T> {
         console.warn('Failed to parse event data:', error);
         console.log('Raw data that failed to parse:', rawData);
       });
+    this.onEvent = options.onEvent;
+    this.emitIncompleteEventOnEof = options.emitIncompleteEventOnEof ?? true;
   }
 
   private handleChunk(
@@ -38,12 +57,36 @@ export class SSEParser<T = unknown> extends TransformStream<string, T> {
     controller: TransformStreamDefaultController<T>
   ): void {
     this.buffer += chunk;
+    if (this.atStart && this.buffer.length > 0) {
+      this.atStart = false;
+      if (this.buffer.startsWith('\uFEFF')) {
+        this.buffer = this.buffer.slice(1);
+      }
+    }
     this.processBuffer(controller);
   }
 
   private handleFlush(controller: TransformStreamDefaultController<T>): void {
+    if (this.terminated) return;
+
     this.processBuffer(controller, true);
-    if (this.currentEvent.rawData) {
+    if (this.terminated) return;
+
+    if (!this.emitIncompleteEventOnEof) {
+      this.buffer = '';
+      this.currentEvent = { dataLines: [] };
+      return;
+    }
+
+    // Ax provider streams have historically accepted a final event without
+    // the spec's terminating blank line. Treat any residual text as its final
+    // line, then dispatch the pending event so browser and server runtimes
+    // behave identically.
+    if (this.buffer.length > 0) {
+      this.parseLine(this.buffer);
+      this.buffer = '';
+    }
+    if (this.currentEvent.dataLines.length > 0) {
       this.processEvent(controller);
     }
   }
@@ -66,14 +109,13 @@ export class SSEParser<T = unknown> extends TransformStream<string, T> {
       pendingCarriageReturn = '\r';
     }
 
-    // Normalize newlines to \n
     const normalizedBuffer = pendingBuffer.replace(/\r\n|\r/g, '\n');
     const lines = normalizedBuffer.split('\n');
     this.buffer = (lines.pop() || '') + pendingCarriageReturn;
 
     for (const line of lines) {
       if (line === '') {
-        this.processEvent(controller);
+        if (this.processEvent(controller)) return;
       } else {
         this.parseLine(line);
       }
@@ -81,68 +123,63 @@ export class SSEParser<T = unknown> extends TransformStream<string, T> {
   }
 
   private parseLine(line: string): void {
-    if (line.startsWith(':')) {
-      return; // Ignore comment lines
-    }
+    if (line.startsWith(':')) return;
 
     const colonIndex = line.indexOf(':');
-    if (colonIndex === -1) {
-      this.currentEvent.rawData +=
-        (this.currentEvent.rawData && !this.currentEvent.rawData.endsWith('\n')
-          ? '\n'
-          : '') + line.trim();
-      return;
-    }
-
-    const field = line.slice(0, colonIndex).trim();
-    const value = line.slice(colonIndex + 1).trim();
+    const field = colonIndex === -1 ? line : line.slice(0, colonIndex);
+    let value = colonIndex === -1 ? '' : line.slice(colonIndex + 1);
+    // SSE removes at most one U+0020 after the colon. Other leading and
+    // trailing whitespace is data and must be preserved.
+    if (value.startsWith(' ')) value = value.slice(1);
 
     switch (field) {
       case 'event':
         this.currentEvent.event = value;
         break;
       case 'data':
-        this.currentEvent.rawData +=
-          (this.currentEvent.rawData &&
-          !this.currentEvent.rawData.endsWith('\n')
-            ? '\n'
-            : '') + value;
+        this.currentEvent.dataLines.push(value);
         break;
       case 'id':
-        this.currentEvent.id = value;
+        if (!value.includes('\0')) this.lastEventId = value;
         break;
-      case 'retry': {
-        const retryValue = Number.parseInt(value, 10);
-        if (!Number.isNaN(retryValue)) {
-          this.currentEvent.retry = retryValue;
-        }
+      case 'retry':
+        if (/^[0-9]+$/.test(value)) this.retry = Number(value);
         break;
-      }
     }
   }
 
-  private processEvent(controller: TransformStreamDefaultController<T>): void {
-    if (this.currentEvent.rawData) {
-      if (!this.currentEvent.event) {
-        this.currentEvent.event = 'message';
-      }
+  private processEvent(
+    controller: TransformStreamDefaultController<T>
+  ): boolean {
+    const event = this.currentEvent;
+    this.currentEvent = { dataLines: [] };
 
-      if (this.currentEvent.rawData.trim() === '[DONE]') {
-        // maybe we want to emit [DONE] to signal the end of the stream
-        // controller.enqueue('[DONE]' as any)
-        // Reset the current event
-        this.currentEvent = { rawData: '' };
-        return;
-      }
+    if (event.dataLines.length === 0) return false;
 
-      try {
-        const parsedData: T = this.dataParser(this.currentEvent.rawData);
-        controller.enqueue(parsedData);
-      } catch (e) {
-        this.onError(e as Error, this.currentEvent.rawData);
-      }
-
-      this.currentEvent = { rawData: '' };
+    const rawData = event.dataLines.join('\n');
+    if (rawData.trim() === '[DONE]') {
+      this.terminated = true;
+      // Terminating the transform closes its readable side and cancels the
+      // upstream response body instead of leaving it open after [DONE].
+      controller.terminate();
+      return true;
     }
+
+    let parsedData: T;
+    try {
+      parsedData = this.dataParser(rawData);
+    } catch (e) {
+      this.onError(e as Error, rawData);
+      return false;
+    }
+
+    this.onEvent?.(parsedData, {
+      event: event.event || 'message',
+      id: this.lastEventId,
+      retry: this.retry,
+    });
+    controller.enqueue(parsedData);
+
+    return false;
   }
 }


### PR DESCRIPTION
## Summary
- route browser and server streaming through the same UTF-8 decoder and SSE parser
- preserve Ax's provider-compatible EOF behavior while making SSE field parsing spec-correct
- terminate and cancel upstream response bodies at the [DONE] sentinel
- add browser/server parity coverage across CRLF and every UTF-8 byte boundary

## Verification
- npm exec vitest -- run --exclude='.claude/**' --exclude='demo/**' src/ax/util/sse.test.ts src/ax/util/apicall.test.ts
- npm run test:unit --workspace=@ax-llm/ax (2994 passed, 1 skipped)
- npm run test:type-check --workspace=@ax-llm/ax
- npm run test:type-tests --workspace=@ax-llm/ax
- npm run test:lint --workspace=@ax-llm/ax
- npm run test:format --workspace=@ax-llm/ax
- npm run build --workspace=@ax-llm/ax
- npm run axir:backlog:check -- --base origin/main --head HEAD