### PR TITLE
fix(axir): preserve thoughts in chat logs

### DIFF
--- a/ir/conformance/axgen/thoughts-in-chat-log.json
+++ b/ir/conformance/axgen/thoughts-in-chat-log.json
@@ -1,0 +1,45 @@
+{
+  "expected_chat_log_subset": [
+    {
+      "thought": "I should preserve this summary.",
+      "thought_blocks": [
+        {
+          "data": "I should preserve this summary.",
+          "encrypted": false
+        }
+      ]
+    }
+  ],
+  "expected_output": {
+    "answer": "kept"
+  },
+  "expected_request_count": 1,
+  "input": {
+    "question": "Keep the thought summary?"
+  },
+  "kind": "forward",
+  "name": "thoughts-in-chat-log",
+  "responses": [
+    {
+      "model_usage": {
+        "tokens": {
+          "total_tokens": 17
+        }
+      },
+      "results": [
+        {
+          "content": "{\"answer\":\"kept\"}",
+          "index": 0,
+          "thought": "I should preserve this summary.",
+          "thought_blocks": [
+            {
+              "data": "I should preserve this summary.",
+              "encrypted": false
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "signature": "question:string -> answer:string"
+}

--- a/packages/cpp/axir-provenance.json
+++ b/packages/cpp/axir-provenance.json
@@ -5,7 +5,7 @@
   "files": {
     "axllm/axllm.cpp": {
       "emitted_lines": 24787,
-      "total_lines": 31873
+      "total_lines": 31875
     }
   }
 }

--- a/packages/cpp/axllm/axllm.cpp
+++ b/packages/cpp/axllm/axllm.cpp
@@ -2166,6 +2166,8 @@ Value Core::axgen_record_chat_log(Value gen, Value request, Value response) {
       {"session_id", get_key(response, "session_id")},
       {"usage", get_key(response, "usage", get_key(response, "model_usage"))},
       {"function_calls", get_key(response, "function_calls", Value::array())},
+      {"thought", get_key(response, "thought")},
+      {"thought_blocks", get_key(response, "thought_blocks", Value::array())},
       {"providerMetadata", get_key(request, "provider_metadata", Value::object())},
   });
   append(chat_log, entry);

--- a/packages/go/axir-provenance.json
+++ b/packages/go/axir-provenance.json
@@ -5,7 +5,7 @@
   "files": {
     "axllm.go": {
       "emitted_lines": 51732,
-      "total_lines": 65141
+      "total_lines": 65153
     }
   }
 }

--- a/packages/go/axllm.go
+++ b/packages/go/axllm.go
@@ -59996,13 +59996,22 @@ func _core_axgen_memory_cleanup_corrections(target Value) Value {
 }
 func _core_axgen_record_chat_log(target Value, values ...Value) Value {
 	log := coreGet(target, "chat_log", Array())
-	entry := Object()
-	for i, value := range values {
-		coreSet(entry, fmt.Sprintf("item%d", i), value)
-	}
-	if len(values) > 0 {
-		coreSet(entry, "providerMetadata", coreGet(values[0], "provider_metadata", Object()))
-	}
+	request := Value(Object())
+	response := Value(Object())
+	if len(values) > 0 { request = values[0] }
+	if len(values) > 1 { response = values[1] }
+	entry := Object(
+		"model", coreGet(request, "model", nil),
+		"messages", coreGet(request, "chat_prompt", Array()),
+		"response", response,
+		"remote_id", coreGet(response, "remote_id", coreGet(response, "id", nil)),
+		"session_id", coreGet(response, "session_id", nil),
+		"usage", coreGet(response, "usage", coreGet(response, "model_usage", nil)),
+		"function_calls", coreGet(response, "function_calls", Array()),
+		"thought", coreGet(response, "thought", nil),
+		"thought_blocks", coreGet(response, "thought_blocks", Array()),
+		"providerMetadata", coreGet(request, "provider_metadata", Object()),
+	)
 	log = coreAppend(log, entry)
 	if g, ok := target.(*AxGen); ok {
 		g.ChatLog = log
@@ -60040,8 +60049,8 @@ func _core_agent_stage_usage(stage Value) Value {
 	case *AxGen:
 		out := Array()
 		for _, entry := range asSlice(s.ChatLog) {
-			response := coreGet(entry, "item1", Object())
-			usage := coreGet(response, "usage", nil)
+			response := coreGet(entry, "response", coreGet(entry, "item1", Object()))
+			usage := coreGet(entry, "usage", coreGet(response, "usage", nil))
 			if usage == nil {
 				usage = coreGet(coreGet(response, "model_usage", Object()), "tokens", nil)
 			}
@@ -61631,6 +61640,9 @@ func runConformanceForward(fixture map[string]Value) {
 		}
 		if expected := coreGet(fixture, "expected_memory_history_subset", nil); expected != nil {
 			assertListSubset(gen.Memory, expected, "memory history")
+		}
+		if expected := coreGet(fixture, "expected_chat_log_subset", nil); expected != nil {
+			assertListSubset(gen.ChatLog, expected, "chat log")
 		}
 	}
 }

--- a/packages/java/axir-provenance.json
+++ b/packages/java/axir-provenance.json
@@ -5,7 +5,7 @@
   "files": {
     "dev/axllm/ax/Core.java": {
       "emitted_lines": 24816,
-      "total_lines": 26126
+      "total_lines": 26128
     }
   }
 }

--- a/packages/java/dev/axllm/ax/Core.java
+++ b/packages/java/dev/axllm/ax/Core.java
@@ -832,6 +832,8 @@ final class Core {
     entry.put("session_id", asMap(response).get("session_id"));
     entry.put("usage", asMap(response).getOrDefault("usage", asMap(response).get("model_usage")));
     entry.put("function_calls", asMap(response).getOrDefault("function_calls", List.of()));
+    entry.put("thought", asMap(response).get("thought"));
+    entry.put("thought_blocks", asMap(response).getOrDefault("thought_blocks", List.of()));
     entry.put("providerMetadata", asMap(request).getOrDefault("provider_metadata", Map.of()));
     asList(get(gen, "chat_log", List.of())).add(entry);
     return null;

--- a/packages/python/axir-provenance.json
+++ b/packages/python/axir-provenance.json
@@ -17,7 +17,7 @@
     },
     "axllm/gen.py": {
       "emitted_lines": 3021,
-      "total_lines": 4102
+      "total_lines": 4104
     },
     "axllm/mcp.py": {
       "emitted_lines": 2192,

--- a/packages/python/axllm/gen.py
+++ b/packages/python/axllm/gen.py
@@ -1052,6 +1052,8 @@ def _core_axgen_record_chat_log(gen, request, response):
         "session_id": _core_get(response, "session_id"),
         "usage": _core_get(response, "usage", _core_get(response, "model_usage")),
         "function_calls": _core_get(response, "function_calls", []),
+        "thought": _core_get(response, "thought"),
+        "thought_blocks": _core_get(response, "thought_blocks", []),
         "providerMetadata": _core_get(request, "provider_metadata", {}),
     }
     chat_log.append(entry)

--- a/packages/rust/axir-provenance.json
+++ b/packages/rust/axir-provenance.json
@@ -5,7 +5,7 @@
   "files": {
     "src/lib.rs": {
       "emitted_lines": 57065,
-      "total_lines": 81638
+      "total_lines": 81660
     }
   }
 }

--- a/packages/rust/src/lib.rs
+++ b/packages/rust/src/lib.rs
@@ -17641,6 +17641,16 @@ fn run_simple_forward_fixture(fixture: &Value) -> AxResult<()> {
             expected,
         )?;
     }
+    if let Some(expected) = fixture
+        .get("expected_chat_log_subset")
+        .and_then(Value::as_array)
+    {
+        expect_json_list_subset(
+            "chat log",
+            &Value::Array(program.chat_log.clone()),
+            expected,
+        )?;
+    }
     if let Some(expected) = fixture.get("expected_tool_calls").and_then(Value::as_array) {
         let actual = Value::Array(recorded_calls.lock().unwrap().clone());
         expect_json_list_exact_subsets("tool calls", &actual, expected)?;
@@ -22752,6 +22762,18 @@ fn core_axgen_record_chat_log(args: &[CoreValue]) -> Result<CoreValue, AxError> 
             core_get(
                 &response,
                 &CoreValue::from("function_calls"),
+                CoreValue::new_list(),
+            ),
+        ),
+        (
+            "thought",
+            core_get(&response, &CoreValue::from("thought"), CoreValue::Null),
+        ),
+        (
+            "thought_blocks",
+            core_get(
+                &response,
+                &CoreValue::from("thought_blocks"),
                 CoreValue::new_list(),
             ),
         ),

--- a/tools/axir/extractors/axgen-goldens.ts
+++ b/tools/axir/extractors/axgen-goldens.ts
@@ -392,6 +392,43 @@ writeFixture('memory-history-and-chat-log', {
   expected_request_count: 1,
 });
 
+writeFixture('thoughts-in-chat-log', {
+  kind: 'forward',
+  signature: 'question:string -> answer:string',
+  input: { question: 'Keep the thought summary?' },
+  responses: [
+    {
+      results: [
+        {
+          index: 0,
+          content: '{"answer":"kept"}',
+          thought: 'I should preserve this summary.',
+          thought_blocks: [
+            {
+              data: 'I should preserve this summary.',
+              encrypted: false,
+            },
+          ],
+        },
+      ],
+      model_usage: { tokens: { total_tokens: 17 } },
+    },
+  ],
+  expected_output: { answer: 'kept' },
+  expected_chat_log_subset: [
+    {
+      thought: 'I should preserve this summary.',
+      thought_blocks: [
+        {
+          data: 'I should preserve this summary.',
+          encrypted: false,
+        },
+      ],
+    },
+  ],
+  expected_request_count: 1,
+});
+
 writeFixture('empty-response-memory-skip', {
   kind: 'forward',
   signature: 'question:string -> answer:string',

--- a/tools/axir/internal/axir/templates/cpp/cppRuntime.cpp
+++ b/tools/axir/internal/axir/templates/cpp/cppRuntime.cpp
@@ -2166,6 +2166,8 @@ Value Core::axgen_record_chat_log(Value gen, Value request, Value response) {
       {"session_id", get_key(response, "session_id")},
       {"usage", get_key(response, "usage", get_key(response, "model_usage"))},
       {"function_calls", get_key(response, "function_calls", Value::array())},
+      {"thought", get_key(response, "thought")},
+      {"thought_blocks", get_key(response, "thought_blocks", Value::array())},
       {"providerMetadata", get_key(request, "provider_metadata", Value::object())},
   });
   append(chat_log, entry);

--- a/tools/axir/internal/axir/templates/go/goRuntime.go.txt
+++ b/tools/axir/internal/axir/templates/go/goRuntime.go.txt
@@ -8264,13 +8264,22 @@ func _core_axgen_memory_cleanup_corrections(target Value) Value {
 }
 func _core_axgen_record_chat_log(target Value, values ...Value) Value {
 	log := coreGet(target, "chat_log", Array())
-	entry := Object()
-	for i, value := range values {
-		coreSet(entry, fmt.Sprintf("item%d", i), value)
-	}
-	if len(values) > 0 {
-		coreSet(entry, "providerMetadata", coreGet(values[0], "provider_metadata", Object()))
-	}
+	request := Value(Object())
+	response := Value(Object())
+	if len(values) > 0 { request = values[0] }
+	if len(values) > 1 { response = values[1] }
+	entry := Object(
+		"model", coreGet(request, "model", nil),
+		"messages", coreGet(request, "chat_prompt", Array()),
+		"response", response,
+		"remote_id", coreGet(response, "remote_id", coreGet(response, "id", nil)),
+		"session_id", coreGet(response, "session_id", nil),
+		"usage", coreGet(response, "usage", coreGet(response, "model_usage", nil)),
+		"function_calls", coreGet(response, "function_calls", Array()),
+		"thought", coreGet(response, "thought", nil),
+		"thought_blocks", coreGet(response, "thought_blocks", Array()),
+		"providerMetadata", coreGet(request, "provider_metadata", Object()),
+	)
 	log = coreAppend(log, entry)
 	if g, ok := target.(*AxGen); ok {
 		g.ChatLog = log
@@ -8308,8 +8317,8 @@ func _core_agent_stage_usage(stage Value) Value {
 	case *AxGen:
 		out := Array()
 		for _, entry := range asSlice(s.ChatLog) {
-			response := coreGet(entry, "item1", Object())
-			usage := coreGet(response, "usage", nil)
+			response := coreGet(entry, "response", coreGet(entry, "item1", Object()))
+			usage := coreGet(entry, "usage", coreGet(response, "usage", nil))
 			if usage == nil {
 				usage = coreGet(coreGet(response, "model_usage", Object()), "tokens", nil)
 			}
@@ -9899,6 +9908,9 @@ func runConformanceForward(fixture map[string]Value) {
 		}
 		if expected := coreGet(fixture, "expected_memory_history_subset", nil); expected != nil {
 			assertListSubset(gen.Memory, expected, "memory history")
+		}
+		if expected := coreGet(fixture, "expected_chat_log_subset", nil); expected != nil {
+			assertListSubset(gen.ChatLog, expected, "chat log")
 		}
 	}
 }

--- a/tools/axir/internal/axir/templates/java/javaCore.java
+++ b/tools/axir/internal/axir/templates/java/javaCore.java
@@ -832,6 +832,8 @@ final class Core {
     entry.put("session_id", asMap(response).get("session_id"));
     entry.put("usage", asMap(response).getOrDefault("usage", asMap(response).get("model_usage")));
     entry.put("function_calls", asMap(response).getOrDefault("function_calls", List.of()));
+    entry.put("thought", asMap(response).get("thought"));
+    entry.put("thought_blocks", asMap(response).getOrDefault("thought_blocks", List.of()));
     entry.put("providerMetadata", asMap(request).getOrDefault("provider_metadata", Map.of()));
     asList(get(gen, "chat_log", List.of())).add(entry);
     return null;

--- a/tools/axir/internal/axir/templates/python/pyGen.py
+++ b/tools/axir/internal/axir/templates/python/pyGen.py
@@ -1050,6 +1050,8 @@ def _core_axgen_record_chat_log(gen, request, response):
         "session_id": _core_get(response, "session_id"),
         "usage": _core_get(response, "usage", _core_get(response, "model_usage")),
         "function_calls": _core_get(response, "function_calls", []),
+        "thought": _core_get(response, "thought"),
+        "thought_blocks": _core_get(response, "thought_blocks", []),
         "providerMetadata": _core_get(request, "provider_metadata", {}),
     }
     chat_log.append(entry)

--- a/tools/axir/internal/axir/templates/rust/rustLib.rs
+++ b/tools/axir/internal/axir/templates/rust/rustLib.rs
@@ -13469,6 +13469,12 @@ fn run_simple_forward_fixture(fixture: &Value) -> AxResult<()> {
     {
         expect_json_list_subset("memory history", &Value::Array(program.memory.clone()), expected)?;
     }
+    if let Some(expected) = fixture
+        .get("expected_chat_log_subset")
+        .and_then(Value::as_array)
+    {
+        expect_json_list_subset("chat log", &Value::Array(program.chat_log.clone()), expected)?;
+    }
     if let Some(expected) = fixture.get("expected_tool_calls").and_then(Value::as_array) {
         let actual = Value::Array(recorded_calls.lock().unwrap().clone());
         expect_json_list_exact_subsets("tool calls", &actual, expected)?;
@@ -18023,6 +18029,18 @@ fn core_axgen_record_chat_log(args: &[CoreValue]) -> Result<CoreValue, AxError> 
             core_get(
                 &response,
                 &CoreValue::from("function_calls"),
+                CoreValue::new_list(),
+            ),
+        ),
+        (
+            "thought",
+            core_get(&response, &CoreValue::from("thought"), CoreValue::Null),
+        ),
+        (
+            "thought_blocks",
+            core_get(
+                &response,
+                &CoreValue::from("thought_blocks"),
                 CoreValue::new_list(),
             ),
         ),


### PR DESCRIPTION
## Summary

- preserve thought summaries and thought blocks when AxGen writes chat logs
- regenerate Python, Java, C++, Go, and Rust packages
- add cross-runtime conformance coverage

## Verification

- npm run axir:conformance:check
- npm run axir:check-packages
- npm run test:axir:tools
- five-language generated runtime verification