### PR TITLE
docs(website): streamline GraphJin case study

### DIFF
--- a/website/content/_index.md
+++ b/website/content/_index.md
@@ -292,53 +292,48 @@ description: "Stop prompting. Start programming. Typed signatures become reliabl
 </div>
 </section>
 
-<section class="home-section home-graphjin" aria-labelledby="graphjin">
-<div class="home-section-heading">
-  <p class="home-section-label">Case study</p>
-  <h2 id="graphjin">GraphJin runs on Ax.</h2>
-  <p><a href="https://graphjin.com">GraphJin</a> — an open-source engine from the same author — connects AI agents to the databases a company already runs. Agents ask in plain English; GraphJin validates every query against the live schema, enforces role-based access, and audits each answer against what actually ran. Its production agent is an Ax Go program — the same harness described above.</p>
+<section id="graphjin" class="home-section home-graphjin" aria-labelledby="graphjin-title">
+<div class="home-graphjin-header">
+  <div class="home-graphjin-heading">
+    <p class="home-section-label">Case study</p>
+    <h2 id="graphjin-title">GraphJin runs on Ax.</h2>
+    <p>An agent built with Ax effortlessly connects all your databases to AI</p>
+  </div>
+  <div class="home-actions home-graphjin-actions">
+    <a href="https://graphjin.com">Explore GraphJin</a>
+    <a class="home-button-secondary" href="https://github.com/dosco/graphjin">GraphJin on GitHub</a>
+  </div>
 </div>
-<div class="home-graphjin-layout">
-  <div class="home-graphjin-code">
-    <div class="home-install" aria-label="Install GraphJin"><span>$</span><code><span class="home-install-command">npm install -g graphjin</span></code></div>
-    <div class="home-install" aria-label="Add GraphJin as an MCP server"><span>$</span><code><span class="home-install-command">claude mcp add graphjin -- graphjin mcp --demo</span></code></div>
-    <div class="home-output-panel" aria-label="GraphJin demo conversation">
+<div class="home-graphjin-demo">
+  <div class="home-graphjin-command-row" aria-label="GraphJin setup commands">
+    <div class="home-graphjin-command" aria-label="Install GraphJin"><span>$</span><code><span class="home-install-command">npm install -g graphjin</span></code></div>
+    <div class="home-graphjin-command" aria-label="Add GraphJin as an MCP server"><span>$</span><code><span class="home-install-command">claude mcp add graphjin -- graphjin mcp --demo</span></code></div>
+  </div>
+  <div class="home-graphjin-terminal" aria-label="GraphJin demo conversation">
     <div class="home-panel-title">Then just ask</div>
 <pre><code>Q: which customers churned last month,
    and what did they have in common?&#10;
 A: 9 of 12 churned accounts were on the Starter plan.
    7 opened a support ticket in their final 30 days.
    Median tenure: 4 months.</code></pre>
-    <div class="home-status"><span aria-hidden="true"></span>Schema-validated · role-checked · audited</div>
-    </div>
-  </div>
-  <div class="home-graphjin-copy">
-    <h3>One governed graph over every database you run.</h3>
-    <p>GraphJin speaks MCP, so the agents you already use — Claude Code, Codex, Cursor, or your own Ax agents — connect in one command. Queries are validated before they run, access policy decides what each role sees, and answers are checked against the execution record before they leave the server.</p>
-    <div class="home-badge-row">
-      <span>PostgreSQL</span><span>MySQL</span><span>SQLite</span><span>MongoDB</span><span>Snowflake</span><span>BigQuery</span><span>12+ engines</span>
-    </div>
-    <div class="home-actions home-section-actions">
-      <a href="https://graphjin.com">Explore GraphJin</a>
-      <a class="home-button-secondary" href="https://github.com/dosco/graphjin">GraphJin on GitHub</a>
-    </div>
-    <p class="home-inline-note">The demo flag ships a full SaaS dataset to explore — no config, no API keys. Curious how the agent is built? <a href="https://graphjin.com/agentic/server-agent/">Read the Ax write-up</a>.</p>
   </div>
 </div>
