### PR TITLE
docs(website): polish homepage layout

### DIFF
--- a/website/content/_index.md
+++ b/website/content/_index.md
@@ -49,14 +49,14 @@ description: "Stop prompting. Start programming. Typed signatures become reliabl
 </div>
 
 <section class="home-section home-academy-cta" aria-labelledby="home-academy-title">
-<article class="home-marketing-card">
+<article class="home-editorial-callout">
 {{< home-icon "list-checks" "icon-violet" >}}
-  <div>
+  <div class="home-editorial-callout-copy">
     <p class="home-section-label">Ax Academy</p>
     <h2 id="home-academy-title">Learn Ax through an adaptive knowledge path.</h2>
     <p>A free course — about six hours end to end, entirely in your browser. Start with a diagnostic, build mastery through short scaffolded lessons, and strengthen due concepts with interleaved spaced review.</p>
-    <div class="home-actions home-section-actions"><a href="/typescript/academy/" data-home-lang-href="academy/">Start Ax Academy</a></div>
   </div>
+  <div class="home-actions home-editorial-callout-actions"><a href="/typescript/academy/" data-home-lang-href="academy/">Start Ax Academy</a></div>
 </article>
 </section>
 
@@ -78,7 +78,7 @@ description: "Stop prompting. Start programming. Typed signatures become reliabl
 </div>
 </section>
 
-<section class="home-section home-code-story" aria-labelledby="why-signatures">
+<section class="home-section home-code-story home-chapter-start" aria-labelledby="why-signatures">
 <div class="home-section-heading">
   <p class="home-section-label">Why signatures?</p>
   <h2 id="why-signatures">Describe the input and output. Ax handles the model call.</h2>
@@ -239,17 +239,17 @@ description: "Stop prompting. Start programming. Typed signatures become reliabl
 </div>
 </section>
 
-<section class="home-section home-agent-section" aria-labelledby="agents-that-work">
+<section class="home-section home-agent-section home-chapter-start" aria-labelledby="agents-that-work">
 <div class="home-section-heading home-agent-heading">
   <p class="home-section-label">Agents</p>
   <h2 id="agents-that-work">One agent harness, every size of job.</h2>
   <p>The design bet: <strong>the model computes on your data instead of reading it.</strong> Bulky inputs live in a runtime session; the agent writes small code steps against them; only compact evidence enters the prompt — so prompts stay bounded at any data size and small, cheap models stay exact. Typed signatures define the job, discovery loads only the schemas the next action needs, and built-in memory, skills, child agents, telemetry, and <code>agent.optimize(...)</code> make it practical to operate.</p>
   <p>Proof you can run: in the <a href="https://github.com/ax-llm/ax/blob/main/src/examples/agent-grounded-audit.ts">grounded-audit example</a>, a small Flash model audits a 250-row ledger it never sees in its prompt and reproduces the exact answer — total to the cent, count, and the full flagged-transaction list — verified against ground truth computed in plain code. <a href="/typescript/agents/performance/">See the measurements</a>.</p>
 </div>
-<div class="home-card-grid three-up">
-  <article class="home-marketing-card">{{< home-icon "zap" "icon-blue" >}}<h3>Micro</h3><p>One signature, a few tools, a typed reply. Zero config still runs the full harness — runtime session included.</p><p><a href="/typescript/agents/micro/">Micro agents</a></p></article>
-  <article class="home-marketing-card">{{< home-icon "bot" "icon-teal" >}}<h3>Standard</h3><p>Namespaced tool catalogs, specialist child agents, structured outputs, and clarification instead of guessing.</p><p><a href="/typescript/agents/standard/">Standard agents</a></p></article>
-  <article class="home-marketing-card">{{< home-icon "brain" "icon-green" >}}<h3>Long-horizon</h3><p>Large context by reference, context policies, memory, skills, and offline optimization for runs that keep going.</p><p><a href="/typescript/agents/long-horizon/">Long-horizon agents</a></p></article>
+<div class="home-card-grid three-up home-agent-tier-grid">
+  <article class="home-marketing-card home-agent-tier-card">{{< home-icon "zap" "icon-blue" >}}<h3>Micro</h3><p>One signature, a few tools, a typed reply. Zero config still runs the full harness — runtime session included.</p><p><a href="/typescript/agents/micro/">Micro agents</a></p></article>
+  <article class="home-marketing-card home-agent-tier-card">{{< home-icon "bot" "icon-teal" >}}<h3>Standard</h3><p>Namespaced tool catalogs, specialist child agents, structured outputs, and clarification instead of guessing.</p><p><a href="/typescript/agents/standard/">Standard agents</a></p></article>
+  <article class="home-marketing-card home-agent-tier-card">{{< home-icon "brain" "icon-green" >}}<h3>Long-horizon</h3><p>Large context by reference, context policies, memory, skills, and offline optimization for runs that keep going.</p><p><a href="/typescript/agents/long-horizon/">Long-horizon agents</a></p></article>
 </div>
 <div class="home-agent-code">
 {{< home-code topic="agent" group="agent" >}}
