### PR TITLE
fix(event): remove abort listener on normal resolution in AxInMemoryEventStore.waitForWork

### DIFF
--- a/src/ax/event/memoryStore.test.ts
+++ b/src/ax/event/memoryStore.test.ts
@@ -1,0 +1,69 @@
+import { getEventListeners } from 'node:events';
+
+import { describe, expect, it } from 'vitest';
+
+import { AxInMemoryEventStore } from './memoryStore.js';
+import type { AxEventIngress } from './types.js';
+
+function ingress(id: string, type: string): AxEventIngress {
+  return {
+    event: {
+      specversion: '1.0',
+      id,
+      source: 'app://tests',
+      type,
+      data: { value: id },
+    },
+  };
+}
+
+function descriptor(instanceKey: string) {
+  return {
+    routeId: 'route',
+    action: 'observe' as const,
+    instanceKey,
+    sizeBytes: 10,
+  };
+}
+
+describe('AxInMemoryEventStore.waitForWork', () => {
+  it('does not leak abort listeners on a reused signal', async () => {
+    const store = new AxInMemoryEventStore();
+    const controller = new AbortController();
+    const { signal } = controller;
+
+    // Mirror a worker loop: repeatedly wait for work, let work arrive (which
+    // resolves the wait), then drain the queue so the next iteration waits
+    // again. Each resolved wait must clean up its abort listener.
+    for (let i = 0; i < 25; i++) {
+      const waited = store.waitForWork(signal);
+      await store.enqueue({
+        ingress: ingress(`event-${i}`, 'work'),
+        // A distinct instanceKey per iteration keeps claim() from being blocked
+        // by the previously claimed (non-terminal) delivery.
+        deliveries: [descriptor(`instance-${i}`)],
+        acceptedAt: Date.now(),
+        publishTimeoutMs: 1_000,
+      });
+      await waited;
+      // Claim the delivery so it is no longer 'queued' and the next
+      // waitForWork() actually waits instead of returning early.
+      await store.claim(`worker-${i}`, Date.now());
+    }
+
+    expect(getEventListeners(signal, 'abort').length).toBe(0);
+  });
+
+  it('still rejects and cleans up when the signal aborts', async () => {
+    const store = new AxInMemoryEventStore();
+    const controller = new AbortController();
+    const { signal } = controller;
+
+    const waited = store.waitForWork(signal);
+    const reason = new Error('shutting down');
+    controller.abort(reason);
+
+    await expect(waited).rejects.toBe(reason);
+    expect(getEventListeners(signal, 'abort').length).toBe(0);
+  });
+});

--- a/src/ax/event/memoryStore.ts
+++ b/src/ax/event/memoryStore.ts
@@ -366,18 +366,27 @@ export class AxInMemoryEventStore implements AxEventStore {
     ) {
       return;
     }
-    await new Promise<void>((resolve, reject) => {
-      const waiter = { resolve, reject };
-      this.workWaiters.add(waiter);
-      signal?.addEventListener(
-        'abort',
-        () => {
-          this.workWaiters.delete(waiter);
-          reject(signal.reason);
-        },
-        { once: true }
-      );
-    });
+    let waiter: Waiter | undefined;
+    let onAbort: (() => void) | undefined;
+    try {
+      await new Promise<void>((resolve, reject) => {
+        waiter = { resolve, reject };
+        this.workWaiters.add(waiter);
+        if (signal) {
+          onAbort = () => {
+            if (waiter) this.workWaiters.delete(waiter);
+            reject(signal.reason);
+          };
+          signal.addEventListener('abort', onAbort, { once: true });
+        }
+      });
+    } finally {
+      // Resolving the waiter via notify() never fires the abort listener, so
+      // remove it here to avoid leaking a listener on a long-lived signal that
+      // a worker loop reuses across many waitForWork() calls.
+      if (waiter) this.workWaiters.delete(waiter);
+      if (signal && onAbort) signal.removeEventListener('abort', onAbort);
+    }
   }
 
   async isIdle(): Promise<boolean> {


### PR DESCRIPTION
### Problem

`AxInMemoryEventStore.waitForWork()` (`src/ax/event/memoryStore.ts`, the default event store) registers an `abort` listener on the passed `AbortSignal` each time it waits, but only removes it on the abort path. On normal resolution — when `notify()` wakes the waiter — the `{ once: true }` listener never fires, so it is never removed and leaks.

`AxEventRuntime.workerLoop()` reuses a single long-lived `AbortSignal` across every loop iteration, so the leaked listeners accumulate without bound and Node eventually emits `MaxListenersExceededWarning`.

### Fix

Remove the listener in a `finally` block, mirroring the pattern the same file already uses in `waitForCapacity`.

### Test

Adds `memoryStore.test.ts`: after 25 wait/notify cycles the signal has 0 leaked listeners (RED before the fix: 25 accumulate; GREEN after: 0). `src/ax/event` + `src/ax/util` suites and `runtime.test.ts` pass; `biome check` clean.