-<div class="home-resource-row home-resource-row-tight">
-  <div>
+<div class="home-graphjin-status">
+  <span aria-hidden="true"></span>
+  <p>Schema-validated · role-checked · audited · 12+ database engines</p>
+  <a href="https://graphjin.com/agentic/server-agent/">Read how the Ax agent is built</a>
+</div>
+<div class="home-graphjin-proof">
+  <div class="home-graphjin-proof-heading">
     <p class="home-section-label">Proof, in public</p>
-    <h3>A flash-lite model runs a whole org's data.</h3>
-    <p>DeepORG is GraphJin's public benchmark: 113 organizational tasks — questions, aggregations, writes, alerts, and the refusals that keep them safe — over live databases, files, and APIs. On the current board a Gemini flash-lite model passes 100 of 113 in full, with zero unsafe effects across every attempt, at about 4¢ a task. The harness behind it is the Ax agent loop described above.</p>
-    <p><a href="https://graphjin.com/benchmark/">See the DeepORG leaderboard</a>.</p>
+    <h3>DeepORG benchmark</h3>
+    <a href="https://graphjin.com/benchmark/">See the leaderboard</a>
   </div>
-  <div>
-    <div class="home-stats" aria-label="DeepORG current board result">
-      <div><strong>100/113</strong><span>tasks passed in full</span></div>
-      <div><strong>0</strong><span>unsafe effects</span></div>
-      <div><strong>~4¢</strong><span>per task</span></div>
-      <div><strong>339</strong><span>graded attempts</span></div>
-    </div>
+  <div class="home-stats" aria-label="DeepORG current board result">
+    <div><strong>100/113</strong><span>tasks passed in full</span></div>
+    <div><strong>0</strong><span>unsafe effects</span></div>
+    <div><strong>~4¢</strong><span>per task</span></div>
+    <div><strong>339</strong><span>graded attempts</span></div>
   </div>
 </div>
 </section>