@@ -374,7 +374,7 @@ description: "Stop prompting. Start programming. Typed signatures become reliabl
 </div>
 </section>
 
-<section class="home-section" aria-labelledby="included">
+<section class="home-section home-chapter-start" aria-labelledby="included">
 <div class="home-section-heading home-section-heading-wide">
   <p class="home-section-label">The full surface</p>
   <h2 id="included">Everything you need to build useful LLM systems.</h2>

--- a/website/static/css/site.css
+++ b/website/static/css/site.css
@@ -1702,6 +1702,13 @@ pre.mermaid {
 }
 
 .home {
+  --home-space-1: 0.5rem;
+  --home-space-2: 0.75rem;
+  --home-space-3: 1rem;
+  --home-space-4: 1.5rem;
+  --home-space-5: 2rem;
+  --home-section-space: 5.5rem;
+  --home-card-radius: 0.75rem;
   max-width: 80rem;
   margin: 0 auto;
   padding: 0.9rem 2rem 5rem;
@@ -1721,16 +1728,16 @@ pre.mermaid {
 }
 
 .home-section {
-  margin: 5.2rem 0;
+  margin: var(--home-section-space) 0;
 }
 
 .home-section:first-of-type {
-  margin-top: 3.6rem;
+  margin-top: var(--home-section-space);
 }
 
 .home-section-heading {
   max-width: 49rem;
-  margin: 0 0 1.8rem;
+  margin: 0 0 var(--home-space-5);
 }
 
 .home-section-heading-wide {
@@ -1738,7 +1745,7 @@ pre.mermaid {
 }
 
 .home-section-heading p {
-  max-width: 47rem;
+  max-width: 68ch;
   color: var(--muted);
   font-size: 1.05rem;
   line-height: 1.58;
@@ -1754,6 +1761,7 @@ pre.mermaid {
 .home h3 {
   color: var(--heading);
   letter-spacing: -0.025em;
+  text-wrap: balance;
 }
 
 .home h1 {
@@ -1789,6 +1797,50 @@ pre.mermaid {
 
 .home p {
   overflow-wrap: anywhere;
+  text-wrap: pretty;
+}
+
+.home-chapter-start {
+  border-top: 1px solid var(--line);
+  padding-top: 3.5rem;
+}
+
+.home-editorial-callout {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  gap: var(--home-space-4) var(--home-space-5);
+  align-items: center;
+  border: 1px solid var(--line);
+  border-radius: var(--home-card-radius);
+  background: var(--panel-soft);
+  padding: var(--home-space-4);
+}
+
+.home-editorial-callout .home-card-icon {
+  align-self: start;
+  margin: 0;
+}
+
+.home-editorial-callout-copy {
+  max-width: 58rem;
+}
+
+.home-editorial-callout-copy h2 {
+  max-width: 34rem;
+  font-size: 2.1rem;
+}
+
+.home-editorial-callout-copy > p:last-child {
+  max-width: 64ch;
+  margin-bottom: 0;
+}
+
+.home-editorial-callout-actions {
+  justify-content: flex-end;
+}
+
+.home-editorial-callout-actions a {
+  white-space: nowrap;
 }
 
 .home-hero .svg-figure {
@@ -2141,7 +2193,7 @@ pre.mermaid {
 }
 
 .home-agent-code {
-  margin: 0 0 1.45rem;
+  margin: 0 0 var(--home-space-4);
 }
 
 .home-agent-code .code-block {
@@ -2153,7 +2205,7 @@ pre.mermaid {
   border-color: rgba(255, 255, 255, 0.12);
   background: var(--code-bg);
   color: var(--code-ink);
-  box-shadow: 0 24px 70px rgba(0, 0, 0, 0.3);
+  box-shadow: var(--shadow-raised);
 }
 
 .home-agent-code .code-block-header {
@@ -2522,17 +2574,10 @@ pre.mermaid {
   min-height: 22rem;
   overflow: hidden;
   border: 1px solid var(--line);
-  border-radius: 8px;
+  border-radius: var(--home-card-radius);
   background: var(--panel);
   padding: 1.6rem;
-  transition:
-    border-color 160ms ease,
-    transform 160ms ease;
-}
-
-.home-visual-card:hover {
-  border-color: var(--line-strong);
-  transform: translateY(-2px);
+  transition: border-color 160ms ease;
 }
 
 .home-visual-title {
@@ -2803,7 +2848,7 @@ pre.mermaid {
 .home-output-panel,
 .home-graphjin-copy {
   border: 1px solid var(--line);
-  border-radius: 8px;
+  border-radius: var(--home-card-radius);
   background: var(--panel);
   padding: 1rem;
 }
@@ -2870,9 +2915,9 @@ pre.mermaid {
 .home-resource-row {
   display: grid;
   grid-template-columns: minmax(0, 0.8fr) minmax(0, 1fr);
-  gap: 1.2rem;
+  gap: var(--home-space-4);
   align-items: start;
-  margin: 1.8rem 0 2rem;
+  margin: var(--home-space-4) 0;
 }
 
 .home-resource-row > div {
@@ -2934,21 +2979,18 @@ pre.mermaid {
 .home-pattern-grid article,
 .home-provider-grid article {
   border: 1px solid var(--line);
-  border-radius: 8px;
+  border-radius: var(--home-card-radius);
   background: var(--panel);
   padding: 1rem;
-  transition:
-    border-color 160ms ease,
-    transform 160ms ease;
+  transition: border-color 160ms ease;
 }
 
-.home-code-card:hover,
-.home-marketing-card:hover,
-.home-paper-card:hover,
-.home-pattern-grid article:hover,
-.home-provider-grid article:hover {
+.home-code-card:focus-within,
+.home-marketing-card:focus-within,
+.home-paper-card:focus-within,
+.home-pattern-grid article:focus-within,
+.home-provider-grid article:focus-within {
   border-color: var(--line-strong);
-  transform: translateY(-2px);
 }
 
 .home-code-card p,
@@ -3297,13 +3339,9 @@ pre.mermaid {
   stroke-width: 2;
 }
 
-.home-agent-section {
-  padding: 0;
-}
-
 .home-agent-heading {
   max-width: 52rem;
-  margin: 0 0 1.8rem;
+  margin: 0 0 var(--home-space-5);
 }
 
 .home-agent-heading h2 {
@@ -3318,11 +3356,33 @@ pre.mermaid {
   margin-left: 0;
 }
 
+.home-agent-tier-grid {
+  margin-bottom: var(--home-space-4);
+}
+
+.home-agent-tier-card {
+  display: flex;
+  flex-direction: column;
+  gap: var(--home-space-2);
+  padding: var(--home-space-4);
+}
+
+.home-agent-tier-card .home-card-icon,
+.home-agent-tier-card h3,
+.home-agent-tier-card p {
+  margin: 0;
+}
+
+.home-agent-tier-card > p:last-child {
+  margin-top: auto;
+  padding-top: var(--home-space-1);
+}
+
 .home-agent-layout {
   grid-template-columns: minmax(0, 0.82fr) minmax(0, 1fr);
-  gap: 1.6rem;
+  gap: var(--home-space-4);
   align-items: start;
-  margin-bottom: 1rem;
+  margin-bottom: var(--home-space-4);
 }
 
 .home-agent-feature-grid {
@@ -3333,7 +3393,7 @@ pre.mermaid {
 
 .home-agent-feature-grid article {
   border: 1px solid var(--line);
-  border-radius: 8px;
+  border-radius: var(--home-card-radius);
   background: var(--panel);
   padding: 1rem;
 }
@@ -3525,7 +3585,7 @@ pre.mermaid {
 }
 
 .home-section-actions {
-  margin-top: 1.2rem;
+  margin-top: var(--home-space-4);
 }
 
 .home-stats {
@@ -3684,12 +3744,6 @@ pre.mermaid {
   font-size: 0.78rem;
 }
 
-.home-graphjin {
-  border-top: 1px solid var(--line);
-  margin-bottom: 0;
-  padding-top: 4.6rem;
-}
-
 .home-graphjin-layout {
   align-items: center;
 }
@@ -3744,6 +3798,36 @@ pre.mermaid {
     box-shadow:
       inset 1.5rem 0 1rem -1rem var(--nav-fade),
       inset -1.5rem 0 1rem -1rem var(--nav-fade);
+  }
+}
+
+@media (max-width: 1100px) {
+  .home {
+    --home-section-space: 4rem;
+    padding-inline: 1.5rem;
+  }
+
+  .home-hero {
+    grid-template-columns: 1fr;
+    gap: var(--home-space-5);
+    align-items: start;
+  }
+
+  .home-hero-copy {
+    max-width: 52rem;
+  }
+
+  .home-hero-panel {
+    width: 100%;
+  }
+
+  .home-editorial-callout {
+    grid-template-columns: auto minmax(0, 1fr);
+  }
+
+  .home-editorial-callout-actions {
+    grid-column: 2;
+    justify-content: flex-start;
   }
 }
 
@@ -3848,6 +3932,14 @@ pre.mermaid {
 
   .home {
     padding: 1.5rem 1rem 4rem;
+  }
+
+  .home-editorial-callout {
+    grid-template-columns: 1fr;
+  }
+
+  .home-editorial-callout-actions {
+    grid-column: 1;
   }
 
   .home-hero,
@@ -3957,6 +4049,7 @@ pre.mermaid {
   }
 
   .home {
+    --home-section-space: 3.5rem;
     padding-inline: 0.88rem;
   }
 
@@ -3968,13 +4061,12 @@ pre.mermaid {
     font-size: 1.72rem;
   }
 
-  .home-section {
-    margin: 3.8rem 0;
+  .home-chapter-start {
+    padding-top: 2.5rem;
   }
 
-  .home-agent-section,
-  .home-graphjin {
-    padding-top: 3.2rem;
+  .home-agent-tier-grid {
+    margin-bottom: var(--home-space-3);
   }
 
   .home-stats,
@@ -4276,28 +4368,20 @@ pre.mermaid {
 }
 
 .home-language-bar {
-  position: sticky;
-  top: 4.15rem;
-  z-index: 15;
   display: flex;
   flex-wrap: wrap;
   align-items: center;
   gap: 0.5rem 1.1rem;
-  margin: 0 0 1.5rem;
+  margin: 0 0 var(--home-space-4);
   padding: 0.6rem 0.9rem;
   border: 1px solid var(--line);
-  border-radius: 12px;
-  background: var(--bg);
+  border-radius: var(--home-card-radius);
+  background: var(--panel);
 }
 
 .home-language-bar .home-language-pills {
   margin: 0;
   view-transition-name: home-language-bar-picker;
-}
-
-.home-language-bar.is-stuck {
-  border-color: var(--line-strong);
-  box-shadow: 0 12px 28px rgba(0, 0, 0, 0.14);
 }
 
 .home-language-bar-label {
@@ -4313,7 +4397,7 @@ pre.mermaid {
   margin: 0 0 2.6rem;
   padding: 0.85rem 1.05rem;
   border: 1px solid var(--line);
-  border-radius: 12px;
+  border-radius: var(--home-card-radius);
   background: var(--panel);
 }
 
@@ -4330,7 +4414,6 @@ pre.mermaid {
 
 @media (max-width: 860px) {
   .home-language-bar {
-    top: 3.8rem;
     gap: 0.5rem;
   }
 

--- a/website/static/js/site.js
+++ b/website/static/js/site.js
@@ -600,19 +600,6 @@ if (homeLanguageRoot) {
   }
 }
 
-const homeLanguageBar = document.querySelector('[data-home-language-bar]');
-if (homeLanguageBar && 'IntersectionObserver' in window) {
-  const sentinel = document.createElement('div');
-  sentinel.setAttribute('aria-hidden', 'true');
-  homeLanguageBar.before(sentinel);
-  new IntersectionObserver(
-    ([entry]) => {
-      homeLanguageBar.classList.toggle('is-stuck', !entry.isIntersecting);
-    },
-    { rootMargin: '-68px 0px 0px 0px' }
-  ).observe(sentinel);
-}
-
 const searchRoot = document.querySelector('[data-site-search]');
 const searchInput = searchRoot?.querySelector('[data-search-input]');
 const searchResults = searchRoot?.querySelector('[data-search-results]');


### PR DESCRIPTION
## Summary

- introduce a calmer homepage rhythm, editorial chapter breaks, and consistent card geometry
- make the homepage language selector static and remove its sticky observer
- stack the hero at 1100px, refine the Academy callout, and align agent-tier cards above the code panel

## Verification

- npm run website:build
- npm run website:check
- npm run skills:check
- npm run test:format
- visual and interaction checks in light and dark modes at 1440x900, 1024x768, 900px, and 390x844