### PR TITLE
fix(util): prevent AxRateLimiterTokenUsage.acquire from hanging when a request exceeds maxTokens

### DIFF
--- a/src/ax/util/rate-limit.test.ts
+++ b/src/ax/util/rate-limit.test.ts
@@ -1,0 +1,48 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { AxRateLimiterTokenUsage } from './rate-limit.js';
+
+describe('AxRateLimiterTokenUsage', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('resolves immediately when enough tokens are available', async () => {
+    const limiter = new AxRateLimiterTokenUsage(100, 10);
+    await expect(limiter.acquire(50)).resolves.toBeUndefined();
+    // A second request within the remaining budget also proceeds.
+    await expect(limiter.acquire(50)).resolves.toBeUndefined();
+  });
+
+  it('resolves a request larger than the bucket capacity instead of hanging forever', async () => {
+    // Regression: a single request larger than maxTokens could never be
+    // satisfied because currentTokens is capped at maxTokens, so acquire()
+    // would await indefinitely.
+    const limiter = new AxRateLimiterTokenUsage(100, 10);
+    await expect(limiter.acquire(150)).resolves.toBeUndefined();
+  });
+
+  it('repays borrowed capacity so the average rate is still honored', async () => {
+    vi.useFakeTimers();
+    // 100 token bucket, refilling 100 tokens/sec.
+    const limiter = new AxRateLimiterTokenUsage(100, 100);
+
+    // First oversized request drains the bucket to -50.
+    await limiter.acquire(150);
+
+    // The next oversized request must wait for the debt (-50) to be repaid and
+    // the bucket to refill to full (100) before it can proceed: 150 tokens at
+    // 100 tokens/sec = 1500ms.
+    let secondResolved = false;
+    const second = limiter.acquire(150).then(() => {
+      secondResolved = true;
+    });
+
+    await vi.advanceTimersByTimeAsync(1400);
+    expect(secondResolved).toBe(false);
+
+    await vi.advanceTimersByTimeAsync(200);
+    await second;
+    expect(secondResolved).toBe(true);
+  });
+});

--- a/src/ax/util/rate-limit.ts
+++ b/src/ax/util/rate-limit.ts
@@ -38,14 +38,21 @@ export class AxRateLimiterTokenUsage {
 
   private async waitUntilTokensAvailable(tokens: number): Promise<void> {
     this.refillTokens();
-    if (this.currentTokens >= tokens) {
+    // A single request can legitimately ask for more tokens than the bucket can
+    // ever hold (for example a large LLM call against a low per-minute budget).
+    // Waiting for `tokens` in that case would never resolve, since currentTokens
+    // is capped at maxTokens by refillTokens(). Wait for a full bucket instead,
+    // then let currentTokens go negative so the borrowed capacity is repaid on
+    // subsequent refills and the average rate is still honored.
+    const required = Math.min(tokens, this.maxTokens);
+    if (this.currentTokens >= required) {
       this.currentTokens -= tokens;
       return;
     }
     if (this.options?.debug) {
       console.log(
         colorLog.red(
-          `Rate limiter: Waiting for ${tokens - this.currentTokens} tokens`
+          `Rate limiter: Waiting for ${required - this.currentTokens} tokens`
         )
       );
     }


### PR DESCRIPTION
### Problem

`AxRateLimiterTokenUsage.acquire(tokens)` (`src/ax/util/rate-limit.ts`, a public exported API) can hang forever. The bucket is capped at `maxTokens`, so when `tokens > maxTokens` the "enough tokens?" check can never become true and `acquire()` re-schedules itself via `setTimeout` indefinitely. This is realistic: a single large LLM request against a small per-interval token budget never returns.

### Fix

When the request exceeds `maxTokens`, wait for the bucket to refill to full and then proceed, letting the balance go negative and be repaid over subsequent intervals (borrow-and-repay). This preserves the average enforced rate and unblocks the oversized request. The `tokens <= maxTokens` path is byte-for-byte unchanged.

### Test

Adds `rate-limit.test.ts` (previously untested API): the oversized-request case completes instead of timing out (RED → GREEN by a 5s test timeout); normal requests still rate-limit as before. `biome check` clean.

Note: this is one reasonable recovery semantics (borrow-and-repay vs. rejecting the oversized request) — happy to switch to a hard error if you'd prefer that contract.
