### PR TITLE
docs(website): improve newcomer path and GraphJin story

### DIFF
--- a/scripts/check-website-links.mjs
+++ b/scripts/check-website-links.mjs
@@ -942,6 +942,7 @@ function collectQualityFailures(rel, html, failures) {
       'production-loop',
       'mcp-bridge',
       'provider-router',
+      'embedded-agent',
     ]) {
       if (!html.includes(`/svg/${svg}.svg`)) {
         failures.push(`${rel}: homepage missing static SVG ${svg}`);
@@ -1099,6 +1100,7 @@ function collectQualityFailures(rel, html, failures) {
     const compilerIndex = html.indexOf('home-compiler-section');
     const agentIndex = html.indexOf('home-agent-section');
     const graphjinIndex = html.indexOf('home-graphjin');
+    const audioIndex = html.indexOf('home-audio-section');
     const finalCtaIndex = html.indexOf('home-final-cta');
     if (
       codeStoryIndex < 0 ||
@@ -1114,12 +1116,21 @@ function collectQualityFailures(rel, html, failures) {
     }
     if (
       graphjinIndex < 0 ||
+      graphjinIndex < agentIndex ||
+      audioIndex < 0 ||
+      graphjinIndex > audioIndex ||
       finalCtaIndex < 0 ||
       graphjinIndex > finalCtaIndex
     ) {
       failures.push(
-        `${rel}: homepage final CTA must close the page after GraphJin`
+        `${rel}: homepage must place GraphJin after agents and before audio`
       );
+    }
+    if (!html.includes('GraphJin runs on Ax')) {
+      failures.push(`${rel}: homepage missing GraphJin case-study heading`);
+    }
+    if (html.includes('Also checkout')) {
+      failures.push(`${rel}: homepage still uses the old GraphJin cross-promo`);
     }
     if (countOccurrences(html, 'language-mark-') < 6) {
       failures.push(`${rel}: homepage missing language logo marks`);
@@ -1238,13 +1249,13 @@ function isApiPage(rel) {
 }
 
 function isTocExpectedPage(rel) {
-  return /^(?:typescript|python|java|cpp|go|rust)\/(?:quick-start|advanced-start|examples(?:\/[^/]+)?|concepts\/[^/]+|subsystems\/[^/]+)\/index\.html$/.test(
+  return /^(?:typescript|python|java|cpp|go|rust)\/(?:quick-start|how-ax-fits-together|advanced-start|faq|examples(?:\/[^/]+)?|concepts\/[^/]+|subsystems\/[^/]+)\/index\.html$/.test(
     rel
   );
 }
 
 function isMermaidExpectedPage(rel) {
-  return /^(?:typescript|python|java|cpp|go|rust)\/(?:quick-start|agents(?:\/(?:standard|long-horizon|internals))?|concepts\/(?:dspy|signatures|tools|llms|mcp|optimization|telemetry)|subsystems\/(?:ai|ax|s|flow|optimize))\/index\.html$/.test(
+  return /^(?:typescript|python|java|cpp|go|rust)\/(?:quick-start|how-ax-fits-together|agents(?:\/(?:standard|long-horizon|internals))?|concepts\/(?:dspy|signatures|tools|llms|mcp|optimization|telemetry)|subsystems\/(?:ai|ax|s|flow|optimize))\/index\.html$/.test(
     rel
   );
 }

--- a/scripts/website-prepare.mjs
+++ b/scripts/website-prepare.mjs
@@ -378,7 +378,9 @@ async function writeExampleGroupPages(language, navPages) {
 
 function sectionNavForPage(page) {
   if (page.slug === 'quick-start') return 'quick-start';
+  if (page.slug === 'how-ax-fits-together') return 'quick-start';
   if (page.slug === 'advanced-start') return 'quick-start';
+  if (page.slug === 'faq') return 'quick-start';
   if (page.slug.startsWith('examples')) return 'examples';
   if (page.slug === 'skills') return 'skills';
   return page.group;
@@ -409,6 +411,10 @@ async function renderContext(language, page) {
     skillInstallCommand: skillInstallCommand(language),
     skillList: skillList(inventory.languageSkills[language.id] ?? [], language),
     skillSource: skillSource(language),
+    quickStartFile: language.quickStartRun.file,
+    quickStartSetup: language.quickStartRun.setup.join('\n'),
+    quickStartRunCommand: language.quickStartRun.run.join('\n'),
+    quickStartOutput: language.quickStartRun.output.join('\n'),
     quickStartCode: lines(snippets.quickStart),
     dspyCode: lines(snippets.dspy ?? snippets.quickStart),
     signatureCode: lines(snippets.signature),

--- a/website/content-src/languages/cpp.json
+++ b/website/content-src/languages/cpp.json
@@ -5,11 +5,26 @@
   "fence": "cpp",
   "packageName": "axllm",
   "install": [
+    "cmake_minimum_required(VERSION 3.20)",
+    "project(ax_quick_start LANGUAGES CXX)",
+    "set(CMAKE_CXX_STANDARD 17)",
+    "",
     "include(FetchContent)",
     "FetchContent_Declare(axllm GIT_REPOSITORY https://github.com/ax-llm/ax GIT_TAG main SOURCE_SUBDIR packages/cpp)",
     "FetchContent_MakeAvailable(axllm)",
-    "target_link_libraries(your_app PRIVATE axllm::axllm)"
+    "",
+    "add_executable(quick_start quick_start.cpp)",
+    "target_link_libraries(quick_start PRIVATE axllm::axllm)"
   ],
+  "quickStartRun": {
+    "file": "quick_start.cpp",
+    "setup": ["export OPENAI_API_KEY=\"sk-...\""],
+    "run": [
+      "cmake -S . -B build && cmake --build build",
+      "./build/quick_start"
+    ],
+    "output": ["sentiment: positive"]
+  },
   "exampleRoot": "packages/cpp/examples",
   "academy": {
     "unitExamples": {
@@ -112,9 +127,19 @@
     },
     "quickStart": [
       "#include <axllm/axllm.hpp>",
+      "#include <cstdlib>",
+      "#include <iostream>",
       "",
-      "auto llm = axllm::ai(\"openai\", axllm::object({{\"apiKey\", std::getenv(\"OPENAI_API_KEY\")}}));",
-      "auto classify = axllm::ax(\"review:string -> sentiment:class \\\"positive, negative, neutral\\\"\");"
+      "int main() {",
+      "  auto llm = axllm::ai(\"openai\", axllm::object({{\"apiKey\", std::getenv(\"OPENAI_API_KEY\")}}));",
+      "  auto classify = axllm::ax(\"review:string -> sentiment:class \\\"positive, negative, neutral\\\"\");",
+      "  auto result = classify.forward(*llm, axllm::object({",
+      "    {\"review\", \"Useful and boring in the best way.\"}",
+      "  }));",
+      "",
+      "  auto sentiment = axllm::Core::get(result, \"sentiment\");",
+      "  std::cout << \"sentiment: \" << std::get<std::string>(sentiment.data) << \"\\n\";",
+      "}"
     ],
     "dspy": [
       "auto qa = axllm::ax(\"question:string -> answer:string, confidence:number\");"

--- a/website/content-src/languages/go.json
+++ b/website/content-src/languages/go.json
@@ -5,6 +5,15 @@
   "fence": "go",
   "packageName": "github.com/ax-llm/ax/packages/go",
   "install": ["go get github.com/ax-llm/ax/packages/go"],
+  "quickStartRun": {
+    "file": "main.go",
+    "setup": [
+      "export OPENAI_API_KEY=\"sk-...\"",
+      "go mod init quickstart && go get github.com/ax-llm/ax/packages/go"
+    ],
+    "run": ["go run ."],
+    "output": ["sentiment: positive"]
+  },
   "exampleRoot": "packages/go/examples",
   "academy": {
     "unitExamples": {
@@ -107,10 +116,28 @@
       ]
     },
     "quickStart": [
-      "import axllm \"github.com/ax-llm/ax/packages/go\"",
+      "package main",
       "",
-      "client := axllm.NewAI(\"openai\", map[string]axllm.Value{\"apiKey\": os.Getenv(\"OPENAI_API_KEY\")})",
-      "classify := axllm.NewAx(\"review:string -> sentiment:class \\\"positive, negative, neutral\\\"\", nil)"
+      "import (",
+      "    \"context\"",
+      "    \"fmt\"",
+      "    \"os\"",
+      "",
+      "    axllm \"github.com/ax-llm/ax/packages/go\"",
+      ")",
+      "",
+      "func main() {",
+      "    client := axllm.NewAI(\"openai\", map[string]axllm.Value{\"apiKey\": os.Getenv(\"OPENAI_API_KEY\")})",
+      "    classify := axllm.NewAx(\"review:string -> sentiment:class \\\"positive, negative, neutral\\\"\", nil)",
+      "    result, err := classify.Forward(context.Background(), client, map[string]axllm.Value{",
+      "        \"review\": \"Useful and boring in the best way.\"",
+      "    }, nil)",
+      "    if err != nil {",
+      "        panic(err)",
+      "    }",
+      "",
+      "    fmt.Println(\"sentiment:\", result.(map[string]axllm.Value)[\"sentiment\"])",
+      "}"
     ],
     "dspy": [
       "qa := axllm.NewAx(\"question:string -> answer:string, confidence:number\", nil)"

--- a/website/content-src/languages/java.json
+++ b/website/content-src/languages/java.json
@@ -6,14 +6,26 @@
   "packageName": "dev.axllm:ax",
   "install": [
     "// Gradle (build.gradle):",
-    "implementation 'dev.axllm:ax:22.0.4'",
+    "implementation 'dev.axllm:ax:24.0.15'",
     "// Maven (pom.xml):",
     "<dependency>",
     "  <groupId>dev.axllm</groupId>",
     "  <artifactId>ax</artifactId>",
-    "  <version>22.0.4</version>",
+    "  <version>24.0.15</version>",
     "</dependency>"
   ],
+  "quickStartRun": {
+    "file": "QuickStart.java",
+    "setup": [
+      "export OPENAI_API_KEY=\"sk-...\"",
+      "mvn dependency:copy -Dartifact=dev.axllm:ax:24.0.15 -DoutputDirectory=."
+    ],
+    "run": [
+      "javac -cp ax-24.0.15.jar QuickStart.java",
+      "java -cp \".:ax-24.0.15.jar\" QuickStart"
+    ],
+    "output": ["sentiment: positive"]
+  },
   "exampleRoot": "packages/java/examples",
   "academy": {
     "unitExamples": {
@@ -112,9 +124,19 @@
     },
     "quickStart": [
       "import dev.axllm.ax.Ax;",
+      "import java.util.Map;",
       "",
-      "var llm = Ax.ai(\"openai\", Map.of(\"apiKey\", System.getenv(\"OPENAI_API_KEY\")));",
-      "var classify = Ax.ax(\"review:string -> sentiment:class \\\"positive, negative, neutral\\\"\");"
+      "public class QuickStart {",
+      "  public static void main(String[] args) throws Exception {",
+      "    var llm = Ax.ai(\"openai\", Map.of(\"apiKey\", System.getenv(\"OPENAI_API_KEY\")));",
+      "    var classify = Ax.ax(\"review:string -> sentiment:class \\\"positive, negative, neutral\\\"\");",
+      "    var result = classify.forward(llm, Map.of(",
+      "      \"review\", \"Useful and boring in the best way.\"",
+      "    ));",
+      "",
+      "    System.out.println(\"sentiment: \" + result.get(\"sentiment\"));",
+      "  }",
+      "}"
     ],
     "dspy": [
       "var qa = Ax.ax(\"question:string -> answer:string, confidence:number\");"

--- a/website/content-src/languages/python.json
+++ b/website/content-src/languages/python.json
@@ -5,6 +5,12 @@
   "fence": "python",
   "packageName": "axllm",
   "install": ["pip install axllm"],
+  "quickStartRun": {
+    "file": "classify.py",
+    "setup": ["export OPENAI_API_KEY=\"sk-...\""],
+    "run": ["python classify.py"],
+    "output": ["sentiment: positive"]
+  },
   "exampleRoot": "packages/python/examples",
   "academy": {
     "unitExamples": {
@@ -110,10 +116,16 @@
       ]
     },
     "quickStart": [
+      "import os",
       "from axllm import ai, ax",
       "",
       "llm = ai('openai', api_key=os.environ['OPENAI_API_KEY'])",
-      "classify = ax('review:string -> sentiment:class \"positive, negative, neutral\"')"
+      "classify = ax('review:string -> sentiment:class \"positive, negative, neutral\"')",
+      "result = classify.forward(llm, {",
+      "    'review': 'Useful and boring in the best way.',",
+      "})",
+      "",
+      "print('sentiment:', result['sentiment'])"
     ],
     "dspy": [
       "from axllm import ai, ax",

--- a/website/content-src/languages/rust.json
+++ b/website/content-src/languages/rust.json
@@ -5,6 +5,15 @@
   "fence": "rust",
   "packageName": "axllm",
   "install": ["cargo add axllm"],
+  "quickStartRun": {
+    "file": "src/main.rs",
+    "setup": [
+      "export OPENAI_API_KEY=\"sk-...\"",
+      "cargo new quickstart && cd quickstart && cargo add axllm serde_json"
+    ],
+    "run": ["cargo run"],
+    "output": ["sentiment: positive"]
+  },
   "exampleRoot": "packages/rust/examples",
   "academy": {
     "unitExamples": {
@@ -106,11 +115,19 @@
       ]
     },
     "quickStart": [
-      "use axllm::{ai, ax};",
+      "use axllm::{ai, ax, AxResult};",
       "use serde_json::json;",
       "",
-      "let llm = ai(\"openai\", json!({\"apiKey\": std::env::var(\"OPENAI_API_KEY\")?}))?;",
-      "let classify = ax(\"review:string -> sentiment:class \\\"positive, negative, neutral\\\"\")?;"
+      "fn main() -> AxResult<()> {",
+      "    let mut llm = ai(\"openai\", json!({\"apiKey\": std::env::var(\"OPENAI_API_KEY\")?}))?;",
+      "    let mut classify = ax(\"review:string -> sentiment:class \\\"positive, negative, neutral\\\"\")?;",
+      "    let result = classify.forward(&mut llm, json!({",
+      "        \"review\": \"Useful and boring in the best way.\"",
+      "    }))?;",
+      "",
+      "    println!(\"sentiment: {}\", result[\"sentiment\"].as_str().unwrap_or_default());",
+      "    Ok(())",
+      "}"
     ],
     "dspy": [
       "let qa = ax(\"question:string -> answer:string, confidence:number\")?;"

--- a/website/content-src/languages/typescript.json
+++ b/website/content-src/languages/typescript.json
@@ -5,6 +5,12 @@
   "fence": "typescript",
   "packageName": "@ax-llm/ax",
   "install": ["npm install @ax-llm/ax"],
+  "quickStartRun": {
+    "file": "classify.ts",
+    "setup": ["export OPENAI_APIKEY=\"sk-...\""],
+    "run": ["npx tsx classify.ts"],
+    "output": ["sentiment: positive"]
+  },
   "exampleRoot": "src/examples",
   "academy": {
     "unitExamples": {
@@ -102,7 +108,9 @@
       "",
       "const result = await classify.forward(llm, {",
       "  review: 'Useful and boring in the best way.',",
-      "});"
+      "});",
+      "",
+      "console.log('sentiment:', result.sentiment);"
     ],
     "dspy": [
       "import { ai, ax } from '@ax-llm/ax';",

--- a/website/content-src/site-map.json
+++ b/website/content-src/site-map.json
@@ -27,10 +27,22 @@
           "description": "Install Ax and run a typed LLM program."
         },
         {
+          "slug": "how-ax-fits-together",
+          "title": "How Ax Fits Together",
+          "template": "how-ax-fits-together",
+          "description": "The Ax stack on one page: signatures, ai(), ax(), flow(), agent(), optimizers, and the AxIR compiler — and how they compose."
+        },
+        {
           "slug": "advanced-start",
           "title": "Advanced Start",
           "template": "advanced-start",
           "description": "Follow the Ax story through selected runnable examples."
+        },
+        {
+          "slug": "faq",
+          "title": "FAQ",
+          "template": "faq",
+          "description": "Plain-English answers to common Ax questions, plus a glossary: DSPy, GEPA, ACE, RLM, PEEK, AxIR."
         }
       ]
     },

--- a/website/content-src/templates/faq.md
+++ b/website/content-src/templates/faq.md
@@ -1,0 +1,91 @@
+# FAQ
+
+Plain-English answers for getting from a first typed call to agents, optimization, and the research terms used across Ax.
+
+## Getting Started
+
+### What is Ax in one sentence?
+
+Ax is a native {{language}} library for declaring typed LLM programs that validate, retry, stream, compose, and improve across model providers.
+
+### Do I need to know DSPy first?
+
+No. Start with a signature and `ax()`; the [DSPy concepts page]({{langRoot}}/concepts/dspy/) explains the research lineage when you want the deeper mental model.
+
+### Which API key do I need?
+
+Use a key from any provider Ax supports. The Quick Start uses OpenAI because it is a familiar default, but the program contract is provider-independent. See [LLMs and providers]({{langRoot}}/concepts/llms/).
+
+### What does it cost to try?
+
+Ax itself is Apache-2.0 open source. Your only required runtime cost is whatever model provider you choose to call; a small model and a short classification request are enough for the Quick Start.
+
+### Is Ax really native in {{language}}?
+
+Yes. This site is generated for each language from one compiler-owned semantic core, while {{packageName}} exposes native naming, errors, builders, transports, and runtime boundaries. It is not a TypeScript program running behind a wrapper.
+
+## Signatures And Typed Calls
+
+### What exactly is a signature?
+
+A signature is a compact contract that names the input fields a model receives and the typed output fields your code expects. Ax uses it to build prompts, schemas, validators, retry feedback, traces, and host-language output types.
+
+### Why not just call the OpenAI SDK myself?
+
+You can when a raw provider call is all you need. As soon as the app adds a prompt string, JSON or regex scraping, schema checks, correction retries, streaming state, traces, evals, and a second provider, that glue becomes the real system. Ax attaches it to one typed contract so the application keeps a stable boundary.
+
+### What happens when the model returns garbage?
+
+Ax parses and validates the declared fields. If output is missing, malformed, or violates a constraint, the retry loop sends the concrete validation error back as feedback instead of silently handing bad data to your code.
+
+### Can I stream results?
+
+Yes. Structured fields are parsed as model output arrives, so callers can consume partial typed deltas while the final result still passes the same validation contract. See the [`ax()` subsystem]({{langRoot}}/subsystems/ax/).
+
+## Agents
+
+### When do I need agent() instead of ax()?
+
+Use `ax()` when one typed model call can answer. Use `agent()` when the job needs tools, several decisions, large data kept outside the prompt, clarification, memory, or a persistent runtime session.
+
+### What is the runtime session in plain English?
+
+It is a scratch computer next to the model. Your data sits in that session, and the model writes small code steps that inspect or transform it instead of trying to read everything in one prompt.
+
+### Why do my rows never enter the prompt?
+
+Context fields and host-owned tools keep bulky values in the runtime. The model receives the schema, a compact descriptor, and the exact evidence returned by the code steps it chose—not the raw table.
+
+### Can an agent call my existing functions or a database?
+
+Yes. Functions become typed tools, MCP servers become discoverable external tools, and runtimes can register host callables in-process. [GraphJin](https://graphjin.com) is the shipped production example: it embeds the Ax Go agent beside its query engine so model-written steps operate on data the host owns.
+
+## Improving Quality
+
+### What does optimization mean here?
+
+`{{optimizeName}}` runs a program, scores its outputs, reflects on failures, and evolves instructions or demonstrations. It improves the existing typed program rather than training a new foundation model.
+
+### Do I need training data?
+
+You need a small set of representative examples and a metric that can tell better from worse. A handful of good cases is enough to begin; add edge cases as traces reveal where the program fails.
+
+## Jargon Translated
+
+| Term | Plain-English meaning |
+| --- | --- |
+| DSPy | A way to program model behavior with declarative modules and measurable examples instead of hand-tuning prompt strings. |
+| GEPA | A Genetic-Pareto optimizer that runs a program, reflects on failures, evolves instructions, and keeps the useful tradeoffs. |
+| ACE | A curated playbook grown from a program's own runs and feedback, then reused as evolving context. |
+| RLM | A model computing on big data through small code steps in a runtime instead of reading all of it in the prompt. |
+| PEEK | A persistent orientation cache for a large corpus that an agent revisits over time. |
+| AxIR | The compiler core that emits the native Python, Java, C++, Go, and Rust packages from shared Ax semantics. |
+| MCP | Model Context Protocol, a standard way for applications to expose tools, resources, prompts, and long-running tasks. |
+| signature | The typed input and output contract that Ax turns into prompts, schemas, validation, retries, and program interfaces. |
+
+## Where To Go Next
+
+- [Run the Quick Start]({{langRoot}}/quick-start/)
+- [See how Ax fits together]({{langRoot}}/how-ax-fits-together/)
+- [Browse runnable examples]({{langRoot}}/examples/)
+- [Read the research map](/research/)

--- a/website/content-src/templates/how-ax-fits-together.md
+++ b/website/content-src/templates/how-ax-fits-together.md
@@ -1,0 +1,158 @@
+# How Ax Fits Together
+
+Ax starts with one signature and lets you add only the machinery the job needs. A typed call can become a workflow, a workflow can include agents, and an agent can become a tool for another agent. The model client stays a forward argument, so the same program can use a different provider on another call—or a different provider at each agent stage. Optimizers and playbooks can wrap any of those programs, while AxIR carries the shared contract into every supported language.
+
+## The Map
+
+The stack is compositional rather than a set of competing APIs. Signatures define the boundary. `ai()` supplies a model when a program runs. `ax()`, `flow()`, and `agent()` are programs that can be nested and forwarded through the same interface. `{{optimizeName}}` and `playbook()` improve those programs without changing their public input and output contract.
+
+```mermaid
+flowchart TB
+  signature["s() signature"] --> gen["ax() typed call"]
+  signature --> flowNode["flow() composition"]
+  signature --> agentNode["agent() runtime pipeline"]
+  client["ai() client per forward"] --> gen
+  client --> flowNode
+  client --> agentNode
+  gen --> wrappers["optimize() and playbook()"]
+  flowNode --> wrappers
+  agentNode --> wrappers
+  wrappers --> compiler["AxIR six language output"]
+```
+
+Every layer shares one programming contract: typed inputs go in, typed outputs come back, and the caller chooses the model client at run time.
+
+## s() — One Signature
+
+A signature is the compact contract at the center of Ax. The same string is parsed at runtime and, in TypeScript, at the type level. Ax turns it into the prompt fields, output schema, validators, and host-language types used by the rest of the program.
+
+```mermaid
+flowchart LR
+  text["Signature string"] --> prompt["Prompt fields"]
+  text --> schema["Output schema"]
+  text --> validation["Validators"]
+  text --> types["Host types"]
+```
+
+Use [`s()`]({{langRoot}}/subsystems/s/) when you want to inspect, reuse, or build that contract directly.
+
+## ai() — Any Model Behind One Client
+
+`ai()` selects a provider, model, credentials, and deployment profile behind one client boundary. Programs do not have to own that choice: the client is supplied to `forward()`, which lets one program move between providers, routers, local models, and test clients without rewriting its signature.
+
+```mermaid
+flowchart LR
+  openai["OpenAI profile"] --> client["ai() client"]
+  claude["Claude profile"] --> client
+  gemini["Gemini profile"] --> client
+  local["Local profile"] --> client
+  client --> program["Program forward"]
+```
+
+See the [`ai()` subsystem]({{langRoot}}/subsystems/ai/) for models, profiles, routing, media, and usage.
+
+## ax() — A Typed Call
+
+`ax()` is the smallest executable Ax program. It renders a prompt from the signature, calls the supplied model, parses the response as it streams, validates every declared field, and returns typed output. If validation fails, Ax can retry with the exact error as model feedback.
+
+```mermaid
+flowchart LR
+  input["Typed inputs"] --> render["Render prompt"]
+  render --> model["Call model"]
+  model --> parse["Streaming parse"]
+  parse --> validate["Validate fields"]
+  validate --> output["Typed outputs"]
+  validate -->|retry with feedback| model
+```
+
+Start with the [`ax()` subsystem]({{langRoot}}/subsystems/ax/) when one model call can do the job.
+
+## flow() — Programs Composed Of Programs
+
+`flow()` connects programs into an explicit graph. A node can run any AxProgrammable: an `ax()` generator, an `agent()`, or another nested flow. Inputs and outputs move through named state rather than a pile of ad hoc callbacks.
+
+The flow grammar is text-complete, so `flow(mermaidString)` compiles a Mermaid diagram into a running program. The diagrams on this page use the same notation you can use to describe a flow.
+
+```mermaid
+flowchart TB
+  request["Request"] --> genNode["AxGen node"]
+  request --> agentNode["AxAgent node"]
+  genNode --> nested["Nested AxFlow node"]
+  agentNode --> nested
+  nested --> merge["Typed result merge"]
+```
+
+See [`flow()` composition]({{langRoot}}/subsystems/flow/) for branches, parallel nodes, nested programs, and Mermaid compilation.
+
+## agent() — Three Stages On A Runtime
+
+`agent()` adds a runtime-backed loop for work that needs tools, large data, or multiple steps. A distiller narrows the task and evidence, an executor writes small code steps against a runtime session, and a responder turns the gathered evidence into the declared typed output.
+
+Data lives in the runtime session: a web-worker JavaScript runtime in TypeScript, goja in Go, and QuickJS-backed profiles in the other native packages. The model receives compact descriptors and tool results instead of raw datasets.
+
+```mermaid
+flowchart LR
+  distiller["Distiller AxGen"] --> executor["Executor AxGen"]
+  executor --> runtime["Runtime session"]
+  runtime --> executor
+  executor -->|evidence descriptor only| responder["Responder AxGen"]
+  distiller -->|respond() skip executor| responder
+  responder --> output["Typed result"]
+```
+
+The reveal is literal: the agent pipeline is itself an AxFlow of three AxGens. Agents also expose `getFunction()`, so one agent can become a typed tool of another. Read [Agent Internals]({{langRoot}}/agents/internals/) for the full boundary.
+
+## {{optimizeName}} — Improve With Evals
+
+Optimization means running a program against examples, scoring the results with a metric, reflecting on failures, and evolving instructions or demonstrations. GEPA keeps a Pareto frontier instead of hiding quality, cost, latency, and brevity behind one score.
+
+```mermaid
+flowchart TB
+  program["Run program"] --> score["Score with metric"]
+  score --> reflect["Reflect on failures"]
+  reflect --> evolve["Evolve instructions"]
+  evolve --> program
+  score --> frontier["Pareto frontier"]
+```
+
+Because the optimizer accepts a programmable root, it can improve a generator, flow, or agent. See [Optimization]({{langRoot}}/concepts/optimization/).
+
+## playbook() — Evolving Context
+
+`playbook()` grows a curated set of strategies from program runs and feedback. Instead of replaying a raw history, it keeps verified, reusable guidance and injects the relevant part into later runs of any program.
+
+```mermaid
+flowchart LR
+  runs["Program runs"] --> feedback["Outcomes and feedback"]
+  feedback --> curate["Curate strategies"]
+  curate --> playbook["Evolving playbook"]
+  playbook --> next["Next program run"]
+```
+
+Use [Playbooks]({{langRoot}}/concepts/playbook/) when the system should learn durable operating guidance from experience.
+
+## AxIR — Compiled Six-Wide
+
+TypeScript is the behavioral reference runtime. AxIR extracts and lowers the shared semantics into one core model, then emits native {{packageName}}-style APIs for Python, Java, C++, Go, and Rust. The result is not transpiled TypeScript: each package keeps native names, errors, builders, callbacks, transports, and runtime boundaries.
+
+```mermaid
+flowchart LR
+  ts["TypeScript conformance"] --> verify["axir verify"]
+  modules["AxIR modules"] --> core["Core runtime model"]
+  core --> python["Python package"]
+  core --> java["Java package"]
+  core --> cpp["C++ package"]
+  core --> go["Go package"]
+  core --> rust["Rust package"]
+  python --> verify
+  rust --> verify
+```
+
+`axir verify` compiles targets, runs generated examples, checks capability manifests, and exercises conformance fixtures before a backend earns its place on the site.
+
+## Where To Go Next
+
+- [Run the Quick Start]({{langRoot}}/quick-start/)
+- [Build an agent]({{langRoot}}/agents/)
+- [Read the FAQ]({{langRoot}}/faq/)
+- [Browse runnable examples]({{langRoot}}/examples/)

--- a/website/content-src/templates/quick-start.md
+++ b/website/content-src/templates/quick-start.md
@@ -8,9 +8,17 @@ Ax gives {{language}} one typed contract for LLM programs: signatures for data s
 {{install}}
 ```
 
+## Set Your API Key
+
+The first program uses OpenAI. Export the key in the same terminal where you will run it.
+
+```{{shellFence}}
+{{quickStartSetup}}
+```
+
 ## First Program
 
-Start with a small typed task. The signature declares the fields the model receives and the fields Ax must parse back out.
+Start with a small typed task. The signature declares the fields the model receives and the fields Ax must parse back out. Save this as `{{quickStartFile}}`.
 
 ```{{fence}}
 {{quickStartCode}}
@@ -31,6 +39,20 @@ flowchart LR
   D --> E["Typed output"]
 ```
 
+## Run It
+
+```{{shellFence}}
+{{quickStartRunCommand}}
+```
+
+You should see:
+
+```text
+{{quickStartOutput}}
+```
+
+The model's wording can vary, but the declared class shape is guaranteed.
+
 The rest of the site keeps the same concepts but swaps install commands, imports, examples, and API names for {{language}}.
 
 ## Where To Go Next
@@ -40,6 +62,8 @@ Use [Examples]({{langRoot}}/examples/) when you want runnable files. Use [Concep
 ## What To Read Next
 
 - [Examples]({{langRoot}}/examples/)
+- [How Ax fits together]({{langRoot}}/how-ax-fits-together/)
+- [FAQ]({{langRoot}}/faq/)
 - [DSPy concepts]({{langRoot}}/concepts/dspy/)
 - [ai() LLM models]({{langRoot}}/subsystems/ai/)
 - [ax() generation]({{langRoot}}/subsystems/ax/)

--- a/website/content/_index.md
+++ b/website/content/_index.md
@@ -20,14 +20,14 @@ description: "Stop prompting. Start programming. Typed signatures become reliabl
     <span><i class="home-proof-dot proof-green" aria-hidden="true"></i>Native in your language — six supported</span>
   </div>
   <div class="home-actions">
-    <a href="/typescript/quick-start/" data-home-lang-href="quick-start/">Get started</a>
+    <a href="/typescript/quick-start/" data-home-lang-href="quick-start/">Get started — 5 min</a>
     <a class="home-button-secondary" href="https://github.com/ax-llm/ax">GitHub</a>
     <div class="home-hero-stats" data-home-stats data-repo="ax-llm/ax" data-npm-package="@ax-llm/ax" aria-label="Project stats">
       <a href="https://github.com/ax-llm/ax" hidden><strong data-stat="stars"></strong><span>GitHub stars</span></a>
       <a href="https://www.npmjs.com/package/@ax-llm/ax" hidden><strong data-stat="downloads"></strong><span>npm downloads/week</span></a>
     </div>
   </div>
-  <p class="home-skills-note">Building with Claude Code or Cursor? <a href="/typescript/skills/" data-home-lang-href="skills/">Install the Ax skills</a> — your coding agent writes correct Ax in all six languages.</p>
+  <p class="home-skills-note">Coding with AI? <a href="/typescript/skills/" data-home-lang-href="skills/">Install the Ax skills</a> — Claude Code, Cursor, and other agents write correct Ax in all six languages.</p>
 </div>
 <div class="home-hero-panel" aria-label="Ax signature runtime preview">
   <div class="home-example-tabs" role="tablist" aria-label="Hero example">
@@ -54,7 +54,7 @@ description: "Stop prompting. Start programming. Typed signatures become reliabl
   <div>
     <p class="home-section-label">Ax Academy</p>
     <h2 id="home-academy-title">Learn Ax through an adaptive knowledge path.</h2>
-    <p>Start with a diagnostic, build mastery through short scaffolded lessons, and strengthen due concepts with interleaved spaced review. Progress stays in your browser.</p>
+    <p>A free course — about six hours end to end, entirely in your browser. Start with a diagnostic, build mastery through short scaffolded lessons, and strengthen due concepts with interleaved spaced review.</p>
     <div class="home-actions home-section-actions"><a href="/typescript/academy/" data-home-lang-href="academy/">Start Ax Academy</a></div>
   </div>
 </article>
@@ -64,7 +64,7 @@ description: "Stop prompting. Start programming. Typed signatures become reliabl
 <div class="home-section-heading">
   <p class="home-section-label">Get started</p>
   <h2 id="quick-install">Quick install</h2>
-  <p>One Ax programming model, six languages — pick yours and drop the package in.</p>
+  <p>Just want the package? One Ax programming model, six languages — pick yours and drop it in.</p>
 </div>
 <div class="home-quick-install-bar">
 {{< home-language-controls >}}
@@ -292,6 +292,41 @@ description: "Stop prompting. Start programming. Typed signatures become reliabl
 </div>
 </section>
 
+<section class="home-section home-graphjin" aria-labelledby="graphjin">
+<div class="home-section-heading">
+  <p class="home-section-label">Case study</p>
+  <h2 id="graphjin">GraphJin runs on Ax.</h2>
+  <p><a href="https://graphjin.com">GraphJin</a> — an automatic GraphQL-to-SQL engine from the same author — embeds the Ax Go agent <strong>in-process</strong> to connect databases and LLMs: <code>ax.NewAgent</code> plus a goja runtime with GraphJin's query engine registered as host tools. Rows never enter a prompt; the model writes small code steps against data the host owns.</p>
+</div>
+<div class="home-graphjin-layout">
+  <div class="home-graphjin-code">
+{{< home-code topic="graphjin" group="graphjin" compact="true" label="Embedded Ax agent" >}}
+  </div>
+  <div class="home-graphjin-copy">
+    <h3>AxAgent embeds into your tool the same way.</h3>
+    <p>Keep database access, permissions, and result rows inside your application process while Ax gives the model a typed agent boundary.</p>
+    <div class="home-badge-row">
+      <span>PostgreSQL</span><span>MySQL</span><span>SQLite</span><span>MongoDB</span><span>Snowflake</span>
+    </div>
+    <div class="home-actions home-section-actions">
+      <a href="https://graphjin.com">Explore GraphJin</a>
+      <a class="home-button-secondary" href="https://github.com/dosco/graphjin">GraphJin on GitHub</a>
+    </div>
+    <p class="home-inline-note">GraphJin also doubles as an MCP server, so any Ax agent can call it as an external tool. <a href="/typescript/concepts/mcp/">Read the MCP guide</a>.</p>
+  </div>
+</div>
+<div class="home-resource-row home-resource-row-tight">
+  <div>
+    <p class="home-section-label">In-process embedding</p>
+    <h3>Put the agent beside the system that owns the data.</h3>
+    <p>The host registers narrow query and schema functions in the runtime session. The executor operates on their results locally, while only bounded prompts and typed evidence cross the model boundary.</p>
+  </div>
+  <div>
+{{< svg "embedded-agent" "Ax agent embedded inside a host application" >}}
+  </div>
+</div>
+</section>
+
 <section class="home-section home-audio-section" aria-labelledby="audio">
 <div class="home-section-heading">
   <p class="home-section-label">Audio</p>
@@ -343,7 +378,7 @@ description: "Stop prompting. Start programming. Typed signatures become reliabl
 <div class="home-section-heading home-section-heading-wide">
   <p class="home-section-label">The full surface</p>
   <h2 id="included">Everything you need to build useful LLM systems.</h2>
-  <p>Every capability above hangs off the same signature contract. Start with a single typed generation call, then grow into tools, agents, voice, workflows, telemetry, optimization, and native packages without switching mental models.</p>
+  <p>Every capability above hangs off the same signature contract. Start with a single typed generation call, then grow into tools, agents, voice, workflows, telemetry, optimization, and native packages without switching mental models. New to Ax? <a href="/typescript/how-ax-fits-together/" data-home-lang-href="how-ax-fits-together/">See how the pieces fit together</a>.</p>
 </div>
 <div class="home-capability-grid">
   <article class="home-marketing-card">{{< home-icon "zap" "icon-blue" >}}<h3>Structured generation <span>ax()</span></h3><p>Declare typed inputs and outputs, then get parsed host values with streaming, validation, retries, and traces.</p></article>
@@ -445,30 +480,6 @@ description: "Stop prompting. Start programming. Typed signatures become reliabl
 </div>
 </section>
 
-<section class="home-section home-graphjin" aria-labelledby="graphjin">
-<div class="home-section-heading">
-  <p class="home-section-label">Also checkout</p>
-  <h2 id="graphjin">Connect AI agents to your database.</h2>
-  <p><a href="https://graphjin.com">GraphJin</a> compiles GraphQL to efficient SQL and doubles as an MCP server, giving Ax agents direct, governed access to application data.</p>
-</div>
-<div class="home-graphjin-layout">
-  <div class="home-graphjin-code">
-{{< home-code topic="graphjin" group="graphjin" compact="true" label="GraphJin MCP" >}}
-  </div>
-  <div class="home-graphjin-copy">
-    <h3>Use GraphJin as an MCP tool inside Ax agents.</h3>
-    <p>PostgreSQL, MySQL, SQLite, MongoDB, Oracle, MSSQL, and Snowflake can sit behind one data access layer for AI workflows.</p>
-    <div class="home-badge-row">
-      <span>PostgreSQL</span><span>MySQL</span><span>SQLite</span><span>MongoDB</span><span>Snowflake</span>
-    </div>
-    <div class="home-actions home-section-actions">
-      <a href="https://graphjin.com">Explore GraphJin</a>
-      <a class="home-button-secondary" href="https://github.com/dosco/graphjin">GitHub</a>
-    </div>
-  </div>
-</div>
-</section>
-
 <section class="home-section home-final-cta" aria-labelledby="get-started">
 <div class="home-section-heading">
   <p class="home-section-label">Start now</p>
@@ -477,6 +488,7 @@ description: "Stop prompting. Start programming. Typed signatures become reliabl
 </div>
 <div class="home-actions">
   <a href="/typescript/quick-start/">Get started</a>
+  <a class="home-button-secondary" href="/typescript/how-ax-fits-together/">How Ax fits together</a>
   <a class="home-button-secondary" href="/typescript/examples/">Examples</a>
   <a class="home-button-secondary" href="https://github.com/ax-llm/ax">GitHub</a>
   <a class="home-button-secondary" href="https://x.com/intent/follow?screen_name=dosco">Follow @dosco on X</a>

--- a/website/data/homepage_languages.yaml
+++ b/website/data/homepage_languages.yaml
@@ -101,21 +101,26 @@ languages:
           config: { baseURL: "http://localhost:11434/v1" },
         });
     graphjin:
-      filename: ax-agent.ts
+      filename: embedded-agent.ts
       code: |
-        import { AxMCPClient, AxMCPHTTPSSETransport, agent } from "@ax-llm/ax";
+        import { AxJSRuntime, agent, fn } from "@ax-llm/ax";
 
-        const transport = new AxMCPHTTPSSETransport(
-          "http://localhost:8080/api/v1/mcp"
+        // GraphJin owns database access inside this process.
+        const query = fn("query")
+          .description("Run a governed GraphJin query")
+          .handler((args) => graphjin.query(args))
+          .build();
+
+        const analyst = agent(
+          "schema:string, question:string -> answer:string",
+          {
+            contextFields: ["schema"],
+            functions: [query],
+            runtime: new AxJSRuntime(),
+          }
         );
-        const mcp = new AxMCPClient(transport);
-        await mcp.init();
 
-        const dataAnalyst = agent({
-          name: "data-analyst",
-          signature: "question:string -> answer:string",
-          functions: mcp.toFunction(),
-        });
+        const result = await analyst.forward(llm, { schema, question });
     patterns:
       classification: ax("text:string -> category:class \"spam, ham, promo\"")
       extraction: ax("document:string -> names:string[], dates:date[]")
@@ -223,20 +228,26 @@ languages:
             "baseURL": "http://localhost:11434/v1"
         })
     graphjin:
-      filename: ax_agent.py
+      filename: embedded_agent.py
       code: |
         from axllm import agent
-        from axllm.mcp import MCPClient, HTTPSSETransport
+        from axllm.runtime_quickjs import AxQuickJsCodeRuntime
 
-        transport = HTTPSSETransport(
-            "http://localhost:8080/api/v1/mcp"
+        # GraphJin owns database access inside this process.
+        runtime = AxQuickJsCodeRuntime()
+        runtime.register_callable("query", graphjin.query)
+
+        analyst = agent(
+            "schema:string, question:string -> answer:string",
+            {
+                "contextFields": ["schema"],
+                "functions": [{"name": "query", "description": "Run a governed GraphJin query"}],
+                "runtime": {"language": "JavaScript"},
+            },
         )
-        mcp = MCPClient(transport)
-        mcp.init()
 
-        data_analyst = agent(
-            "question:string -> answer:string",
-            {"functions": mcp.to_functions()},
+        result = analyst.forward(
+            llm, {"schema": schema, "question": question}, {"runtime": runtime}
         )
     patterns:
       classification: ax('text:string -> category:class "spam, ham, promo"')
@@ -350,17 +361,27 @@ languages:
           "baseURL", "http://localhost:11434/v1"
         ));
     graphjin:
-      filename: AxAgent.java
+      filename: EmbeddedAgent.java
       code: |
-        var transport = new AxMCPHTTPSSETransport(
-          "http://localhost:8080/api/v1/mcp"
-        );
-        var mcp = new AxMCPClient(transport);
-        mcp.init();
+        // GraphJin owns database access inside this process.
+        var runtime = new AxQuickJsCodeRuntime();
+        runtime.registerCallable("query", graphjin::query);
 
-        var dataAnalyst = Ax.agent(
-          "question:string -> answer:string",
-          Map.of("functions", mcp.toFunctions())
+        var analyst = Ax.agent(
+          "schema:string, question:string -> answer:string",
+          Map.of(
+            "contextFields", List.of("schema"),
+            "functions", List.of(Map.of(
+              "name", "query",
+              "description", "Run a governed GraphJin query"
+            )),
+            "runtime", Map.of("language", "JavaScript")
+          )
+        );
+
+        var result = analyst.forward(
+          llm, Map.of("schema", schema, "question", question),
+          Map.of("runtime", runtime)
         );
     patterns:
       classification: Ax.ax("text:string -> category:class \"spam, ham, promo\"")
@@ -469,17 +490,29 @@ languages:
           {"baseURL", "http://localhost:11434/v1"}
         }));
     graphjin:
-      filename: ax_agent.cpp
+      filename: embedded_agent.cpp
       code: |
-        auto transport = axllm::MCPHTTPSSETransport(
-          "http://localhost:8080/api/v1/mcp"
-        );
-        auto mcp = axllm::MCPClient(transport);
-        mcp.init();
+        // GraphJin owns database access inside this process.
+        axllm::runtime::quickjs::QuickJsCodeRuntime runtime;
+        runtime.register_callable("query", [&graphjin](axllm::Value args) {
+          return graphjin.query(args);
+        });
 
-        auto data_analyst = axllm::agent(
-          "question:string -> answer:string",
-          axllm::object({{"functions", mcp.to_functions()}})
+        auto analyst = axllm::agent(
+          "schema:string, question:string -> answer:string",
+          axllm::object({
+            {"contextFields", axllm::array({"schema"})},
+            {"functions", axllm::array({axllm::object({
+              {"name", "query"},
+              {"description", "Run a governed GraphJin query"}
+            })})},
+            {"runtime", axllm::object({{"language", "JavaScript"}})}
+          })
+        );
+
+        auto result = analyst.forward(
+          llm, axllm::object({{"schema", schema}, {"question", question}}),
+          axllm::object({{"runtime", axllm::Core::code_runtime_ref(runtime)}})
         );
     patterns:
       classification: axllm::ax("text:string -> category:class \"spam, ham, promo\"")
@@ -594,19 +627,28 @@ languages:
           "baseURL": "http://localhost:11434/v1",
         })
     graphjin:
-      filename: ax_agent.go
+      filename: embedded_agent.go
       code: |
-        transport := ax.NewMCPHTTPSSETransport(
-          "http://localhost:8080/api/v1/mcp",
+        // GraphJin owns database access inside this process.
+        runtime := axgoja.NewRuntime(
+          axgoja.WithCallable("query", queryTool),
         )
-        mcp := ax.NewMCPClient(transport)
-        err := mcp.Init(ctx)
 
-        dataAnalyst := ax.NewAgent(
-          "question:string -> answer:string",
+        analyst := ax.NewAgent(
+          "schema:string, question:string -> answer:string",
           map[string]ax.Value{
-            "functions": mcp.ToFunctions(),
+            "contextFields": ax.Array("schema"),
+            "functions": ax.Array(ax.Object(
+              "name", "query",
+              "description", "Run a governed GraphJin query",
+            )),
           },
+        )
+
+        result, err := analyst.Forward(
+          ctx, llm,
+          map[string]ax.Value{"schema": schema, "question": question},
+          map[string]ax.Value{"runtime": runtime},
         )
     patterns:
       classification: ax.NewAx("text:string -> category:class \"spam, ham, promo\"", nil)
@@ -717,17 +759,29 @@ languages:
           "baseURL": "http://localhost:11434/v1"
         }))?;
     graphjin:
-      filename: ax_agent.rs
+      filename: embedded_agent.rs
       code: |
-        let transport = MCPHTTPSSETransport::new(
-          "http://localhost:8080/api/v1/mcp"
-        );
-        let mut mcp = MCPClient::new(transport);
-        mcp.init().await?;
+        // GraphJin owns database access inside this process.
+        let mut runtime = QuickJsCodeRuntime::new();
+        runtime.register_callable("query", move |args| {
+          graphjin.query(args)
+        })?;
 
-        let mut data_analyst = agent(
-          "question:string -> answer:string"
-        )?.with_functions(mcp.to_functions());
+        let mut analyst = agent_with_options(
+          "schema:string, question:string -> answer:string",
+          json!({
+            "contextFields": ["schema"],
+            "functions": [{
+              "name": "query",
+              "description": "Run a governed GraphJin query"
+            }],
+            "runtime": {"language": "JavaScript"}
+          })
+        )?.with_runtime(Box::new(runtime))?;
+
+        let result = analyst.forward(
+          &mut llm, json!({"schema": schema, "question": question})
+        )?;
     patterns:
       classification: ax("text:string -> category:class \"spam, ham, promo\"")?
       extraction: ax("document:string -> names:string[], dates:date[]")?

--- a/website/static/cpp/.well-known/agent-skills/ax-cpp-agent-context/SKILL.md
+++ b/website/static/cpp/.well-known/agent-skills/ax-cpp-agent-context/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-cpp-agent-context"
 description: "Use when writing C++ code with `axllm` for deciding between context maps, trajectory context policy, offline optimization (ACE/GEPA), and memory recall for long-context agents."
-version: "24.0.14"
+version: "24.0.15"
 ---
 # AxAgent Context Selection For C++
 

--- a/website/static/cpp/.well-known/agent-skills/ax-cpp-agent-memory-skills/SKILL.md
+++ b/website/static/cpp/.well-known/agent-skills/ax-cpp-agent-memory-skills/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-cpp-agent-memory-skills"
 description: "Use when writing C++ code with `axllm` for agent memory, recall callbacks, dynamic skill discovery, loaded-skill state, and used-skill tracking."
-version: "24.0.14"
+version: "24.0.15"
 ---
 # AxAgent Memory And Skills For C++
 

--- a/website/static/cpp/.well-known/agent-skills/ax-cpp-agent-observability/SKILL.md
+++ b/website/static/cpp/.well-known/agent-skills/ax-cpp-agent-observability/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-cpp-agent-observability"
 description: "Use when writing C++ code with `axllm` for agent tracing, centralized and multi-tenant usage accounting, action logs, runtime diagnostics, replay, and production debugging."
-version: "24.0.14"
+version: "24.0.15"
 ---
 # AxAgent Observability For C++
 

--- a/website/static/cpp/.well-known/agent-skills/ax-cpp-agent-optimize/SKILL.md
+++ b/website/static/cpp/.well-known/agent-skills/ax-cpp-agent-optimize/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-cpp-agent-optimize"
 description: "Use when writing C++ code with `axllm` for agent optimization, verified agent-playbook evolution, evaluators, judges, optimizer artifacts, BootstrapFewShot, and GEPA."
-version: "24.0.14"
+version: "24.0.15"
 ---
 # AxAgent Optimize For C++
 

--- a/website/static/cpp/.well-known/agent-skills/ax-cpp-agent-rlm/SKILL.md
+++ b/website/static/cpp/.well-known/agent-skills/ax-cpp-agent-rlm/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-cpp-agent-rlm"
 description: "Use when writing C++ code with `axllm` for RLM executor loops, AxCodeRuntime sessions, runtime envelopes, process runtimes, and optional runtime profiles."
-version: "24.0.14"
+version: "24.0.15"
 ---
 # AxAgent RLM Runtime For C++
 

--- a/website/static/cpp/.well-known/agent-skills/ax-cpp-agent/SKILL.md
+++ b/website/static/cpp/.well-known/agent-skills/ax-cpp-agent/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-cpp-agent"
 description: "Use when writing C++ code with `axllm` for agents, child delegation, tools, MCP, citations, persistent playbook learning, stage instructions, runtime state, final typed responses, and direct-respond executor skipping."
-version: "24.0.14"
+version: "24.0.15"
 ---
 # AxAgent For C++
 

--- a/website/static/cpp/.well-known/agent-skills/ax-cpp-ai/SKILL.md
+++ b/website/static/cpp/.well-known/agent-skills/ax-cpp-ai/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-cpp-ai"
 description: "Use when writing C++ code with `axllm` for named deployment profiles, generic provider clients, model selection, OpenAI-compatible calls, Responses, Gemini, Anthropic, routers, and balancers."
-version: "24.0.14"
+version: "24.0.15"
 ---
 # AxAI Providers For C++
 

--- a/website/static/cpp/.well-known/agent-skills/ax-cpp-audio/SKILL.md
+++ b/website/static/cpp/.well-known/agent-skills/ax-cpp-audio/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-cpp-audio"
 description: "Use when writing C++ code with `axllm` for audio input/output, OpenAI Responses audio mapping, realtime event folding, and generated package audio examples."
-version: "24.0.14"
+version: "24.0.15"
 ---
 # Ax Audio And Realtime For C++
 

--- a/website/static/cpp/.well-known/agent-skills/ax-cpp-flow/SKILL.md
+++ b/website/static/cpp/.well-known/agent-skills/ax-cpp-flow/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-cpp-flow"
 description: "Use when writing C++ code with `axllm` for flows, nodes, program graphs, nested programs, dynamic options, caching, and optimizer components."
-version: "24.0.14"
+version: "24.0.15"
 ---
 # AxFlow For C++
 

--- a/website/static/cpp/.well-known/agent-skills/ax-cpp-gen/SKILL.md
+++ b/website/static/cpp/.well-known/agent-skills/ax-cpp-gen/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-cpp-gen"
 description: "Use when writing C++ code with `axllm` for AxGen programs, forward calls, indexed multi-sampling, result pickers, streaming, tools, assertions, traces, usage, and output parsing."
-version: "24.0.14"
+version: "24.0.15"
 ---
 # AxGen Structured Generation For C++
 

--- a/website/static/cpp/.well-known/agent-skills/ax-cpp-gepa/SKILL.md
+++ b/website/static/cpp/.well-known/agent-skills/ax-cpp-gepa/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-cpp-gepa"
 description: "Use when writing C++ code with `axllm` for GEPA, Pareto tradeoffs, reflection clients, metric budgets, optimizer state, and artifacts."
-version: "24.0.14"
+version: "24.0.15"
 ---
 # Ax GEPA For C++
 

--- a/website/static/cpp/.well-known/agent-skills/ax-cpp-llm/SKILL.md
+++ b/website/static/cpp/.well-known/agent-skills/ax-cpp-llm/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-cpp-llm"
 description: "Use when writing C++ code with `axllm` for using the generated Ax package, factory functions, package docs, examples, and API reference."
-version: "24.0.14"
+version: "24.0.15"
 ---
 # Ax LLM Quick Reference For C++
 

--- a/website/static/cpp/.well-known/agent-skills/ax-cpp-playbook/SKILL.md
+++ b/website/static/cpp/.well-known/agent-skills/ax-cpp-playbook/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-cpp-playbook"
 description: "Use when writing C++ code with `axllm` for the playbook() context-engineering surface, agent-bound verified evolution, run-end learning, online updates, and rendering a playbook into a program."
-version: "24.0.14"
+version: "24.0.15"
 ---
 # Ax Playbook For C++
 

--- a/website/static/cpp/.well-known/agent-skills/ax-cpp-refine/SKILL.md
+++ b/website/static/cpp/.well-known/agent-skills/ax-cpp-refine/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-cpp-refine"
 description: "Use when writing C++ code with `axllm` for reward-scored generation, iterative candidate improvement, evaluator feedback, and optimizer-backed refinement patterns."
-version: "24.0.14"
+version: "24.0.15"
 ---
 # Ax Refinement Patterns For C++
 

--- a/website/static/cpp/.well-known/agent-skills/ax-cpp-signature/SKILL.md
+++ b/website/static/cpp/.well-known/agent-skills/ax-cpp-signature/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-cpp-signature"
 description: "Use when writing C++ code with `axllm` for string signatures, field descriptors, JSON schema output, validation, and typed tool argument shapes."
-version: "24.0.14"
+version: "24.0.15"
 ---
 # Ax Signatures For C++
 

--- a/website/static/cpp/.well-known/agent-skills/index.json
+++ b/website/static/cpp/.well-known/agent-skills/index.json
@@ -6,105 +6,105 @@
       "type": "skill-md",
       "description": "Use when writing C++ code with `axllm` for using the generated Ax package, factory functions, package docs, examples, and API reference.",
       "url": "ax-cpp-llm/SKILL.md",
-      "digest": "sha256:2399e0801ac385e862bf3cf3b9b1b65068f3ab2e432ee3d0a2a35e671e31da50"
+      "digest": "sha256:0d5bde29ebda0993e90febe2a4642b6e62591c5c57d3fabef75c0a4b71123620"
     },
     {
       "name": "ax-cpp-ai",
       "type": "skill-md",
       "description": "Use when writing C++ code with `axllm` for named deployment profiles, generic provider clients, model selection, OpenAI-compatible calls, Responses, Gemini, Anthropic, routers, and balancers.",
       "url": "ax-cpp-ai/SKILL.md",
-      "digest": "sha256:022f2a3025cd644c04770baaf28d4732bb6efadccc45d76b63cb9a11b2fcfbe5"
+      "digest": "sha256:a024e19e6213d88684645c090ef0bc24b61cb03150546942759cb7206871433f"
     },
     {
       "name": "ax-cpp-audio",
       "type": "skill-md",
       "description": "Use when writing C++ code with `axllm` for audio input/output, OpenAI Responses audio mapping, realtime event folding, and generated package audio examples.",
       "url": "ax-cpp-audio/SKILL.md",
-      "digest": "sha256:86666c7b34341c9c96f64209885a35844ecdebc0a52f415dcf739dcc6adb0af0"
+      "digest": "sha256:d178c3b4f739ed5b84449dd7fd6bc991af7424d5634b9de000ca245e105a79f1"
     },
     {
       "name": "ax-cpp-signature",
       "type": "skill-md",
       "description": "Use when writing C++ code with `axllm` for string signatures, field descriptors, JSON schema output, validation, and typed tool argument shapes.",
       "url": "ax-cpp-signature/SKILL.md",
-      "digest": "sha256:c917b0789f294b21623a3e58fe3b329b30e459f7b94f37e861c6ec05f09a5d81"
+      "digest": "sha256:d8f88f583911d3a89177e66f3226e3a0952c271430cb9e9010c631ed949d66e1"
     },
     {
       "name": "ax-cpp-gen",
       "type": "skill-md",
       "description": "Use when writing C++ code with `axllm` for AxGen programs, forward calls, indexed multi-sampling, result pickers, streaming, tools, assertions, traces, usage, and output parsing.",
       "url": "ax-cpp-gen/SKILL.md",
-      "digest": "sha256:3cfea180d9682fe9706b2d611d8dab70c0c0bb77476795b5e37289c51af4cbc7"
+      "digest": "sha256:ac38e82a4e61a9c86a661e97390b51f906352a0515777ab4c6fa1f28b1c33a81"
     },
     {
       "name": "ax-cpp-flow",
       "type": "skill-md",
       "description": "Use when writing C++ code with `axllm` for flows, nodes, program graphs, nested programs, dynamic options, caching, and optimizer components.",
       "url": "ax-cpp-flow/SKILL.md",
-      "digest": "sha256:4af8db3bc65ea9b8af0ce547f721461575ceac1c46b51ead39012dabca59b11c"
+      "digest": "sha256:838d45ff489810312071bfcd15a0323b4f7891189321759108e87b550527e095"
     },
     {
       "name": "ax-cpp-agent",
       "type": "skill-md",
       "description": "Use when writing C++ code with `axllm` for agents, child delegation, tools, MCP, citations, persistent playbook learning, stage instructions, runtime state, final typed responses, and direct-respond executor skipping.",
       "url": "ax-cpp-agent/SKILL.md",
-      "digest": "sha256:b1953e70563567faa2c843193eca0b9ca67ffbe9436cffdd158cb0a7d12493ca"
+      "digest": "sha256:d5bb63011ebad9574624a608db6a891a01510ffdc3da4d5ba9cc65d3f5535bdf"
     },
     {
       "name": "ax-cpp-agent-rlm",
       "type": "skill-md",
       "description": "Use when writing C++ code with `axllm` for RLM executor loops, AxCodeRuntime sessions, runtime envelopes, process runtimes, and optional runtime profiles.",
       "url": "ax-cpp-agent-rlm/SKILL.md",
-      "digest": "sha256:a17b6f76b9e4a35cd1e6fd00be6364f5b61cc0718c2e10d261e5d7b5bbf3846c"
+      "digest": "sha256:82750c592f986954b92dc3c275765f0a0817bf656e45cce306bab99e9ba797a6"
     },
     {
       "name": "ax-cpp-agent-memory-skills",
       "type": "skill-md",
       "description": "Use when writing C++ code with `axllm` for agent memory, recall callbacks, dynamic skill discovery, loaded-skill state, and used-skill tracking.",
       "url": "ax-cpp-agent-memory-skills/SKILL.md",
-      "digest": "sha256:0b5b57fa8107d69a216a30d88d9c6ff31a93bf47f7ec3563af71fa48f94cdd9f"
+      "digest": "sha256:a7e40fb1527bbf08445c22ea1bbbd44dfc20b22f6ea4606e02c5304fa9fdd9f9"
     },
     {
       "name": "ax-cpp-agent-observability",
       "type": "skill-md",
       "description": "Use when writing C++ code with `axllm` for agent tracing, centralized and multi-tenant usage accounting, action logs, runtime diagnostics, replay, and production debugging.",
       "url": "ax-cpp-agent-observability/SKILL.md",
-      "digest": "sha256:f2da2fd59df4d975feb781d1428b463e8a2a3c208ed5ffa196c359333ee55f35"
+      "digest": "sha256:806f4749d95a147378afdd40d2cad27fcddd9d6901a470db81d2efca2d6df72b"
     },
     {
       "name": "ax-cpp-agent-optimize",
       "type": "skill-md",
       "description": "Use when writing C++ code with `axllm` for agent optimization, verified agent-playbook evolution, evaluators, judges, optimizer artifacts, BootstrapFewShot, and GEPA.",
       "url": "ax-cpp-agent-optimize/SKILL.md",
-      "digest": "sha256:ad73a9f080528d35b62deade2b65e59d47e840ae56a1405c14e43066a7d4bdda"
+      "digest": "sha256:0b13a6f4815dbf8553dd314007231aaefeff086ac0062aa159215b6c12cb5952"
     },
     {
       "name": "ax-cpp-agent-context",
       "type": "skill-md",
       "description": "Use when writing C++ code with `axllm` for deciding between context maps, trajectory context policy, offline optimization (ACE/GEPA), and memory recall for long-context agents.",
       "url": "ax-cpp-agent-context/SKILL.md",
-      "digest": "sha256:bc7fd654b51c27427ec5f3d1cf012ea0a682f77a6550b06e6423953ab87b6ba9"
+      "digest": "sha256:fb52916cf56adb59399509a1eefb76434cda6f835c6f9473838318131f129224"
     },
     {
       "name": "ax-cpp-gepa",
       "type": "skill-md",
       "description": "Use when writing C++ code with `axllm` for GEPA, Pareto tradeoffs, reflection clients, metric budgets, optimizer state, and artifacts.",
       "url": "ax-cpp-gepa/SKILL.md",
-      "digest": "sha256:eca1a7e3eba633b25d2bbf02f49490b3b76a0a8650b28ede400572376b8ebbaf"
+      "digest": "sha256:0d024608c6ab8eedace6b83f6d2dc7f21397f9ab4dd128a3ccaea4dc318b4083"
     },
     {
       "name": "ax-cpp-refine",
       "type": "skill-md",
       "description": "Use when writing C++ code with `axllm` for reward-scored generation, iterative candidate improvement, evaluator feedback, and optimizer-backed refinement patterns.",
       "url": "ax-cpp-refine/SKILL.md",
-      "digest": "sha256:bb8c7a829df6313992c0226a2fe0a0ae9c71de55f261ed6afe5b5b9344ea938a"
+      "digest": "sha256:8fb697859b9ced08116d6ee84c655969ac882a6db9cb9881f3162c41d1bef646"
     },
     {
       "name": "ax-cpp-playbook",
       "type": "skill-md",
       "description": "Use when writing C++ code with `axllm` for the playbook() context-engineering surface, agent-bound verified evolution, run-end learning, online updates, and rendering a playbook into a program.",
       "url": "ax-cpp-playbook/SKILL.md",
-      "digest": "sha256:4a61076a30e1ddfee90a01e3a47ed0dfbe238cabc472de4be82322584e61312c"
+      "digest": "sha256:941a447da9bb2fa2f519dff4c85551606c1e7d4d7588f86d2947a22d6a04d9ac"
     }
   ]
 }

--- a/website/static/go/.well-known/agent-skills/ax-go-agent-context/SKILL.md
+++ b/website/static/go/.well-known/agent-skills/ax-go-agent-context/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-go-agent-context"
 description: "Use when writing Go code with `github.com/ax-llm/ax/packages/go` for deciding between context maps, trajectory context policy, offline optimization (ACE/GEPA), and memory recall for long-context agents."
-version: "24.0.14"
+version: "24.0.15"
 ---
 # AxAgent Context Selection For Go
 

--- a/website/static/go/.well-known/agent-skills/ax-go-agent-memory-skills/SKILL.md
+++ b/website/static/go/.well-known/agent-skills/ax-go-agent-memory-skills/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-go-agent-memory-skills"
 description: "Use when writing Go code with `github.com/ax-llm/ax/packages/go` for agent memory, recall callbacks, dynamic skill discovery, loaded-skill state, and used-skill tracking."
-version: "24.0.14"
+version: "24.0.15"
 ---
 # AxAgent Memory And Skills For Go
 

--- a/website/static/go/.well-known/agent-skills/ax-go-agent-observability/SKILL.md
+++ b/website/static/go/.well-known/agent-skills/ax-go-agent-observability/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-go-agent-observability"
 description: "Use when writing Go code with `github.com/ax-llm/ax/packages/go` for agent tracing, centralized and multi-tenant usage accounting, action logs, runtime diagnostics, replay, and production debugging."
-version: "24.0.14"
+version: "24.0.15"
 ---
 # AxAgent Observability For Go
 

--- a/website/static/go/.well-known/agent-skills/ax-go-agent-optimize/SKILL.md
+++ b/website/static/go/.well-known/agent-skills/ax-go-agent-optimize/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-go-agent-optimize"
 description: "Use when writing Go code with `github.com/ax-llm/ax/packages/go` for agent optimization, verified agent-playbook evolution, evaluators, judges, optimizer artifacts, BootstrapFewShot, and GEPA."
-version: "24.0.14"
+version: "24.0.15"
 ---
 # AxAgent Optimize For Go
 

--- a/website/static/go/.well-known/agent-skills/ax-go-agent-rlm/SKILL.md
+++ b/website/static/go/.well-known/agent-skills/ax-go-agent-rlm/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-go-agent-rlm"
 description: "Use when writing Go code with `github.com/ax-llm/ax/packages/go` for RLM executor loops, AxCodeRuntime sessions, runtime envelopes, process runtimes, and optional runtime profiles."
-version: "24.0.14"
+version: "24.0.15"
 ---
 # AxAgent RLM Runtime For Go
 

--- a/website/static/go/.well-known/agent-skills/ax-go-agent/SKILL.md
+++ b/website/static/go/.well-known/agent-skills/ax-go-agent/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-go-agent"
 description: "Use when writing Go code with `github.com/ax-llm/ax/packages/go` for agents, child delegation, tools, MCP, citations, persistent playbook learning, stage instructions, runtime state, final typed responses, and direct-respond executor skipping."
-version: "24.0.14"
+version: "24.0.15"
 ---
 # AxAgent For Go
 

--- a/website/static/go/.well-known/agent-skills/ax-go-ai/SKILL.md
+++ b/website/static/go/.well-known/agent-skills/ax-go-ai/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-go-ai"
 description: "Use when writing Go code with `github.com/ax-llm/ax/packages/go` for named deployment profiles, generic provider clients, model selection, OpenAI-compatible calls, Responses, Gemini, Anthropic, routers, and balancers."
-version: "24.0.14"
+version: "24.0.15"
 ---
 # AxAI Providers For Go
 

--- a/website/static/go/.well-known/agent-skills/ax-go-audio/SKILL.md
+++ b/website/static/go/.well-known/agent-skills/ax-go-audio/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-go-audio"
 description: "Use when writing Go code with `github.com/ax-llm/ax/packages/go` for audio input/output, OpenAI Responses audio mapping, realtime event folding, and generated package audio examples."
-version: "24.0.14"
+version: "24.0.15"
 ---
 # Ax Audio And Realtime For Go
 

--- a/website/static/go/.well-known/agent-skills/ax-go-flow/SKILL.md
+++ b/website/static/go/.well-known/agent-skills/ax-go-flow/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-go-flow"
 description: "Use when writing Go code with `github.com/ax-llm/ax/packages/go` for flows, nodes, program graphs, nested programs, dynamic options, caching, and optimizer components."
-version: "24.0.14"
+version: "24.0.15"
 ---
 # AxFlow For Go
 

--- a/website/static/go/.well-known/agent-skills/ax-go-gen/SKILL.md
+++ b/website/static/go/.well-known/agent-skills/ax-go-gen/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-go-gen"
 description: "Use when writing Go code with `github.com/ax-llm/ax/packages/go` for AxGen programs, forward calls, indexed multi-sampling, result pickers, streaming, tools, assertions, traces, usage, and output parsing."
-version: "24.0.14"
+version: "24.0.15"
 ---
 # AxGen Structured Generation For Go
 

--- a/website/static/go/.well-known/agent-skills/ax-go-gepa/SKILL.md
+++ b/website/static/go/.well-known/agent-skills/ax-go-gepa/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-go-gepa"
 description: "Use when writing Go code with `github.com/ax-llm/ax/packages/go` for GEPA, Pareto tradeoffs, reflection clients, metric budgets, optimizer state, and artifacts."
-version: "24.0.14"
+version: "24.0.15"
 ---
 # Ax GEPA For Go
 

--- a/website/static/go/.well-known/agent-skills/ax-go-llm/SKILL.md
+++ b/website/static/go/.well-known/agent-skills/ax-go-llm/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-go-llm"
 description: "Use when writing Go code with `github.com/ax-llm/ax/packages/go` for using the generated Ax package, factory functions, package docs, examples, and API reference."
-version: "24.0.14"
+version: "24.0.15"
 ---
 # Ax LLM Quick Reference For Go
 

--- a/website/static/go/.well-known/agent-skills/ax-go-playbook/SKILL.md
+++ b/website/static/go/.well-known/agent-skills/ax-go-playbook/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-go-playbook"
 description: "Use when writing Go code with `github.com/ax-llm/ax/packages/go` for the playbook() context-engineering surface, agent-bound verified evolution, run-end learning, online updates, and rendering a playbook into a program."
-version: "24.0.14"
+version: "24.0.15"
 ---
 # Ax Playbook For Go
 

--- a/website/static/go/.well-known/agent-skills/ax-go-refine/SKILL.md
+++ b/website/static/go/.well-known/agent-skills/ax-go-refine/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-go-refine"
 description: "Use when writing Go code with `github.com/ax-llm/ax/packages/go` for reward-scored generation, iterative candidate improvement, evaluator feedback, and optimizer-backed refinement patterns."
-version: "24.0.14"
+version: "24.0.15"
 ---
 # Ax Refinement Patterns For Go
 

--- a/website/static/go/.well-known/agent-skills/ax-go-signature/SKILL.md
+++ b/website/static/go/.well-known/agent-skills/ax-go-signature/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-go-signature"
 description: "Use when writing Go code with `github.com/ax-llm/ax/packages/go` for string signatures, field descriptors, JSON schema output, validation, and typed tool argument shapes."
-version: "24.0.14"
+version: "24.0.15"
 ---
 # Ax Signatures For Go
 

--- a/website/static/go/.well-known/agent-skills/index.json
+++ b/website/static/go/.well-known/agent-skills/index.json
@@ -6,105 +6,105 @@
       "type": "skill-md",
       "description": "Use when writing Go code with `github.com/ax-llm/ax/packages/go` for using the generated Ax package, factory functions, package docs, examples, and API reference.",
       "url": "ax-go-llm/SKILL.md",
-      "digest": "sha256:9e5dbf3e47b9176552bf482d889a178694cad8a3f876faff4f1c4482ec81e8ac"
+      "digest": "sha256:e3da0936e1bad822e8760daff3b9347b2baf17f672d9273ac18f0f8151d4cbb3"
     },
     {
       "name": "ax-go-ai",
       "type": "skill-md",
       "description": "Use when writing Go code with `github.com/ax-llm/ax/packages/go` for named deployment profiles, generic provider clients, model selection, OpenAI-compatible calls, Responses, Gemini, Anthropic, routers, and balancers.",
       "url": "ax-go-ai/SKILL.md",
-      "digest": "sha256:61fa59bdefc72de08e8434eedaffe3128994aa3bb2a1cffa310eeafceb5c9783"
+      "digest": "sha256:e454f22f8ef676055336eddd3f0dad516397e5d4a8bf03517d963a4d6b380532"
     },
     {
       "name": "ax-go-audio",
       "type": "skill-md",
       "description": "Use when writing Go code with `github.com/ax-llm/ax/packages/go` for audio input/output, OpenAI Responses audio mapping, realtime event folding, and generated package audio examples.",
       "url": "ax-go-audio/SKILL.md",
-      "digest": "sha256:26a91ea9ea8805159c328da164430e21e465b4192bc9e4b6d465850102bacde8"
+      "digest": "sha256:f69a958f074473f6c892f6521b9397d884adc75f57c7623f634a867987f6bd98"
     },
     {
       "name": "ax-go-signature",
       "type": "skill-md",
       "description": "Use when writing Go code with `github.com/ax-llm/ax/packages/go` for string signatures, field descriptors, JSON schema output, validation, and typed tool argument shapes.",
       "url": "ax-go-signature/SKILL.md",
-      "digest": "sha256:b4b2375b0e98804e8c2646ab42483d331c9eceadb11ae6a95751394dfcd4e314"
+      "digest": "sha256:7b703519227e51d765e8ecaaffd697286e981d7118815a48d7e48ea8bf0fd161"
     },
     {
       "name": "ax-go-gen",
       "type": "skill-md",
       "description": "Use when writing Go code with `github.com/ax-llm/ax/packages/go` for AxGen programs, forward calls, indexed multi-sampling, result pickers, streaming, tools, assertions, traces, usage, and output parsing.",
       "url": "ax-go-gen/SKILL.md",
-      "digest": "sha256:d4e43246032712b836c123047df2eb741ccf27b5fef6eafd0e12e2746f6b748f"
+      "digest": "sha256:f5330fc367e297d79b0317cac10874d5aeb567479d1705ffb6f567132011674e"
     },
     {
       "name": "ax-go-flow",
       "type": "skill-md",
       "description": "Use when writing Go code with `github.com/ax-llm/ax/packages/go` for flows, nodes, program graphs, nested programs, dynamic options, caching, and optimizer components.",
       "url": "ax-go-flow/SKILL.md",
-      "digest": "sha256:59ee848e2f2e7740536ecfa951f0fac5081959357c26ea347c57d57fe2dd80eb"
+      "digest": "sha256:3f670f1bcb7cd691c7ac59e1465bda362ab835d0527deb8e7588b698edfebd87"
     },
     {
       "name": "ax-go-agent",
       "type": "skill-md",
       "description": "Use when writing Go code with `github.com/ax-llm/ax/packages/go` for agents, child delegation, tools, MCP, citations, persistent playbook learning, stage instructions, runtime state, final typed responses, and direct-respond executor skipping.",
       "url": "ax-go-agent/SKILL.md",
-      "digest": "sha256:14722ea721e7edc188ab42fb7317ed4c66b0171cc5c388f205e7a8e63827849a"
+      "digest": "sha256:4b8dab5020234c8b1fa5970daf0aa40115ef4f91bf0ab8f89c40fad2406dd307"
     },
     {
       "name": "ax-go-agent-rlm",
       "type": "skill-md",
       "description": "Use when writing Go code with `github.com/ax-llm/ax/packages/go` for RLM executor loops, AxCodeRuntime sessions, runtime envelopes, process runtimes, and optional runtime profiles.",
       "url": "ax-go-agent-rlm/SKILL.md",
-      "digest": "sha256:0968ef628983edb60c9b6800f229a03c041e5fd760ffb6f52b7bbeaeee425414"
+      "digest": "sha256:0290ed1ad7e48f20fbc2ba2ce6862e11e79fe218ee1fb80ce3d3734b670cf418"
     },
     {
       "name": "ax-go-agent-memory-skills",
       "type": "skill-md",
       "description": "Use when writing Go code with `github.com/ax-llm/ax/packages/go` for agent memory, recall callbacks, dynamic skill discovery, loaded-skill state, and used-skill tracking.",
       "url": "ax-go-agent-memory-skills/SKILL.md",
-      "digest": "sha256:dbffd8bac8aee55418eb7c0602d964b8474bd2fc76a3d2b897502a0ab19e8e67"
+      "digest": "sha256:93fd852e8e232ad7d0b54dd93c8d579c87eace2d2f2ef10b97d04217250eb682"
     },
     {
       "name": "ax-go-agent-observability",
       "type": "skill-md",
       "description": "Use when writing Go code with `github.com/ax-llm/ax/packages/go` for agent tracing, centralized and multi-tenant usage accounting, action logs, runtime diagnostics, replay, and production debugging.",
       "url": "ax-go-agent-observability/SKILL.md",
-      "digest": "sha256:ebe26ab87a7d0d415ff445809e063f3b60e724bbb178a64e6280c6b04e5859b6"
+      "digest": "sha256:ae3f300381451329d38586b78e5c1fc02f407deaeae143ee446c8c956479caef"
     },
     {
       "name": "ax-go-agent-optimize",
       "type": "skill-md",
       "description": "Use when writing Go code with `github.com/ax-llm/ax/packages/go` for agent optimization, verified agent-playbook evolution, evaluators, judges, optimizer artifacts, BootstrapFewShot, and GEPA.",
       "url": "ax-go-agent-optimize/SKILL.md",
-      "digest": "sha256:53b68b09bb99a37622fbd07f722cfba975888ff462fe8022779a745448e1a50d"
+      "digest": "sha256:b22a4c273b278aa796c17411c10475ad6be481a69d4542a6a7f0ca76ddace527"
     },
     {
       "name": "ax-go-agent-context",
       "type": "skill-md",
       "description": "Use when writing Go code with `github.com/ax-llm/ax/packages/go` for deciding between context maps, trajectory context policy, offline optimization (ACE/GEPA), and memory recall for long-context agents.",
       "url": "ax-go-agent-context/SKILL.md",
-      "digest": "sha256:d7224f671cafb471d8334f8b9a11e860a240ac18442ed113bded05aa955228e3"
+      "digest": "sha256:57030c699ef6ebe01fa0bada9f50f243990a161837e397c969e77c05c2350165"
     },
     {
       "name": "ax-go-gepa",
       "type": "skill-md",
       "description": "Use when writing Go code with `github.com/ax-llm/ax/packages/go` for GEPA, Pareto tradeoffs, reflection clients, metric budgets, optimizer state, and artifacts.",
       "url": "ax-go-gepa/SKILL.md",
-      "digest": "sha256:39b86539115d03be6fef25f35f4b5e388fe50d8612c424a14b01414fa4edf6f6"
+      "digest": "sha256:6277191e4da5553a6ee0b49a17011cbce17b85aecf7f7498638d1c2c658d31b2"
     },
     {
       "name": "ax-go-refine",
       "type": "skill-md",
       "description": "Use when writing Go code with `github.com/ax-llm/ax/packages/go` for reward-scored generation, iterative candidate improvement, evaluator feedback, and optimizer-backed refinement patterns.",
       "url": "ax-go-refine/SKILL.md",
-      "digest": "sha256:d10df3e2759b3d824c5318eac701e6bac9f04daf0416040fe9a4274201d61ada"
+      "digest": "sha256:90d46118461c51677b176d352758f34f6e3aee93cc12c694d4b96bf5a44153f2"
     },
     {
       "name": "ax-go-playbook",
       "type": "skill-md",
       "description": "Use when writing Go code with `github.com/ax-llm/ax/packages/go` for the playbook() context-engineering surface, agent-bound verified evolution, run-end learning, online updates, and rendering a playbook into a program.",
       "url": "ax-go-playbook/SKILL.md",
-      "digest": "sha256:29925dce46040f0129953dd30ea81543751a8e0bee8be3562971fc22ef5428ab"
+      "digest": "sha256:23205b45c4f72fe467ae99773809f6a9eb33a3b5940afb92db88d7e50cdfd763"
     }
   ]
 }

--- a/website/static/java/.well-known/agent-skills/ax-java-agent-context/SKILL.md
+++ b/website/static/java/.well-known/agent-skills/ax-java-agent-context/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-java-agent-context"
 description: "Use when writing Java code with `dev.axllm:ax` for deciding between context maps, trajectory context policy, offline optimization (ACE/GEPA), and memory recall for long-context agents."
-version: "24.0.14"
+version: "24.0.15"
 ---
 # AxAgent Context Selection For Java
 

--- a/website/static/java/.well-known/agent-skills/ax-java-agent-memory-skills/SKILL.md
+++ b/website/static/java/.well-known/agent-skills/ax-java-agent-memory-skills/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-java-agent-memory-skills"
 description: "Use when writing Java code with `dev.axllm:ax` for agent memory, recall callbacks, dynamic skill discovery, loaded-skill state, and used-skill tracking."
-version: "24.0.14"
+version: "24.0.15"
 ---
 # AxAgent Memory And Skills For Java
 

--- a/website/static/java/.well-known/agent-skills/ax-java-agent-observability/SKILL.md
+++ b/website/static/java/.well-known/agent-skills/ax-java-agent-observability/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-java-agent-observability"
 description: "Use when writing Java code with `dev.axllm:ax` for agent tracing, centralized and multi-tenant usage accounting, action logs, runtime diagnostics, replay, and production debugging."
-version: "24.0.14"
+version: "24.0.15"
 ---
 # AxAgent Observability For Java
 

--- a/website/static/java/.well-known/agent-skills/ax-java-agent-optimize/SKILL.md
+++ b/website/static/java/.well-known/agent-skills/ax-java-agent-optimize/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-java-agent-optimize"
 description: "Use when writing Java code with `dev.axllm:ax` for agent optimization, verified agent-playbook evolution, evaluators, judges, optimizer artifacts, BootstrapFewShot, and GEPA."
-version: "24.0.14"
+version: "24.0.15"
 ---
 # AxAgent Optimize For Java
 

--- a/website/static/java/.well-known/agent-skills/ax-java-agent-rlm/SKILL.md
+++ b/website/static/java/.well-known/agent-skills/ax-java-agent-rlm/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-java-agent-rlm"
 description: "Use when writing Java code with `dev.axllm:ax` for RLM executor loops, AxCodeRuntime sessions, runtime envelopes, process runtimes, and optional runtime profiles."
-version: "24.0.14"
+version: "24.0.15"
 ---
 # AxAgent RLM Runtime For Java
 

--- a/website/static/java/.well-known/agent-skills/ax-java-agent/SKILL.md
+++ b/website/static/java/.well-known/agent-skills/ax-java-agent/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-java-agent"
 description: "Use when writing Java code with `dev.axllm:ax` for agents, child delegation, tools, MCP, citations, persistent playbook learning, stage instructions, runtime state, final typed responses, and direct-respond executor skipping."
-version: "24.0.14"
+version: "24.0.15"
 ---
 # AxAgent For Java
 

--- a/website/static/java/.well-known/agent-skills/ax-java-ai/SKILL.md
+++ b/website/static/java/.well-known/agent-skills/ax-java-ai/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-java-ai"
 description: "Use when writing Java code with `dev.axllm:ax` for named deployment profiles, generic provider clients, model selection, OpenAI-compatible calls, Responses, Gemini, Anthropic, routers, and balancers."
-version: "24.0.14"
+version: "24.0.15"
 ---
 # AxAI Providers For Java
 

--- a/website/static/java/.well-known/agent-skills/ax-java-audio/SKILL.md
+++ b/website/static/java/.well-known/agent-skills/ax-java-audio/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-java-audio"
 description: "Use when writing Java code with `dev.axllm:ax` for audio input/output, OpenAI Responses audio mapping, realtime event folding, and generated package audio examples."
-version: "24.0.14"
+version: "24.0.15"
 ---
 # Ax Audio And Realtime For Java
 

--- a/website/static/java/.well-known/agent-skills/ax-java-flow/SKILL.md
+++ b/website/static/java/.well-known/agent-skills/ax-java-flow/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-java-flow"
 description: "Use when writing Java code with `dev.axllm:ax` for flows, nodes, program graphs, nested programs, dynamic options, caching, and optimizer components."
-version: "24.0.14"
+version: "24.0.15"
 ---
 # AxFlow For Java
 

--- a/website/static/java/.well-known/agent-skills/ax-java-gen/SKILL.md
+++ b/website/static/java/.well-known/agent-skills/ax-java-gen/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-java-gen"
 description: "Use when writing Java code with `dev.axllm:ax` for AxGen programs, forward calls, indexed multi-sampling, result pickers, streaming, tools, assertions, traces, usage, and output parsing."
-version: "24.0.14"
+version: "24.0.15"
 ---
 # AxGen Structured Generation For Java
 

--- a/website/static/java/.well-known/agent-skills/ax-java-gepa/SKILL.md
+++ b/website/static/java/.well-known/agent-skills/ax-java-gepa/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-java-gepa"
 description: "Use when writing Java code with `dev.axllm:ax` for GEPA, Pareto tradeoffs, reflection clients, metric budgets, optimizer state, and artifacts."
-version: "24.0.14"
+version: "24.0.15"
 ---
 # Ax GEPA For Java
 

--- a/website/static/java/.well-known/agent-skills/ax-java-llm/SKILL.md
+++ b/website/static/java/.well-known/agent-skills/ax-java-llm/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-java-llm"
 description: "Use when writing Java code with `dev.axllm:ax` for using the generated Ax package, factory functions, package docs, examples, and API reference."
-version: "24.0.14"
+version: "24.0.15"
 ---
 # Ax LLM Quick Reference For Java
 

--- a/website/static/java/.well-known/agent-skills/ax-java-playbook/SKILL.md
+++ b/website/static/java/.well-known/agent-skills/ax-java-playbook/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-java-playbook"
 description: "Use when writing Java code with `dev.axllm:ax` for the playbook() context-engineering surface, agent-bound verified evolution, run-end learning, online updates, and rendering a playbook into a program."
-version: "24.0.14"
+version: "24.0.15"
 ---
 # Ax Playbook For Java
 

--- a/website/static/java/.well-known/agent-skills/ax-java-refine/SKILL.md
+++ b/website/static/java/.well-known/agent-skills/ax-java-refine/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-java-refine"
 description: "Use when writing Java code with `dev.axllm:ax` for reward-scored generation, iterative candidate improvement, evaluator feedback, and optimizer-backed refinement patterns."
-version: "24.0.14"
+version: "24.0.15"
 ---
 # Ax Refinement Patterns For Java
 

--- a/website/static/java/.well-known/agent-skills/ax-java-signature/SKILL.md
+++ b/website/static/java/.well-known/agent-skills/ax-java-signature/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-java-signature"
 description: "Use when writing Java code with `dev.axllm:ax` for string signatures, field descriptors, JSON schema output, validation, and typed tool argument shapes."
-version: "24.0.14"
+version: "24.0.15"
 ---
 # Ax Signatures For Java
 

--- a/website/static/java/.well-known/agent-skills/index.json
+++ b/website/static/java/.well-known/agent-skills/index.json
@@ -6,105 +6,105 @@
       "type": "skill-md",
       "description": "Use when writing Java code with `dev.axllm:ax` for using the generated Ax package, factory functions, package docs, examples, and API reference.",
       "url": "ax-java-llm/SKILL.md",
-      "digest": "sha256:db1f11313d0df161ec0ee53ae1d928a42dded984e6b7abf27fe5a52a476c8f19"
+      "digest": "sha256:90c0a86cfe0938714323047138481c6ec7fdf46cfd88ee29b5b698b14d9700f2"
     },
     {
       "name": "ax-java-ai",
       "type": "skill-md",
       "description": "Use when writing Java code with `dev.axllm:ax` for named deployment profiles, generic provider clients, model selection, OpenAI-compatible calls, Responses, Gemini, Anthropic, routers, and balancers.",
       "url": "ax-java-ai/SKILL.md",
-      "digest": "sha256:8aeec7d30a854aa0b401a3ea68074f0bac919313ef162bb96dabdd3f036b3a77"
+      "digest": "sha256:1c8a41f3a19933b7ccf58f4c8f8a38ff2c2c51108d9a6ad392fad78d8af28efb"
     },
     {
       "name": "ax-java-audio",
       "type": "skill-md",
       "description": "Use when writing Java code with `dev.axllm:ax` for audio input/output, OpenAI Responses audio mapping, realtime event folding, and generated package audio examples.",
       "url": "ax-java-audio/SKILL.md",
-      "digest": "sha256:4b289bf988bc3d8e27643128cbb95f512646f7169be8f1657cb609b8f59ab1a3"
+      "digest": "sha256:469c23f02e4d38f8b78c4cf059f62df10fec682b2c33af105d99287a2552a1c5"
     },
     {
       "name": "ax-java-signature",
       "type": "skill-md",
       "description": "Use when writing Java code with `dev.axllm:ax` for string signatures, field descriptors, JSON schema output, validation, and typed tool argument shapes.",
       "url": "ax-java-signature/SKILL.md",
-      "digest": "sha256:9489755a20bb91e51feeb420162d95c6fe4cd22ff1e8290f1a10a6228e221802"
+      "digest": "sha256:a9abb3756285b3532546b7634db0e5131a266d855b90c8d9ebdc2522f5e00457"
     },
     {
       "name": "ax-java-gen",
       "type": "skill-md",
       "description": "Use when writing Java code with `dev.axllm:ax` for AxGen programs, forward calls, indexed multi-sampling, result pickers, streaming, tools, assertions, traces, usage, and output parsing.",
       "url": "ax-java-gen/SKILL.md",
-      "digest": "sha256:e4f705e47b371815d8296fe5d0446996057e1710a6a0329647326cca55823a8c"
+      "digest": "sha256:8d60d28c8f50ff18de97fc95bcedeac96688160ed48a63f04a0cb55d403dd4f0"
     },
     {
       "name": "ax-java-flow",
       "type": "skill-md",
       "description": "Use when writing Java code with `dev.axllm:ax` for flows, nodes, program graphs, nested programs, dynamic options, caching, and optimizer components.",
       "url": "ax-java-flow/SKILL.md",
-      "digest": "sha256:44155d8cc79fc2df93ddf9cea77474827f6a7ce0e65480e478e4ad8e024492c6"
+      "digest": "sha256:a33e81ae5228dff7abf308cba144d6892fba88b2904b6fb9af9e49b202c1b65f"
     },
     {
       "name": "ax-java-agent",
       "type": "skill-md",
       "description": "Use when writing Java code with `dev.axllm:ax` for agents, child delegation, tools, MCP, citations, persistent playbook learning, stage instructions, runtime state, final typed responses, and direct-respond executor skipping.",
       "url": "ax-java-agent/SKILL.md",
-      "digest": "sha256:55a69af78c5074df8ed39d59eb570000f1682d1350973ae2854508cf1ea36493"
+      "digest": "sha256:e44d80b44ea14a87397049f540575069840496fff8a455ef0b234e9efe8a4484"
     },
     {
       "name": "ax-java-agent-rlm",
       "type": "skill-md",
       "description": "Use when writing Java code with `dev.axllm:ax` for RLM executor loops, AxCodeRuntime sessions, runtime envelopes, process runtimes, and optional runtime profiles.",
       "url": "ax-java-agent-rlm/SKILL.md",
-      "digest": "sha256:8e47c10ef7b18b459ef2b54deb98719c386e549c35bb548735e11be02d0fb767"
+      "digest": "sha256:4c13fb8615ba686bd291b98d07f94d09f29e8e1f146b5be8826b52c1774c29bc"
     },
     {
       "name": "ax-java-agent-memory-skills",
       "type": "skill-md",
       "description": "Use when writing Java code with `dev.axllm:ax` for agent memory, recall callbacks, dynamic skill discovery, loaded-skill state, and used-skill tracking.",
       "url": "ax-java-agent-memory-skills/SKILL.md",
-      "digest": "sha256:e6c7350f9690ab78c15e6bcb166ac2e5f4610623165bf8c3e97dc3bfb2cb385b"
+      "digest": "sha256:8bdc816732339b32b50989616ebfc2e20fc01a2ebfd1f89dcabe8337d5e2ce16"
     },
     {
       "name": "ax-java-agent-observability",
       "type": "skill-md",
       "description": "Use when writing Java code with `dev.axllm:ax` for agent tracing, centralized and multi-tenant usage accounting, action logs, runtime diagnostics, replay, and production debugging.",
       "url": "ax-java-agent-observability/SKILL.md",
-      "digest": "sha256:c84d513973dae53dcda8485b7d72d5bcf2dbc0c3794e28ebc0a6e05492464c21"
+      "digest": "sha256:20c386fc79bfa24446a1591ec573057d070a192d5f766c0a082bb4315817dc24"
     },
     {
       "name": "ax-java-agent-optimize",
       "type": "skill-md",
       "description": "Use when writing Java code with `dev.axllm:ax` for agent optimization, verified agent-playbook evolution, evaluators, judges, optimizer artifacts, BootstrapFewShot, and GEPA.",
       "url": "ax-java-agent-optimize/SKILL.md",
-      "digest": "sha256:ad8e1377fbafc92813c95f9f35791202fa17a981bcc901c5ea91a3bf149de6d5"
+      "digest": "sha256:00b3fbfd0f06ad4d7377845be7c9e8ba9d8a097b0412f9342fd36bb79fcb9087"
     },
     {
       "name": "ax-java-agent-context",
       "type": "skill-md",
       "description": "Use when writing Java code with `dev.axllm:ax` for deciding between context maps, trajectory context policy, offline optimization (ACE/GEPA), and memory recall for long-context agents.",
       "url": "ax-java-agent-context/SKILL.md",
-      "digest": "sha256:783fb16412c183096b0bb9520db8ed2cfcfade5c1781b5804698ef640b5b6560"
+      "digest": "sha256:33b6d5f14e2649f47b35cb0b00e2bdd2bbf91e43a59693bb3d2248fabca78af5"
     },
     {
       "name": "ax-java-gepa",
       "type": "skill-md",
       "description": "Use when writing Java code with `dev.axllm:ax` for GEPA, Pareto tradeoffs, reflection clients, metric budgets, optimizer state, and artifacts.",
       "url": "ax-java-gepa/SKILL.md",
-      "digest": "sha256:1dec8ab7c5bb8e4c2158443b2c0e1b90f6f1511446f381cbae2e29628365e2d9"
+      "digest": "sha256:e580d35913e141f05818e74dcb33aeeddd53fa7953d9e826fbd9beaeb734ad0e"
     },
     {
       "name": "ax-java-refine",
       "type": "skill-md",
       "description": "Use when writing Java code with `dev.axllm:ax` for reward-scored generation, iterative candidate improvement, evaluator feedback, and optimizer-backed refinement patterns.",
       "url": "ax-java-refine/SKILL.md",
-      "digest": "sha256:8e038dd7006256cc998ea185c9e29167980455b3c94ae2cdad32da311339c1ad"
+      "digest": "sha256:88b37675ac578971b5ca12cd2236f5f1f12ecb3cc4d09c1c8b9466c7f21ff29f"
     },
     {
       "name": "ax-java-playbook",
       "type": "skill-md",
       "description": "Use when writing Java code with `dev.axllm:ax` for the playbook() context-engineering surface, agent-bound verified evolution, run-end learning, online updates, and rendering a playbook into a program.",
       "url": "ax-java-playbook/SKILL.md",
-      "digest": "sha256:bf6ce81fa656ce672bac7ce61aaf3b79847440a2bd83ee95ccc88b72fb6364c6"
+      "digest": "sha256:41a3c46e1d09f144b7f1e57223674dc805b5a5c6bcb400c836382d7e55547e5d"
     }
   ]
 }

--- a/website/static/python/.well-known/agent-skills/ax-python-agent-context/SKILL.md
+++ b/website/static/python/.well-known/agent-skills/ax-python-agent-context/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-python-agent-context"
 description: "Use when writing Python code with `axllm` for deciding between context maps, trajectory context policy, offline optimization (ACE/GEPA), and memory recall for long-context agents."
-version: "24.0.14"
+version: "24.0.15"
 ---
 # AxAgent Context Selection For Python
 

--- a/website/static/python/.well-known/agent-skills/ax-python-agent-memory-skills/SKILL.md
+++ b/website/static/python/.well-known/agent-skills/ax-python-agent-memory-skills/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-python-agent-memory-skills"
 description: "Use when writing Python code with `axllm` for agent memory, recall callbacks, dynamic skill discovery, loaded-skill state, and used-skill tracking."
-version: "24.0.14"
+version: "24.0.15"
 ---
 # AxAgent Memory And Skills For Python
 

--- a/website/static/python/.well-known/agent-skills/ax-python-agent-observability/SKILL.md
+++ b/website/static/python/.well-known/agent-skills/ax-python-agent-observability/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-python-agent-observability"
 description: "Use when writing Python code with `axllm` for agent tracing, centralized and multi-tenant usage accounting, action logs, runtime diagnostics, replay, and production debugging."
-version: "24.0.14"
+version: "24.0.15"
 ---
 # AxAgent Observability For Python
 

--- a/website/static/python/.well-known/agent-skills/ax-python-agent-optimize/SKILL.md
+++ b/website/static/python/.well-known/agent-skills/ax-python-agent-optimize/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-python-agent-optimize"
 description: "Use when writing Python code with `axllm` for agent optimization, verified agent-playbook evolution, evaluators, judges, optimizer artifacts, BootstrapFewShot, and GEPA."
-version: "24.0.14"
+version: "24.0.15"
 ---
 # AxAgent Optimize For Python
 

--- a/website/static/python/.well-known/agent-skills/ax-python-agent-rlm/SKILL.md
+++ b/website/static/python/.well-known/agent-skills/ax-python-agent-rlm/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-python-agent-rlm"
 description: "Use when writing Python code with `axllm` for RLM executor loops, AxCodeRuntime sessions, runtime envelopes, process runtimes, and optional runtime profiles."
-version: "24.0.14"
+version: "24.0.15"
 ---
 # AxAgent RLM Runtime For Python
 

--- a/website/static/python/.well-known/agent-skills/ax-python-agent/SKILL.md
+++ b/website/static/python/.well-known/agent-skills/ax-python-agent/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-python-agent"
 description: "Use when writing Python code with `axllm` for agents, child delegation, tools, MCP, citations, persistent playbook learning, stage instructions, runtime state, final typed responses, and direct-respond executor skipping."
-version: "24.0.14"
+version: "24.0.15"
 ---
 # AxAgent For Python
 

--- a/website/static/python/.well-known/agent-skills/ax-python-ai/SKILL.md
+++ b/website/static/python/.well-known/agent-skills/ax-python-ai/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-python-ai"
 description: "Use when writing Python code with `axllm` for named deployment profiles, generic provider clients, model selection, OpenAI-compatible calls, Responses, Gemini, Anthropic, routers, and balancers."
-version: "24.0.14"
+version: "24.0.15"
 ---
 # AxAI Providers For Python
 

--- a/website/static/python/.well-known/agent-skills/ax-python-audio/SKILL.md
+++ b/website/static/python/.well-known/agent-skills/ax-python-audio/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-python-audio"
 description: "Use when writing Python code with `axllm` for audio input/output, OpenAI Responses audio mapping, realtime event folding, and generated package audio examples."
-version: "24.0.14"
+version: "24.0.15"
 ---
 # Ax Audio And Realtime For Python
 

--- a/website/static/python/.well-known/agent-skills/ax-python-flow/SKILL.md
+++ b/website/static/python/.well-known/agent-skills/ax-python-flow/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-python-flow"
 description: "Use when writing Python code with `axllm` for flows, nodes, program graphs, nested programs, dynamic options, caching, and optimizer components."
-version: "24.0.14"
+version: "24.0.15"
 ---
 # AxFlow For Python
 

--- a/website/static/python/.well-known/agent-skills/ax-python-gen/SKILL.md
+++ b/website/static/python/.well-known/agent-skills/ax-python-gen/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-python-gen"
 description: "Use when writing Python code with `axllm` for AxGen programs, forward calls, indexed multi-sampling, result pickers, streaming, tools, assertions, traces, usage, and output parsing."
-version: "24.0.14"
+version: "24.0.15"
 ---
 # AxGen Structured Generation For Python
 

--- a/website/static/python/.well-known/agent-skills/ax-python-gepa/SKILL.md
+++ b/website/static/python/.well-known/agent-skills/ax-python-gepa/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-python-gepa"
 description: "Use when writing Python code with `axllm` for GEPA, Pareto tradeoffs, reflection clients, metric budgets, optimizer state, and artifacts."
-version: "24.0.14"
+version: "24.0.15"
 ---
 # Ax GEPA For Python
 

--- a/website/static/python/.well-known/agent-skills/ax-python-llm/SKILL.md
+++ b/website/static/python/.well-known/agent-skills/ax-python-llm/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-python-llm"
 description: "Use when writing Python code with `axllm` for using the generated Ax package, factory functions, package docs, examples, and API reference."
-version: "24.0.14"
+version: "24.0.15"
 ---
 # Ax LLM Quick Reference For Python
 

--- a/website/static/python/.well-known/agent-skills/ax-python-playbook/SKILL.md
+++ b/website/static/python/.well-known/agent-skills/ax-python-playbook/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-python-playbook"
 description: "Use when writing Python code with `axllm` for the playbook() context-engineering surface, agent-bound verified evolution, run-end learning, online updates, and rendering a playbook into a program."
-version: "24.0.14"
+version: "24.0.15"
 ---
 # Ax Playbook For Python
 

--- a/website/static/python/.well-known/agent-skills/ax-python-refine/SKILL.md
+++ b/website/static/python/.well-known/agent-skills/ax-python-refine/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-python-refine"
 description: "Use when writing Python code with `axllm` for reward-scored generation, iterative candidate improvement, evaluator feedback, and optimizer-backed refinement patterns."
-version: "24.0.14"
+version: "24.0.15"
 ---
 # Ax Refinement Patterns For Python
 

--- a/website/static/python/.well-known/agent-skills/ax-python-signature/SKILL.md
+++ b/website/static/python/.well-known/agent-skills/ax-python-signature/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-python-signature"
 description: "Use when writing Python code with `axllm` for string signatures, field descriptors, JSON schema output, validation, and typed tool argument shapes."
-version: "24.0.14"
+version: "24.0.15"
 ---
 # Ax Signatures For Python
 

--- a/website/static/python/.well-known/agent-skills/index.json
+++ b/website/static/python/.well-known/agent-skills/index.json
@@ -6,105 +6,105 @@
       "type": "skill-md",
       "description": "Use when writing Python code with `axllm` for using the generated Ax package, factory functions, package docs, examples, and API reference.",
       "url": "ax-python-llm/SKILL.md",
-      "digest": "sha256:1cfaf85af0397a6c48d6e68e174c6c7f97a909cdacf63c9b5f7a9929ddb76aee"
+      "digest": "sha256:d1a4d9c08afe0f8c8ccd727cda2801fcfc88e3af2a0500c7879ef842085e324f"
     },
     {
       "name": "ax-python-ai",
       "type": "skill-md",
       "description": "Use when writing Python code with `axllm` for named deployment profiles, generic provider clients, model selection, OpenAI-compatible calls, Responses, Gemini, Anthropic, routers, and balancers.",
       "url": "ax-python-ai/SKILL.md",
-      "digest": "sha256:80e408547f1d53ec0d6d4f27a99d34047c7b06986d5ac3babcc8b72599076a8b"
+      "digest": "sha256:820a6c1877aa4881168d5bc93d3f5d243fcacce9da24df5fc26ef2fa30b42753"
     },
     {
       "name": "ax-python-audio",
       "type": "skill-md",
       "description": "Use when writing Python code with `axllm` for audio input/output, OpenAI Responses audio mapping, realtime event folding, and generated package audio examples.",
       "url": "ax-python-audio/SKILL.md",
-      "digest": "sha256:181dbd5fb828fd3bdc4ffe0e614c8fc1e2c86e16ee06e0c455afbfed61ed06af"
+      "digest": "sha256:828b8a70e7bac634e3d21c320bd299cd72d9420a666d7ae5f49c9cf7511e5f13"
     },
     {
       "name": "ax-python-signature",
       "type": "skill-md",
       "description": "Use when writing Python code with `axllm` for string signatures, field descriptors, JSON schema output, validation, and typed tool argument shapes.",
       "url": "ax-python-signature/SKILL.md",
-      "digest": "sha256:078c62ab6396390d6d2b97ad684b7f9d2ce7dcf0420338dfcee93fdb89df5621"
+      "digest": "sha256:78c695fc59a50b4b8b2e65690783a38775ab2475273f543db006cf8891288163"
     },
     {
       "name": "ax-python-gen",
       "type": "skill-md",
       "description": "Use when writing Python code with `axllm` for AxGen programs, forward calls, indexed multi-sampling, result pickers, streaming, tools, assertions, traces, usage, and output parsing.",
       "url": "ax-python-gen/SKILL.md",
-      "digest": "sha256:a3e7def0ea5c9148baac3c19aa7839ca3045a7a66c5c2269461933a62ac23704"
+      "digest": "sha256:88676242d854ccbfda47167f4bd99a23301c2558d0d8794f815d02376a7b10e7"
     },
     {
       "name": "ax-python-flow",
       "type": "skill-md",
       "description": "Use when writing Python code with `axllm` for flows, nodes, program graphs, nested programs, dynamic options, caching, and optimizer components.",
       "url": "ax-python-flow/SKILL.md",
-      "digest": "sha256:a05b9a5e84eb50b5e597573e9229d5b5a2816e7df3b29916b88ad0b9f6c7d674"
+      "digest": "sha256:a26e34c8e72b6f56d48106a406c13a755df6fae9e710cb7383608b605dc86260"
     },
     {
       "name": "ax-python-agent",
       "type": "skill-md",
       "description": "Use when writing Python code with `axllm` for agents, child delegation, tools, MCP, citations, persistent playbook learning, stage instructions, runtime state, final typed responses, and direct-respond executor skipping.",
       "url": "ax-python-agent/SKILL.md",
-      "digest": "sha256:c79eeb0839f1bd1fbf0d3803c1589867f303c70e885e9cfa9a11ebfe76cfe143"
+      "digest": "sha256:f7517033dfbab014bc4a69d7e894f905905276911427f6db840ba9175be1dd8d"
     },
     {
       "name": "ax-python-agent-rlm",
       "type": "skill-md",
       "description": "Use when writing Python code with `axllm` for RLM executor loops, AxCodeRuntime sessions, runtime envelopes, process runtimes, and optional runtime profiles.",
       "url": "ax-python-agent-rlm/SKILL.md",
-      "digest": "sha256:a46b73a4d2febac2d00812159f0e48c8cf209e272f0770b6e343f9ccbb168305"
+      "digest": "sha256:c70703d6bdbac492f9bc093b2f518456b925f9fb56cc5b0a5bf2bd490dea85cb"
     },
     {
       "name": "ax-python-agent-memory-skills",
       "type": "skill-md",
       "description": "Use when writing Python code with `axllm` for agent memory, recall callbacks, dynamic skill discovery, loaded-skill state, and used-skill tracking.",
       "url": "ax-python-agent-memory-skills/SKILL.md",
-      "digest": "sha256:df97f42447dc8036e23c04437eb9dac3ee1e88cb97199f8fbd9194d2fd499b99"
+      "digest": "sha256:e25fc22ddcd509cb85373d188ca40d8886aab662d543fe58855bd73b05ac900a"
     },
     {
       "name": "ax-python-agent-observability",
       "type": "skill-md",
       "description": "Use when writing Python code with `axllm` for agent tracing, centralized and multi-tenant usage accounting, action logs, runtime diagnostics, replay, and production debugging.",
       "url": "ax-python-agent-observability/SKILL.md",
-      "digest": "sha256:c2a22e9a13a8d640f8f9c4c32d2b7106cb3b65612e7f4292ec2bd7ff6357534f"
+      "digest": "sha256:358ea37ceab4d68e323243ff8fda46da8299e0d0a5b47d94406dd1c56da6f029"
     },
     {
       "name": "ax-python-agent-optimize",
       "type": "skill-md",
       "description": "Use when writing Python code with `axllm` for agent optimization, verified agent-playbook evolution, evaluators, judges, optimizer artifacts, BootstrapFewShot, and GEPA.",
       "url": "ax-python-agent-optimize/SKILL.md",
-      "digest": "sha256:77f4c6a185a34c735cacfec0cf7c94396e69ebbfbc6ce9c24a68bb1aefba77a0"
+      "digest": "sha256:72ea666c60eb6663e591b519342de5d15f880861f10f016d52e2ce461df8eacb"
     },
     {
       "name": "ax-python-agent-context",
       "type": "skill-md",
       "description": "Use when writing Python code with `axllm` for deciding between context maps, trajectory context policy, offline optimization (ACE/GEPA), and memory recall for long-context agents.",
       "url": "ax-python-agent-context/SKILL.md",
-      "digest": "sha256:ac8ebd621190269d9bf0516767ae55f5544f8e31828d435df347b031e27da890"
+      "digest": "sha256:2211156bed536f04c5228b4edae6538a1536a2b83efcb398c2dedf2e552960b1"
     },
     {
       "name": "ax-python-gepa",
       "type": "skill-md",
       "description": "Use when writing Python code with `axllm` for GEPA, Pareto tradeoffs, reflection clients, metric budgets, optimizer state, and artifacts.",
       "url": "ax-python-gepa/SKILL.md",
-      "digest": "sha256:c463caa399cdc1fd45b025eeb0063fff0fa67fbb50d7d614ddfe6440d18a865c"
+      "digest": "sha256:6d8e1061636de76ef2f97af3268da22cd4f336f67473e24d538d3087d131be7a"
     },
     {
       "name": "ax-python-refine",
       "type": "skill-md",
       "description": "Use when writing Python code with `axllm` for reward-scored generation, iterative candidate improvement, evaluator feedback, and optimizer-backed refinement patterns.",
       "url": "ax-python-refine/SKILL.md",
-      "digest": "sha256:074571b8db20ecde76ae783846cf933ad34952cae0391637e369c52b5eb1e03b"
+      "digest": "sha256:f1e44e92eb03828f6ae887e75ab94de63f355e374cc043dffd3088a8b9923e1d"
     },
     {
       "name": "ax-python-playbook",
       "type": "skill-md",
       "description": "Use when writing Python code with `axllm` for the playbook() context-engineering surface, agent-bound verified evolution, run-end learning, online updates, and rendering a playbook into a program.",
       "url": "ax-python-playbook/SKILL.md",
-      "digest": "sha256:3d44d919743cfd6d0ff7c7a2a72b643b9abeb389c821c4f3f84a1612e3feae84"
+      "digest": "sha256:115cde16899b1054b19ee954a4f4f4431243129976c9fb494b3693ada3a4cc9e"
     }
   ]
 }

--- a/website/static/rust/.well-known/agent-skills/ax-rust-agent-context/SKILL.md
+++ b/website/static/rust/.well-known/agent-skills/ax-rust-agent-context/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-rust-agent-context"
 description: "Use when writing Rust code with `axllm` for deciding between context maps, trajectory context policy, offline optimization (ACE/GEPA), and memory recall for long-context agents."
-version: "24.0.14"
+version: "24.0.15"
 ---
 # AxAgent Context Selection For Rust
 

--- a/website/static/rust/.well-known/agent-skills/ax-rust-agent-memory-skills/SKILL.md
+++ b/website/static/rust/.well-known/agent-skills/ax-rust-agent-memory-skills/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-rust-agent-memory-skills"
 description: "Use when writing Rust code with `axllm` for agent memory, recall callbacks, dynamic skill discovery, loaded-skill state, and used-skill tracking."
-version: "24.0.14"
+version: "24.0.15"
 ---
 # AxAgent Memory And Skills For Rust
 

--- a/website/static/rust/.well-known/agent-skills/ax-rust-agent-observability/SKILL.md
+++ b/website/static/rust/.well-known/agent-skills/ax-rust-agent-observability/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-rust-agent-observability"
 description: "Use when writing Rust code with `axllm` for agent tracing, centralized and multi-tenant usage accounting, action logs, runtime diagnostics, replay, and production debugging."
-version: "24.0.14"
+version: "24.0.15"
 ---
 # AxAgent Observability For Rust
 

--- a/website/static/rust/.well-known/agent-skills/ax-rust-agent-optimize/SKILL.md
+++ b/website/static/rust/.well-known/agent-skills/ax-rust-agent-optimize/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-rust-agent-optimize"
 description: "Use when writing Rust code with `axllm` for agent optimization, verified agent-playbook evolution, evaluators, judges, optimizer artifacts, BootstrapFewShot, and GEPA."
-version: "24.0.14"
+version: "24.0.15"
 ---
 # AxAgent Optimize For Rust
 

--- a/website/static/rust/.well-known/agent-skills/ax-rust-agent-rlm/SKILL.md
+++ b/website/static/rust/.well-known/agent-skills/ax-rust-agent-rlm/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-rust-agent-rlm"
 description: "Use when writing Rust code with `axllm` for RLM executor loops, AxCodeRuntime sessions, runtime envelopes, process runtimes, and optional runtime profiles."
-version: "24.0.14"
+version: "24.0.15"
 ---
 # AxAgent RLM Runtime For Rust
 

--- a/website/static/rust/.well-known/agent-skills/ax-rust-agent/SKILL.md
+++ b/website/static/rust/.well-known/agent-skills/ax-rust-agent/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-rust-agent"
 description: "Use when writing Rust code with `axllm` for agents, child delegation, tools, MCP, citations, persistent playbook learning, stage instructions, runtime state, final typed responses, and direct-respond executor skipping."
-version: "24.0.14"
+version: "24.0.15"
 ---
 # AxAgent For Rust
 

--- a/website/static/rust/.well-known/agent-skills/ax-rust-ai/SKILL.md
+++ b/website/static/rust/.well-known/agent-skills/ax-rust-ai/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-rust-ai"
 description: "Use when writing Rust code with `axllm` for named deployment profiles, generic provider clients, model selection, OpenAI-compatible calls, Responses, Gemini, Anthropic, routers, and balancers."
-version: "24.0.14"
+version: "24.0.15"
 ---
 # AxAI Providers For Rust
 

--- a/website/static/rust/.well-known/agent-skills/ax-rust-audio/SKILL.md
+++ b/website/static/rust/.well-known/agent-skills/ax-rust-audio/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-rust-audio"
 description: "Use when writing Rust code with `axllm` for audio input/output, OpenAI Responses audio mapping, realtime event folding, and generated package audio examples."
-version: "24.0.14"
+version: "24.0.15"
 ---
 # Ax Audio And Realtime For Rust
 

--- a/website/static/rust/.well-known/agent-skills/ax-rust-flow/SKILL.md
+++ b/website/static/rust/.well-known/agent-skills/ax-rust-flow/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-rust-flow"
 description: "Use when writing Rust code with `axllm` for flows, nodes, program graphs, nested programs, dynamic options, caching, and optimizer components."
-version: "24.0.14"
+version: "24.0.15"
 ---
 # AxFlow For Rust
 

--- a/website/static/rust/.well-known/agent-skills/ax-rust-gen/SKILL.md
+++ b/website/static/rust/.well-known/agent-skills/ax-rust-gen/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-rust-gen"
 description: "Use when writing Rust code with `axllm` for AxGen programs, forward calls, indexed multi-sampling, result pickers, streaming, tools, assertions, traces, usage, and output parsing."
-version: "24.0.14"
+version: "24.0.15"
 ---
 # AxGen Structured Generation For Rust
 

--- a/website/static/rust/.well-known/agent-skills/ax-rust-gepa/SKILL.md
+++ b/website/static/rust/.well-known/agent-skills/ax-rust-gepa/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-rust-gepa"
 description: "Use when writing Rust code with `axllm` for GEPA, Pareto tradeoffs, reflection clients, metric budgets, optimizer state, and artifacts."
-version: "24.0.14"
+version: "24.0.15"
 ---
 # Ax GEPA For Rust
 

--- a/website/static/rust/.well-known/agent-skills/ax-rust-llm/SKILL.md
+++ b/website/static/rust/.well-known/agent-skills/ax-rust-llm/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-rust-llm"
 description: "Use when writing Rust code with `axllm` for using the generated Ax package, factory functions, package docs, examples, and API reference."
-version: "24.0.14"
+version: "24.0.15"
 ---
 # Ax LLM Quick Reference For Rust
 

--- a/website/static/rust/.well-known/agent-skills/ax-rust-playbook/SKILL.md
+++ b/website/static/rust/.well-known/agent-skills/ax-rust-playbook/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-rust-playbook"
 description: "Use when writing Rust code with `axllm` for the playbook() context-engineering surface, agent-bound verified evolution, run-end learning, online updates, and rendering a playbook into a program."
-version: "24.0.14"
+version: "24.0.15"
 ---
 # Ax Playbook For Rust
 

--- a/website/static/rust/.well-known/agent-skills/ax-rust-refine/SKILL.md
+++ b/website/static/rust/.well-known/agent-skills/ax-rust-refine/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-rust-refine"
 description: "Use when writing Rust code with `axllm` for reward-scored generation, iterative candidate improvement, evaluator feedback, and optimizer-backed refinement patterns."
-version: "24.0.14"
+version: "24.0.15"
 ---
 # Ax Refinement Patterns For Rust
 

--- a/website/static/rust/.well-known/agent-skills/ax-rust-signature/SKILL.md
+++ b/website/static/rust/.well-known/agent-skills/ax-rust-signature/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-rust-signature"
 description: "Use when writing Rust code with `axllm` for string signatures, field descriptors, JSON schema output, validation, and typed tool argument shapes."
-version: "24.0.14"
+version: "24.0.15"
 ---
 # Ax Signatures For Rust
 

--- a/website/static/rust/.well-known/agent-skills/index.json
+++ b/website/static/rust/.well-known/agent-skills/index.json
@@ -6,105 +6,105 @@
       "type": "skill-md",
       "description": "Use when writing Rust code with `axllm` for using the generated Ax package, factory functions, package docs, examples, and API reference.",
       "url": "ax-rust-llm/SKILL.md",
-      "digest": "sha256:6cfd82c5cb9219f6aa1445876a5bdc5ffff6b5bf57269885eb6da75664f3f652"
+      "digest": "sha256:54f1a4ebcab0718ba8118cdaaceb92a9fb9f4a56b77a9b930ba384d711102173"
     },
     {
       "name": "ax-rust-ai",
       "type": "skill-md",
       "description": "Use when writing Rust code with `axllm` for named deployment profiles, generic provider clients, model selection, OpenAI-compatible calls, Responses, Gemini, Anthropic, routers, and balancers.",
       "url": "ax-rust-ai/SKILL.md",
-      "digest": "sha256:6af84d10c636d41280714ced8fef401c9b770929f069833ba3389cf364f32b23"
+      "digest": "sha256:04fe7075c869d6aee20479ffa623504b66362a62cfed02d0ff78609459b2d795"
     },
     {
       "name": "ax-rust-audio",
       "type": "skill-md",
       "description": "Use when writing Rust code with `axllm` for audio input/output, OpenAI Responses audio mapping, realtime event folding, and generated package audio examples.",
       "url": "ax-rust-audio/SKILL.md",
-      "digest": "sha256:c9f0d15000b219e055ddbf77bb494a75b993936b9a8be7c1523d9e69863733e5"
+      "digest": "sha256:f47baefbc0b953977077f909a90b0eb5d82aa1eb9973eba3c982995cb6947901"
     },
     {
       "name": "ax-rust-signature",
       "type": "skill-md",
       "description": "Use when writing Rust code with `axllm` for string signatures, field descriptors, JSON schema output, validation, and typed tool argument shapes.",
       "url": "ax-rust-signature/SKILL.md",
-      "digest": "sha256:6a8cd6c0142eeff43ceac366376fc4e72e9680155bed36e7b2682d9248517c9c"
+      "digest": "sha256:fb59f3098297ab354ffc9be035fa8dd4cc27c9f2748b282b90073226cb8ef2b7"
     },
     {
       "name": "ax-rust-gen",
       "type": "skill-md",
       "description": "Use when writing Rust code with `axllm` for AxGen programs, forward calls, indexed multi-sampling, result pickers, streaming, tools, assertions, traces, usage, and output parsing.",
       "url": "ax-rust-gen/SKILL.md",
-      "digest": "sha256:45ef95d2fc5e7be5022300bea5d91ad0add0a688ddc44437a0edc284d4ae21ac"
+      "digest": "sha256:72d4ff3e787a3a47444a9ae87bdda3b742116e8b57afc77f2d2da8128555f0c9"
     },
     {
       "name": "ax-rust-flow",
       "type": "skill-md",
       "description": "Use when writing Rust code with `axllm` for flows, nodes, program graphs, nested programs, dynamic options, caching, and optimizer components.",
       "url": "ax-rust-flow/SKILL.md",
-      "digest": "sha256:88938e652609c5cdceec6735e35a95e19e355fa0ab37abfae6d56f07e66a6aa0"
+      "digest": "sha256:626bdaec0309679c193ad83e65e546d7ba1916ed3f8914b04776979e1d44b132"
     },
     {
       "name": "ax-rust-agent",
       "type": "skill-md",
       "description": "Use when writing Rust code with `axllm` for agents, child delegation, tools, MCP, citations, persistent playbook learning, stage instructions, runtime state, final typed responses, and direct-respond executor skipping.",
       "url": "ax-rust-agent/SKILL.md",
-      "digest": "sha256:fd05133fc9c0da41e5ad13442981b7c65d748d3ad50f72f490b3199957b1f322"
+      "digest": "sha256:79b5032cffce3223d928944d881b29089cb66b95a9b1c9af46121ad0f908710e"
     },
     {
       "name": "ax-rust-agent-rlm",
       "type": "skill-md",
       "description": "Use when writing Rust code with `axllm` for RLM executor loops, AxCodeRuntime sessions, runtime envelopes, process runtimes, and optional runtime profiles.",
       "url": "ax-rust-agent-rlm/SKILL.md",
-      "digest": "sha256:59036034c501a4d8d2deca03a39b58cf4bb25d78876b44a161a77c8b8475b8ba"
+      "digest": "sha256:aa54c8a7649187a54dd349e4369e5f8fce5bbda89fe2c7f2d4a72e05038ea943"
     },
     {
       "name": "ax-rust-agent-memory-skills",
       "type": "skill-md",
       "description": "Use when writing Rust code with `axllm` for agent memory, recall callbacks, dynamic skill discovery, loaded-skill state, and used-skill tracking.",
       "url": "ax-rust-agent-memory-skills/SKILL.md",
-      "digest": "sha256:bdb4243019f6ecb87c10352f380fe0e3c588775c7ceb07e98398fefe3e85d5ab"
+      "digest": "sha256:604062a93374e989ab2f5d228c46363f00f1077d07db00957dcf651cad43d716"
     },
     {
       "name": "ax-rust-agent-observability",
       "type": "skill-md",
       "description": "Use when writing Rust code with `axllm` for agent tracing, centralized and multi-tenant usage accounting, action logs, runtime diagnostics, replay, and production debugging.",
       "url": "ax-rust-agent-observability/SKILL.md",
-      "digest": "sha256:09377a9b65eae3f4f83727c627c467f652a44c52e408b4c7ff0841c01a668512"
+      "digest": "sha256:099717b905b1580bc4fc529458df4a393cdf1a2a764826309a6e57e708f492e0"
     },
     {
       "name": "ax-rust-agent-optimize",
       "type": "skill-md",
       "description": "Use when writing Rust code with `axllm` for agent optimization, verified agent-playbook evolution, evaluators, judges, optimizer artifacts, BootstrapFewShot, and GEPA.",
       "url": "ax-rust-agent-optimize/SKILL.md",
-      "digest": "sha256:f3a077ee8af3919a96b965f35466df16ff729aa4db1e77b1c8987449c9528465"
+      "digest": "sha256:74ef489c8d599951155fcdf49b2a1938e0ca392c0f7803833025b4e61e9a20b8"
     },
     {
       "name": "ax-rust-agent-context",
       "type": "skill-md",
       "description": "Use when writing Rust code with `axllm` for deciding between context maps, trajectory context policy, offline optimization (ACE/GEPA), and memory recall for long-context agents.",
       "url": "ax-rust-agent-context/SKILL.md",
-      "digest": "sha256:353bbc8130c87c341ce3b404dbaa29a0c8c6deb3bad5e034edc619a1051770b4"
+      "digest": "sha256:7b993ad8494990c1db4ce40e4ef2627b191f985b36a55a3a548d6f7928619f0f"
     },
     {
       "name": "ax-rust-gepa",
       "type": "skill-md",
       "description": "Use when writing Rust code with `axllm` for GEPA, Pareto tradeoffs, reflection clients, metric budgets, optimizer state, and artifacts.",
       "url": "ax-rust-gepa/SKILL.md",
-      "digest": "sha256:5b3c4dd5e68424c58e9b43bd38dcde1e440b28d0b54061b14371800b0081dfe3"
+      "digest": "sha256:5f9176ba15b7dda574d46a7786d287aa75c387fb13fc317952914deed222535f"
     },
     {
       "name": "ax-rust-refine",
       "type": "skill-md",
       "description": "Use when writing Rust code with `axllm` for reward-scored generation, iterative candidate improvement, evaluator feedback, and optimizer-backed refinement patterns.",
       "url": "ax-rust-refine/SKILL.md",
-      "digest": "sha256:2e17d246338f5020d78dd054721e0e9427abf7fa594380d7033c4f44093919f3"
+      "digest": "sha256:013d9113667ffb5ed20ba236171a2ec162bd2d9be5f3a9267e53e931d3c3d387"
     },
     {
       "name": "ax-rust-playbook",
       "type": "skill-md",
       "description": "Use when writing Rust code with `axllm` for the playbook() context-engineering surface, agent-bound verified evolution, run-end learning, online updates, and rendering a playbook into a program.",
       "url": "ax-rust-playbook/SKILL.md",
-      "digest": "sha256:08ec3c27a734392e3c6c17d4d8f8c16e92a87b616bc2e4a1f7cd0e7062f1391a"
+      "digest": "sha256:a96a4b5bd4758644fa0f13fbde6b5a4a7a4b51ee604af16c4698036e015386a1"
     }
   ]
 }

--- a/website/static/svg/embedded-agent.svg
+++ b/website/static/svg/embedded-agent.svg
@@ -1,0 +1,81 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 980 420" role="img" aria-labelledby="title desc">
+  <title id="title">Embedded Ax agent architecture</title>
+  <desc id="desc">A host application keeps GraphJin data and an Ax runtime session in process while bounded prompts and typed output cross to an LLM provider.</desc>
+  <style>
+    text { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; }
+    .ink { fill: #0a2540; }
+    .muted { fill: #61758a; }
+    .frame { fill: none; stroke: #9aa8ba; stroke-width: 2.2; }
+    .flow { fill: none; stroke: #9aa8ba; stroke-width: 2.2; stroke-linecap: round; stroke-linejoin: round; }
+    .thin { fill: none; stroke: #c8d3df; stroke-width: 1.4; stroke-linecap: round; }
+    .soft-blue { fill: #e7f4ff; }
+    .soft-teal { fill: #e7fbf5; }
+    .soft-green { fill: #e9fbf2; }
+    .soft-amber { fill: #fff5da; }
+    .blue { fill: #067ab8; }
+    .teal { fill: #0a8f7a; }
+    .green { fill: #0a8852; }
+    .amber { fill: #a97009; }
+    .big { font-size: 20px; font-weight: 760; }
+    .label { font-size: 13px; font-weight: 700; }
+    .small { font-size: 10px; font-weight: 620; }
+    @media (prefers-color-scheme: dark) {
+      .ink { fill: #f4f7fb; }
+      .muted { fill: #aab8cb; }
+      .frame { stroke: #78879d; }
+      .flow { stroke: #78879d; }
+      .thin { stroke: #34445c; }
+      .soft-blue { fill: #10263a; }
+      .soft-teal { fill: #11342e; }
+      .soft-green { fill: #123323; }
+      .soft-amber { fill: #302614; }
+    }
+  </style>
+  <defs>
+    <marker id="arrow-embed" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="6" markerHeight="6" orient="auto">
+      <path d="M0 0 10 5 0 10Z" fill="#9aa8ba"/>
+    </marker>
+  </defs>
+
+  <rect class="frame" x="30" y="34" width="600" height="352" rx="24"/>
+  <text class="ink big" x="58" y="72">Your application process</text>
+
+  <rect class="soft-teal" x="64" y="110" width="230" height="108" rx="16"/>
+  <circle class="teal" cx="88" cy="140" r="6"/>
+  <text class="ink label" x="104" y="145">GraphJin query engine</text>
+  <rect class="thin" x="88" y="170" width="72" height="26" rx="13"/>
+  <text class="muted small" x="108" y="187">query</text>
+  <rect class="thin" x="172" y="170" width="82" height="26" rx="13"/>
+  <text class="muted small" x="193" y="187">schema</text>
+
+  <rect class="soft-blue" x="336" y="110" width="258" height="108" rx="16"/>
+  <circle class="blue" cx="360" cy="140" r="6"/>
+  <text class="ink label" x="376" y="145">Ax agent</text>
+  <rect class="thin" x="360" y="170" width="68" height="26" rx="13"/>
+  <text class="muted small" x="373" y="187">distiller</text>
+  <rect class="thin" x="438" y="170" width="70" height="26" rx="13"/>
+  <text class="muted small" x="451" y="187">executor</text>
+  <rect class="thin" x="518" y="170" width="58" height="26" rx="13"/>
+  <text class="muted small" x="529" y="187">responder</text>
+
+  <rect class="soft-green" x="202" y="264" width="258" height="86" rx="16"/>
+  <circle class="green" cx="226" cy="294" r="6"/>
+  <text class="ink label" x="242" y="299">runtime session</text>
+  <text class="muted small" x="242" y="325">rows stay here</text>
+
+  <path class="flow" marker-end="url(#arrow-embed)" d="M294 164H326"/>
+  <path class="flow" marker-end="url(#arrow-embed)" d="M473 218V252H410"/>
+  <path class="flow" marker-end="url(#arrow-embed)" d="M336 278H474V228"/>
+
+  <path class="thin" d="M676 48V372"/>
+  <text class="muted small" x="648" y="398">process boundary</text>
+
+  <rect class="soft-amber" x="750" y="140" width="184" height="132" rx="20"/>
+  <circle class="amber" cx="778" cy="174" r="7"/>
+  <text class="ink big" x="798" y="181">LLM provider</text>
+
+  <path class="flow" marker-end="url(#arrow-embed)" d="M594 142H730"/>
+  <text class="muted small" x="624" y="128">bounded prompts</text>
+  <path class="flow" marker-end="url(#arrow-embed)" d="M750 244H614"/>
+  <text class="muted small" x="644" y="266">typed output</text>
+</svg>

--- a/website/static/typescript/.well-known/agent-skills/ax-agent-context/SKILL.md
+++ b/website/static/typescript/.well-known/agent-skills/ax-agent-context/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: ax-agent-context
 description: This skill helps an LLM pick the right AxAgent context tool for a job - contextMap for recurring corpora, contextPolicy presets for within-run trajectory compaction, agent.optimize for offline GEPA instruction/demo tuning, agent.playbook for an evolving context playbook (offline evolve + online update), and recall/memories + skills for per-turn retrieval. Use when the user asks "which context feature should I use", confuses contextMap with contextPolicy or memory, or wants a decision guide for long-context agents. For contextPolicy/contextMap codegen use ax-agent-rlm; for recall/skills use ax-agent-memory-skills; for agent.optimize or agent.playbook use ax-agent-optimize.
-version: "24.0.14"
+version: "24.0.15"
 ---
 
 # AxAgent Context Selection (@ax-llm/ax)

--- a/website/static/typescript/.well-known/agent-skills/ax-agent-memory-skills/SKILL.md
+++ b/website/static/typescript/.well-known/agent-skills/ax-agent-memory-skills/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: ax-agent-memory-skills
 description: This skill helps an LLM generate correct AxAgent memory retrieval, context-map, and dynamic skill-loading code using @ax-llm/ax. Use when the user asks about contextMap, AxAgentContextMap, onMemoriesSearch, memoriesCatalog, recall(...), inputs.memories, onLoadedMemories, onUsedMemories, onSkillsSearch, skillsCatalog, AxAgentCatalogSkill, discover({ skills }), onLoadedSkills, onUsedSkills, preloaded skills, preloading memories at forward time, relevanceRanking hints, loaded memory/skill IDs, or carrying memories across forward() calls.
-version: "24.0.14"
+version: "24.0.15"
 ---
 
 # AxAgent Memory And Skills Rules (@ax-llm/ax)

--- a/website/static/typescript/.well-known/agent-skills/ax-agent-observability/SKILL.md
+++ b/website/static/typescript/.well-known/agent-skills/ax-agent-observability/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: ax-agent-observability
 description: This skill helps an LLM generate correct AxAgent observability code using @ax-llm/ax. Use when the user asks about axGlobals.onUsage, usageContext, centralized or multi-tenant usage accounting, actorTurnCallback, onContextEvent, agentStatusCallback, onFunctionCall, reportSuccess, reportFailure, getChatLog(), getUsage(), resetUsage(), debug traces, progress updates, or telemetry for AxAgent runs.
-version: "24.0.14"
+version: "24.0.15"
 ---
 
 # AxAgent Observability Rules (@ax-llm/ax)

--- a/website/static/typescript/.well-known/agent-skills/ax-agent-optimize/SKILL.md
+++ b/website/static/typescript/.well-known/agent-skills/ax-agent-optimize/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: ax-agent-optimize
 description: This skill helps an LLM generate correct AxAgent tuning and evaluation code using @ax-llm/ax. Use when the user asks about agent.optimize(...), judgeOptions, eval datasets, optimization targets, saved optimizedProgram artifacts, or agent optimization guidance.
-version: "24.0.14"
+version: "24.0.15"
 ---
 
 # AxAgent Optimize Codegen Rules (@ax-llm/ax)

--- a/website/static/typescript/.well-known/agent-skills/ax-agent-rlm/SKILL.md
+++ b/website/static/typescript/.well-known/agent-skills/ax-agent-rlm/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: ax-agent-rlm
 description: This skill helps an LLM generate correct AxAgent RLM/runtime code using @ax-llm/ax. Use when the user asks about RLM code execution, AxJSRuntime, contextFields, contextPolicy, liveRuntimeState, promptLevel, stage prompt controls, executorModelPolicy, maxRuntimeChars, agent.test(...), llmQuery(...), recursionOptions, or long-running agent runtime behavior.
-version: "24.0.14"
+version: "24.0.15"
 ---
 
 # AxAgent RLM Runtime Rules (@ax-llm/ax)

--- a/website/static/typescript/.well-known/agent-skills/ax-agent/SKILL.md
+++ b/website/static/typescript/.well-known/agent-skills/ax-agent/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: ax-agent
 description: This skill helps an LLM generate correct core AxAgent code using @ax-llm/ax. Use when the user asks about agent(), child agents, namespaced functions, discovery mode, clarification, bubbleErrors, host-side final/clarification protocol, or ordinary agent runtime behavior. For MCP clients, native runtime modules, subscriptions, tasks, or authentication use ax-mcp alongside this skill. For RLM/code-runtime work use ax-agent-rlm; for callbacks and telemetry use ax-agent-observability; for recall/memory/skill loading use ax-agent-memory-skills; for agent.optimize(...) use ax-agent-optimize.
-version: "24.0.14"
+version: "24.0.15"
 ---
 
 # AxAgent Codegen Rules (@ax-llm/ax)

--- a/website/static/typescript/.well-known/agent-skills/ax-ai/SKILL.md
+++ b/website/static/typescript/.well-known/agent-skills/ax-ai/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: ax-ai
 description: This skill helps an LLM generate correct AI provider setup and configuration code using @ax-llm/ax. Use when the user asks about ai(), providers, models, routing, adaptive balancing, presets, embeddings, batch audio with ai.transcribe() or ai.speak(), extended thinking, context caching, or mentions OpenAI/Anthropic/Google/Azure/DeepSeek/Mistral/Cohere/Reka/Grok with @ax-llm/ax.
-version: "24.0.14"
+version: "24.0.15"
 ---
 
 # AI Provider Codegen Rules (@ax-llm/ax)

--- a/website/static/typescript/.well-known/agent-skills/ax-audio/SKILL.md
+++ b/website/static/typescript/.well-known/agent-skills/ax-audio/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: ax-audio
 description: This skill helps an LLM generate correct audio code with @ax-llm/ax. Use when the user asks about ai.transcribe(), ai.speak(), signature audio inputs or outputs, agent audio behavior, .chat() conversational audio, OpenAI audio or realtime models, Gemini Live native audio, Grok Voice Agent models, voices, formats, transcripts, or how audio fits with structured outputs.
-version: "24.0.14"
+version: "24.0.15"
 ---
 
 # Audio I/O Codegen Rules (@ax-llm/ax)

--- a/website/static/typescript/.well-known/agent-skills/ax-flow/SKILL.md
+++ b/website/static/typescript/.well-known/agent-skills/ax-flow/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: ax-flow
 description: This skill helps an LLM generate correct AxFlow workflow code using @ax-llm/ax. Use when the user asks about flow(), AxFlow, workflow orchestration, parallel execution, DAG workflows, conditional routing, map/reduce patterns, or multi-node AI pipelines.
-version: "24.0.14"
+version: "24.0.15"
 ---
 
 # AxFlow Codegen Rules (@ax-llm/ax)

--- a/website/static/typescript/.well-known/agent-skills/ax-gen/SKILL.md
+++ b/website/static/typescript/.well-known/agent-skills/ax-gen/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: ax-gen
 description: This skill helps an LLM generate correct AxGen code using @ax-llm/ax. Use when the user asks about ax(), AxGen, generators, forward(), streamingForward(), validation, assertions, streaming assertions, field processors, step hooks, self-tuning, or structured outputs. For MCP clients, transports, prompts, resources, tasks, subscriptions, or authentication use ax-mcp alongside this skill.
-version: "24.0.14"
+version: "24.0.15"
 ---
 
 # AxGen Codegen Rules (@ax-llm/ax)

--- a/website/static/typescript/.well-known/agent-skills/ax-gepa/SKILL.md
+++ b/website/static/typescript/.well-known/agent-skills/ax-gepa/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: ax-gepa
 description: This skill helps an LLM generate correct AxGEPA optimization code using @ax-llm/ax. Use when the user asks about AxGEPA, GEPA, Pareto optimization, multi-objective prompt tuning, reflective prompt evolution, validationExamples, maxMetricCalls, or optimizing a generator, flow, or agent tree.
-version: "24.0.14"
+version: "24.0.15"
 ---
 
 # GEPA Optimization Codegen Rules (@ax-llm/ax)

--- a/website/static/typescript/.well-known/agent-skills/ax-llm/SKILL.md
+++ b/website/static/typescript/.well-known/agent-skills/ax-llm/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: ax-llm
 description: This skill helps with using the @ax-llm/ax TypeScript library for building LLM applications. Use when the user asks about ax(), ai(), f(), s(), agent(), flow(), AxGen, AxAgent, AxFlow, signatures, streaming, or mentions @ax-llm/ax.
-version: "24.0.14"
+version: "24.0.15"
 ---
 
 # Ax Library (@ax-llm/ax) Quick Reference

--- a/website/static/typescript/.well-known/agent-skills/ax-mcp/SKILL.md
+++ b/website/static/typescript/.well-known/agent-skills/ax-mcp/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: ax-mcp
 description: This skill helps an LLM build correct native Model Context Protocol integrations with @ax-llm/ax. Use when the user asks about AxMCPClient, MCP transports, tools, prompts, resources, subscriptions, tasks, sampling, elicitation, roots, authentication, OAuth, MCP Apps, recording/replay, or MCP integration with AxGen, AxAgent, AxFlow, chat, optimization, and AxEventRuntime.
-version: "24.0.14"
+version: "24.0.15"
 ---
 
 # Native MCP With Ax

--- a/website/static/typescript/.well-known/agent-skills/ax-playbook/SKILL.md
+++ b/website/static/typescript/.well-known/agent-skills/ax-playbook/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: ax-playbook
 description: This skill helps an LLM generate correct playbook code using @ax-llm/ax. Use when the user asks about playbook(), AxPlaybook, context playbooks, evolving context, ACE / Agentic Context Engineering, agent.playbook(), or growing/applying task knowledge offline and online with evolve() and update().
-version: "24.0.14"
+version: "24.0.15"
 ---
 
 # Playbook Codegen Rules (@ax-llm/ax)

--- a/website/static/typescript/.well-known/agent-skills/ax-refine/SKILL.md
+++ b/website/static/typescript/.well-known/agent-skills/ax-refine/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: ax-refine
 description: Use this skill when writing or reviewing Ax bestOfN/refine code, reward functions, thresholds, native sample selection, serial attempts, generated advice, and attempt diagnostics.
-version: "24.0.14"
+version: "24.0.15"
 ---
 
 # Ax Refine And BestOfN

--- a/website/static/typescript/.well-known/agent-skills/ax-signature/SKILL.md
+++ b/website/static/typescript/.well-known/agent-skills/ax-signature/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: ax-signature
 description: This skill helps an LLM generate correct DSPy signature code using @ax-llm/ax. Use when the user asks about signatures, s(), f(), field types, string syntax, fluent builder API, validation constraints, or type-safe inputs/outputs.
-version: "24.0.14"
+version: "24.0.15"
 ---
 
 # Ax Signature Reference

--- a/website/static/typescript/.well-known/agent-skills/index.json
+++ b/website/static/typescript/.well-known/agent-skills/index.json
@@ -6,91 +6,91 @@
       "type": "skill-md",
       "description": "This skill helps with using the @ax-llm/ax TypeScript library for building LLM applications. Use when the user asks about ax(), ai(), f(), s(), agent(), flow(), AxGen, AxAgent, AxFlow, signatures, streaming, or mentions @ax-llm/ax.",
       "url": "ax-llm/SKILL.md",
-      "digest": "sha256:b089538505ea97ed023bd2db044e52098884dd62b778e892fc7370a96c62d642"
+      "digest": "sha256:9d24b9c164c03a0345a498d098956aaec356d368e1aaf2f929967ccf257d44ff"
     },
     {
       "name": "ax-ai",
       "type": "skill-md",
       "description": "This skill helps an LLM generate correct AI provider setup and configuration code using @ax-llm/ax. Use when the user asks about ai(), providers, models, routing, adaptive balancing, presets, embeddings, batch audio with ai.transcribe() or ai.speak(), extended thinking, context caching, or mentions OpenAI/Anthropic/Google/Azure/DeepSeek/Mistral/Cohere/Reka/Grok with @ax-llm/ax.",
       "url": "ax-ai/SKILL.md",
-      "digest": "sha256:6ab085519f4e73b57a4953f0cf0b98bf1e1aaca076aa3c662c4fae19bb5fc287"
+      "digest": "sha256:3e5a5dc520e302b54020e35dcd00b55d56091e4687d4a4ff9fd41827acc28f6d"
     },
     {
       "name": "ax-audio",
       "type": "skill-md",
       "description": "This skill helps an LLM generate correct audio code with @ax-llm/ax. Use when the user asks about ai.transcribe(), ai.speak(), signature audio inputs or outputs, agent audio behavior, .chat() conversational audio, OpenAI audio or realtime models, Gemini Live native audio, Grok Voice Agent models, voices, formats, transcripts, or how audio fits with structured outputs.",
       "url": "ax-audio/SKILL.md",
-      "digest": "sha256:9cd7ea5cf8a6c825b06aee525ec05527ecf4f0c2b790561ea5c678ca4d96d36c"
+      "digest": "sha256:b38441b73877d58d3d4e4d12629c4ea8925cc22c6af9fd7ef8fec3570d86ff18"
     },
     {
       "name": "ax-signature",
       "type": "skill-md",
       "description": "This skill helps an LLM generate correct DSPy signature code using @ax-llm/ax. Use when the user asks about signatures, s(), f(), field types, string syntax, fluent builder API, validation constraints, or type-safe inputs/outputs.",
       "url": "ax-signature/SKILL.md",
-      "digest": "sha256:7f37b57478e32894665b004fd77fa43bfa8b5ed49097afa470cb963fd6897674"
+      "digest": "sha256:0683cbc3979ecf2ca2dae93b46f3532e6d32578eb0917fcfb107f8cf167e185e"
     },
     {
       "name": "ax-gen",
       "type": "skill-md",
       "description": "This skill helps an LLM generate correct AxGen code using @ax-llm/ax. Use when the user asks about ax(), AxGen, generators, forward(), streamingForward(), validation, assertions, streaming assertions, field processors, step hooks, self-tuning, or structured outputs. For MCP clients, transports, prompts, resources, tasks, subscriptions, or authentication use ax-mcp alongside this skill.",
       "url": "ax-gen/SKILL.md",
-      "digest": "sha256:faa34156ebb454542cf322849f7ba6a3dd0efa4c9e3696f42e7143da880041aa"
+      "digest": "sha256:0e7a3cedaa67b49a736af9212e06c5d2ff775360fed9b37bd4e829392b4449d9"
     },
     {
       "name": "ax-mcp",
       "type": "skill-md",
       "description": "This skill helps an LLM build correct native Model Context Protocol integrations with @ax-llm/ax. Use when the user asks about AxMCPClient, MCP transports, tools, prompts, resources, subscriptions, tasks, sampling, elicitation, roots, authentication, OAuth, MCP Apps, recording/replay, or MCP integration with AxGen, AxAgent, AxFlow, chat, optimization, and AxEventRuntime.",
       "url": "ax-mcp/SKILL.md",
-      "digest": "sha256:f81fbe4bc8e56905ee2f1257e02d51bef4b9e7ee85824bc73958e4f9aa680630"
+      "digest": "sha256:41d6020f297b252765a8177677475b88e0239b54fe8c8501db8152a83fef7867"
     },
     {
       "name": "ax-flow",
       "type": "skill-md",
       "description": "This skill helps an LLM generate correct AxFlow workflow code using @ax-llm/ax. Use when the user asks about flow(), AxFlow, workflow orchestration, parallel execution, DAG workflows, conditional routing, map/reduce patterns, or multi-node AI pipelines.",
       "url": "ax-flow/SKILL.md",
-      "digest": "sha256:622bc8bb3ec7a15fd42d2e37016f5a67d9cce4add185cc80a6187e42079311ac"
+      "digest": "sha256:aa9e208eacbf5a91833e0666ddcb8d49f8eb06d3575e5a723e4f1d395fc24b28"
     },
     {
       "name": "ax-agent",
       "type": "skill-md",
       "description": "This skill helps an LLM generate correct core AxAgent code using @ax-llm/ax. Use when the user asks about agent(), child agents, namespaced functions, discovery mode, clarification, bubbleErrors, host-side final/clarification protocol, or ordinary agent runtime behavior. For MCP clients, native runtime modules, subscriptions, tasks, or authentication use ax-mcp alongside this skill. For RLM/code-runtime work use ax-agent-rlm; for callbacks and telemetry use ax-agent-observability; for recall/memory/skill loading use ax-agent-memory-skills; for agent.optimize(...) use ax-agent-optimize.",
       "url": "ax-agent/SKILL.md",
-      "digest": "sha256:8a7d5c20823567c794538d1f9606c1efe58307473aa15ceaa2c7f6b1fad3038f"
+      "digest": "sha256:6ee9ca78468a448bd54c6208bc6d0c0ac2846e1e4457dc741e70fd46a6f89bcf"
     },
     {
       "name": "ax-agent-rlm",
       "type": "skill-md",
       "description": "This skill helps an LLM generate correct AxAgent RLM/runtime code using @ax-llm/ax. Use when the user asks about RLM code execution, AxJSRuntime, contextFields, contextPolicy, liveRuntimeState, promptLevel, stage prompt controls, executorModelPolicy, maxRuntimeChars, agent.test(...), llmQuery(...), recursionOptions, or long-running agent runtime behavior.",
       "url": "ax-agent-rlm/SKILL.md",
-      "digest": "sha256:ba1597cabcfe9a41f6d0bae042a94baa19756593290b693abf46605844d78e60"
+      "digest": "sha256:96705f269eac09760fde69fdbbc84d7643a810cba6b9b824b21b5dfc0fda01a9"
     },
     {
       "name": "ax-agent-memory-skills",
       "type": "skill-md",
       "description": "This skill helps an LLM generate correct AxAgent memory retrieval, context-map, and dynamic skill-loading code using @ax-llm/ax. Use when the user asks about contextMap, AxAgentContextMap, onMemoriesSearch, memoriesCatalog, recall(...), inputs.memories, onLoadedMemories, onUsedMemories, onSkillsSearch, skillsCatalog, AxAgentCatalogSkill, discover({ skills }), onLoadedSkills, onUsedSkills, preloaded skills, preloading memories at forward time, relevanceRanking hints, loaded memory/skill IDs, or carrying memories across forward() calls.",
       "url": "ax-agent-memory-skills/SKILL.md",
-      "digest": "sha256:d06da09450f1bdef8ea587401082f3f12bc5fe8cd8e3689d079bb8c694d6ed42"
+      "digest": "sha256:122ce0c0fe02ad555eb315865f208643f306b431ad980af8c6a3baa02fc6b76d"
     },
     {
       "name": "ax-agent-observability",
       "type": "skill-md",
       "description": "This skill helps an LLM generate correct AxAgent observability code using @ax-llm/ax. Use when the user asks about axGlobals.onUsage, usageContext, centralized or multi-tenant usage accounting, actorTurnCallback, onContextEvent, agentStatusCallback, onFunctionCall, reportSuccess, reportFailure, getChatLog(), getUsage(), resetUsage(), debug traces, progress updates, or telemetry for AxAgent runs.",
       "url": "ax-agent-observability/SKILL.md",
-      "digest": "sha256:d18c51f71939924e0f68f4885726dfecb5f07c299de9c769ab4b97566ce3ba57"
+      "digest": "sha256:45671e710d66b7f610389d771dcaaaeb78fa6b89594e45ebe1addc30932ce380"
     },
     {
       "name": "ax-agent-optimize",
       "type": "skill-md",
       "description": "This skill helps an LLM generate correct AxAgent tuning and evaluation code using @ax-llm/ax. Use when the user asks about agent.optimize(...), judgeOptions, eval datasets, optimization targets, saved optimizedProgram artifacts, or agent optimization guidance.",
       "url": "ax-agent-optimize/SKILL.md",
-      "digest": "sha256:3963c18d02ace34be8a20dcc1ac6f68c55e4da1b7712531f13da9beb0e502743"
+      "digest": "sha256:5f1bc419a4e12dd3b8f064110d6b2684af96b99f9b9c0ede2785870a1a6dfe6f"
     },
     {
       "name": "ax-agent-context",
       "type": "skill-md",
       "description": "This skill helps an LLM pick the right AxAgent context tool for a job - contextMap for recurring corpora, contextPolicy presets for within-run trajectory compaction, agent.optimize for offline GEPA instruction/demo tuning, agent.playbook for an evolving context playbook (offline evolve + online update), and recall/memories + skills for per-turn retrieval. Use when the user asks \"which context feature should I use\", confuses contextMap with contextPolicy or memory, or wants a decision guide for long-context agents. For contextPolicy/contextMap codegen use ax-agent-rlm; for recall/skills use ax-agent-memory-skills; for agent.optimize or agent.playbook use ax-agent-optimize.",
       "url": "ax-agent-context/SKILL.md",
-      "digest": "sha256:83e3e5afaad3a6a4b7ff8b715bb0e7f1d4f96a3c80575d595c7bee43a180c846"
+      "digest": "sha256:1afe82309827712a0f4695ebe1f739706069cbde288da7caaab498b7f3222dfc"
     },
     {
       "name": "ax-event-runtime",
@@ -104,21 +104,21 @@
       "type": "skill-md",
       "description": "This skill helps an LLM generate correct AxGEPA optimization code using @ax-llm/ax. Use when the user asks about AxGEPA, GEPA, Pareto optimization, multi-objective prompt tuning, reflective prompt evolution, validationExamples, maxMetricCalls, or optimizing a generator, flow, or agent tree.",
       "url": "ax-gepa/SKILL.md",
-      "digest": "sha256:dba5f9922a0bde376ab5577536c043ddbaaf0be3faa490ea84f5f419e186d045"
+      "digest": "sha256:459e7b3e200dcb7d3a38ed3d861eacded9a705f59255ac7b0785c4aa2c8ab146"
     },
     {
       "name": "ax-refine",
       "type": "skill-md",
       "description": "Use this skill when writing or reviewing Ax bestOfN/refine code, reward functions, thresholds, native sample selection, serial attempts, generated advice, and attempt diagnostics.",
       "url": "ax-refine/SKILL.md",
-      "digest": "sha256:1fc798ff69c51a6d3bbb4629e4cabab11a8e6ca013e42878dc630cb0e6d5a8f0"
+      "digest": "sha256:063496895c20b0d16ac52820af343f608a37cf681ca0aaaee433f29cfddfa0e9"
     },
     {
       "name": "ax-playbook",
       "type": "skill-md",
       "description": "This skill helps an LLM generate correct playbook code using @ax-llm/ax. Use when the user asks about playbook(), AxPlaybook, context playbooks, evolving context, ACE / Agentic Context Engineering, agent.playbook(), or growing/applying task knowledge offline and online with evolve() and update().",
       "url": "ax-playbook/SKILL.md",
-      "digest": "sha256:f7bbfc2e62c36510aca7f315ba6a4195fa3c9ba77af01516283d6f32d7fee5cd"
+      "digest": "sha256:0e221c91ca6edc97f7ca609b23f798c9adc3bb05790403a42a288f69aa029b8a"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- add a newcomer composition guide and FAQ across all six language routes
- make every quick start runnable from API key setup through expected output
- elevate GraphJin into an in-process AxAgent case study with native language panels and architecture art
- lock navigation, Mermaid, SVG, and homepage ordering into website checks
- refresh deterministic website skill snapshots for 24.0.15

## Verification
- npm run website:prepare
- npm run website:check
- npm run skills:check
- npm run axir:check-packages
- npm run example -- list and --json
- npm run test:examples:generated
- Biome and git diff checks
- desktop, mobile, light, dark, Mermaid, sidebar, FAQ, and six-panel browser QA