--- a/website/static/css/site.css
+++ b/website/static/css/site.css
@@ -2838,7 +2838,6 @@ pre.mermaid {
 
 .home-code-pair,
 .home-agent-layout,
-.home-graphjin-layout,
 .home-provider-layout {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
@@ -2850,8 +2849,7 @@ pre.mermaid {
   align-items: stretch;
 }
 
-.home-output-panel,
-.home-graphjin-copy {
+.home-output-panel {
   border: 1px solid var(--line);
   border-radius: var(--home-card-radius);
   background: var(--panel);
@@ -3002,8 +3000,7 @@ pre.mermaid {
 .home-marketing-card p,
 .home-paper-card p,
 .home-pattern-grid p,
-.home-provider-grid p,
-.home-graphjin-copy p {
+.home-provider-grid p {
   margin: 0;
   color: var(--muted);
   font-size: 0.92rem;
@@ -3749,35 +3746,174 @@ pre.mermaid {
   font-size: 0.78rem;
 }
 
-.home-graphjin-layout {
+.home-graphjin-header {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: var(--home-space-5);
+  align-items: end;
+  margin-bottom: var(--home-space-4);
+}
+
+.home-graphjin-heading {
+  max-width: 52rem;
+}
+
+.home-graphjin-heading .home-section-label {
+  color: var(--accent-2);
+  margin-bottom: 0.55rem;
+}
+
+.home-graphjin-heading > p:last-child {
+  max-width: 54ch;
+  margin: 0.85rem 0 0;
+  color: var(--muted);
+  font-size: 1.08rem;
+  line-height: 1.5;
+}
+
+.home-graphjin-actions {
+  justify-content: flex-end;
+  margin: 0 0 0.15rem;
+}
+
+.home-graphjin-demo {
+  overflow: hidden;
+  border: 1px solid var(--line-strong);
+  border-radius: var(--home-card-radius);
+  background: var(--code-bg);
+}
+
+.home-graphjin-command-row {
+  display: grid;
+  grid-template-columns: minmax(15rem, 0.72fr) minmax(24rem, 1.28fr);
+  border-bottom: 1px solid var(--install-border);
+  background: var(--install-bg);
+}
+
+.home-graphjin-command {
+  display: flex;
   align-items: center;
+  gap: 0.62rem;
+  min-width: 0;
+  padding: 0.95rem 1.25rem;
+  color: var(--install-ink);
 }
 
-.home-graphjin-copy {
-  background: var(--panel-soft);
+.home-graphjin-command + .home-graphjin-command {
+  border-left: 1px solid var(--install-border);
 }
 
-.home-graphjin-copy .home-actions {
-  margin-bottom: 0;
+.home-graphjin-command > span {
+  color: var(--install-prompt);
+  font-family: var(--font-mono);
 }
 
-.home-graphjin-code {
+.home-graphjin-command code {
+  overflow-x: auto;
+  border: 0;
+  background: transparent;
+  color: var(--install-ink);
+  padding: 0;
+  white-space: nowrap;
+}
+
+.home-graphjin-terminal {
+  min-height: 15rem;
+  padding: 1.65rem 1.5rem 1.75rem;
+}
+
+.home-graphjin-terminal .home-panel-title {
+  color: var(--syntax-comment);
+  margin-bottom: 1.15rem;
+}
+
+.home-graphjin-terminal pre {
+  overflow-x: auto;
+  margin: 0;
+  border: 0;
+  background: transparent;
+  color: var(--code-ink);
+  font-size: 0.94rem;
+  line-height: 1.62;
+  padding: 0;
+}
+
+.home-graphjin-terminal code {
+  border: 0;
+  background: transparent;
+  color: inherit;
+  padding: 0;
+}
+
+.home-graphjin-status {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  border-bottom: 1px solid var(--line);
+  color: var(--muted);
+  padding: 1rem 0.15rem;
+}
+
+.home-graphjin-status > span {
+  flex: 0 0 auto;
+  width: 0.52rem;
+  height: 0.52rem;
+  border-radius: 999px;
+  background: var(--green);
+}
+
+.home-graphjin-status p {
+  margin: 0;
+  font-size: 0.94rem;
+  line-height: 1.45;
+}
+
+.home-graphjin-status a {
+  margin-left: auto;
+  font-size: 0.9rem;
+  white-space: nowrap;
+}
+
+.home-graphjin-proof {
+  display: grid;
+  grid-template-columns: minmax(12rem, 0.78fr) minmax(0, 4fr);
+  gap: var(--home-space-4);
+  align-items: stretch;
+  padding-top: var(--home-space-5);
+}
+
+.home-graphjin-proof-heading {
   display: flex;
   flex-direction: column;
-  gap: 0.6rem;
+  align-items: flex-start;
+  justify-content: center;
+  padding-right: var(--home-space-3);
 }
 
-.home-graphjin-code .home-install {
-  margin: 0;
+.home-graphjin-proof-heading h3 {
+  margin: 0 0 0.55rem;
+}
+
+.home-graphjin-proof-heading a {
+  font-size: 0.9rem;
 }
 
 .home-graphjin .home-stats {
-  grid-template-columns: repeat(2, minmax(0, 1fr));
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 0;
   margin: 0;
 }
 
+.home-graphjin .home-stats div {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  border-left: 1px solid var(--line);
+  padding: 0.75rem 1rem;
+}
+
 .home-graphjin .home-stats strong {
-  font-size: 2.6rem;
+  font-size: clamp(2rem, 3.35vw, 3rem);
 }
 
 @media (max-width: 1180px) {
@@ -3965,7 +4101,6 @@ pre.mermaid {
   .home-hero,
   .home-code-pair,
   .home-agent-layout,
-  .home-graphjin-layout,
   .home-provider-layout,
   .home-resource-row {
     grid-template-columns: 1fr;
@@ -4021,6 +4156,47 @@ pre.mermaid {
 
   .home-research-compact .paper-title-row {
     align-items: flex-start;
+  }
+
+  .home-graphjin-header {
+    grid-template-columns: 1fr;
+    gap: var(--home-space-3);
+    align-items: start;
+  }
+
+  .home-graphjin-actions {
+    justify-content: flex-start;
+  }
+
+  .home-graphjin-command-row {
+    grid-template-columns: 1fr;
+  }
+
+  .home-graphjin-command + .home-graphjin-command {
+    border-top: 1px solid var(--install-border);
+    border-left: 0;
+  }
+
+  .home-graphjin-proof {
+    grid-template-columns: 1fr;
+    gap: var(--home-space-3);
+  }
+
+  .home-graphjin-proof-heading {
+    padding-right: 0;
+  }
+
+  .home-graphjin .home-stats {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    border-top: 1px solid var(--line);
+  }
+
+  .home-graphjin .home-stats div:nth-child(odd) {
+    border-left: 0;
+  }
+
+  .home-graphjin .home-stats div:nth-child(n + 3) {
+    border-top: 1px solid var(--line);
   }
 
   .paper-item-meta {
@@ -4098,8 +4274,48 @@ pre.mermaid {
     grid-template-columns: 1fr;
   }
 
-  .home-graphjin .home-stats {
-    grid-template-columns: 1fr;
+  .home-graphjin-status {
+    display: grid;
+    grid-template-columns: auto minmax(0, 1fr);
+    align-items: start;
+  }
+
+  .home-graphjin-status a {
+    grid-column: 2;
+    margin-left: 0;
+    white-space: normal;
+  }
+
+  .home-graphjin-terminal {
+    min-height: 0;
+    padding: 1.25rem 1rem 1.35rem;
+  }
+
+  .home-graphjin-terminal pre {
+    font-size: 0.82rem;
+    overflow-x: visible;
+    overflow-wrap: anywhere;
+    white-space: pre-wrap;
+  }
+
+  .home-graphjin-command code {
+    overflow-x: visible;
+    overflow-wrap: anywhere;
+    white-space: normal;
+  }
+
+  .home-graphjin-command .home-install-command {
+    overflow-x: visible;
+    overflow-wrap: anywhere;
+    white-space: normal;
+  }
+
+  .home-graphjin .home-stats div {
+    padding: 1rem 0.45rem;
+  }
+
+  .home-graphjin .home-stats strong {
+    font-size: 2rem;
   }
 
   .paper-title-row {

--- a/website/static/js/site.js
+++ b/website/static/js/site.js
@@ -443,8 +443,23 @@ function runHomeLanguageViewTransition(update) {
     return Promise.resolve();
   }
 
-  const transition = document.startViewTransition(update);
-  return (transition.updateCallbackDone || transition.ready).catch(() => {});
+  try {
+    const transition = document.startViewTransition(update);
+    // A view transition may be aborted by navigation, theme changes, or the
+    // browser starting another transition. Consume every lifecycle rejection
+    // so an expected abort does not surface as an unhandled console error.
+    for (const promise of [
+      transition.updateCallbackDone,
+      transition.ready,
+      transition.finished,
+    ]) {
+      promise?.catch(() => {});
+    }
+    return (transition.updateCallbackDone || transition.ready).catch(() => {});
+  } catch {
+    update();
+    return Promise.resolve();
+  }
 }
 
 function finishHomeLanguageTransition(targets) {


### PR DESCRIPTION
## Summary
- replace the text-heavy GraphJin card wall with the selected demo-first layout
- use the requested Ax agent subtitle and a compact DeepORG proof bar
- fix anchor overlap, mobile command wrapping, and expected view-transition abort noise

## Verification
- npm run website:build
- npm run website:check
- visual QA in light and dark at 1440x900, 1024x768, 900px, and 390x844
- exercised language switching, hero tabs, copy feedback, keyboard focus, themes, CTAs, and #graphjin navigation