### PR TITLE
feat(bedrock): add native Converse capabilities

### DIFF
--- a/docs/AXIR_BACKLOG.md
+++ b/docs/AXIR_BACKLOG.md
@@ -21,7 +21,7 @@ This ledger tracks portable TypeScript behavior that should be migrated into AxI
 - `axir-2026-08-31-preserve-native-file-content-through-provider-routing` [axai] Preserve native file content through provider routing
   - Status: open
   - Source commit: `5fe5e9f130cdc51168f57bffcb7e271357d4d327`
-  - TS paths: `src/ax/ai/processor.ts`, `src/ax/ai/router.ts`
+  - TS paths: `src/ax/ai/processor.test.ts`, `src/ax/ai/processor.ts`, `src/ax/ai/router.test.ts`, `src/ax/ai/router.ts`
   - Impact: File-capable providers now receive native file content instead of degraded text; generated runtimes need matching provider-aware file pass-through behavior.
   - Suggested AxIR work: Add or update the TS-derived conformance fixture.; Update AxIR/Core or descriptor data to match the portable TS behavior.; Run npm run axir:conformance:check and npm run test:axir.
 

--- a/docs/AXIR_BACKLOG.md
+++ b/docs/AXIR_BACKLOG.md
@@ -18,7 +18,12 @@ This ledger tracks portable TypeScript behavior that should be migrated into AxI
 
 ## Open
 
-No entries.
+- `axir-2026-08-31-preserve-native-file-content-through-provider-routing` [axai] Preserve native file content through provider routing
+  - Status: open
+  - Source commit: `5fe5e9f130cdc51168f57bffcb7e271357d4d327`
+  - TS paths: `src/ax/ai/processor.ts`, `src/ax/ai/router.ts`
+  - Impact: File-capable providers now receive native file content instead of degraded text; generated runtimes need matching provider-aware file pass-through behavior.
+  - Suggested AxIR work: Add or update the TS-derived conformance fixture.; Update AxIR/Core or descriptor data to match the portable TS behavior.; Run npm run axir:conformance:check and npm run test:axir.
 
 ## Done
 

--- a/ir/axir-backlog.json
+++ b/ir/axir-backlog.json
@@ -1236,7 +1236,12 @@
       "createdAt": "2026-08-31",
       "sourcePR": null,
       "sourceCommit": "5fe5e9f130cdc51168f57bffcb7e271357d4d327",
-      "tsPaths": ["src/ax/ai/processor.ts", "src/ax/ai/router.ts"],
+      "tsPaths": [
+        "src/ax/ai/processor.test.ts",
+        "src/ax/ai/processor.ts",
+        "src/ax/ai/router.test.ts",
+        "src/ax/ai/router.ts"
+      ],
       "portableSurface": "axai",
       "impact": "File-capable providers now receive native file content instead of degraded text; generated runtimes need matching provider-aware file pass-through behavior.",
       "suggestedAxirWork": [

--- a/ir/axir-backlog.json
+++ b/ir/axir-backlog.json
@@ -1228,6 +1228,25 @@
       "completedAt": "2026-08-29",
       "completedByCommit": "e62cfc20df1c683713c33ffae05b2fb9f74da9b0",
       "verification": "npm run test:axir; npm run test:examples:generated; npm run axir:check-packages; npm run axir:conformance:check; npm run website:check; live OpenAI gpt-5.6-luna and Gemini gemini-3.7-flash smokes on Python, Java, Go, Rust, and C++"
+    },
+    {
+      "id": "axir-2026-08-31-preserve-native-file-content-through-provider-routing",
+      "status": "open",
+      "title": "Preserve native file content through provider routing",
+      "createdAt": "2026-08-31",
+      "sourcePR": null,
+      "sourceCommit": "5fe5e9f130cdc51168f57bffcb7e271357d4d327",
+      "tsPaths": ["src/ax/ai/processor.ts", "src/ax/ai/router.ts"],
+      "portableSurface": "axai",
+      "impact": "File-capable providers now receive native file content instead of degraded text; generated runtimes need matching provider-aware file pass-through behavior.",
+      "suggestedAxirWork": [
+        "Add or update the TS-derived conformance fixture.",
+        "Update AxIR/Core or descriptor data to match the portable TS behavior.",
+        "Run npm run axir:conformance:check and npm run test:axir."
+      ],
+      "completedAt": null,
+      "completedByCommit": null,
+      "verification": null
     }
   ],
   "nonPortableExemptions": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ax-llm/ax-monorepo",
-  "version": "23.0.6",
+  "version": "24.0.16",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@ax-llm/ax-monorepo",
-      "version": "23.0.6",
+      "version": "24.0.16",
       "license": "Apache-2.0",
       "workspaces": [
         "src/*",
@@ -116,220 +116,23 @@
         "node": ">=18"
       }
     },
-    "node_modules/@aws-crypto/crc32": {
-      "version": "5.2.0",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-crypto/util": "^5.2.0",
-        "@aws-sdk/types": "^3.222.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-crypto/sha256-browser": {
-      "version": "5.2.0",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-crypto/sha256-js": "^5.2.0",
-        "@aws-crypto/supports-web-crypto": "^5.2.0",
-        "@aws-crypto/util": "^5.2.0",
-        "@aws-sdk/types": "^3.222.0",
-        "@aws-sdk/util-locate-window": "^3.0.0",
-        "@smithy/util-utf8": "^2.0.0",
-        "tslib": "^2.6.2"
-      }
-    },
-    "node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/is-array-buffer": {
-      "version": "2.2.0",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/util-buffer-from": {
-      "version": "2.2.0",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/is-array-buffer": "^2.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/util-utf8": {
-      "version": "2.3.0",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/util-buffer-from": "^2.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-crypto/sha256-js": {
-      "version": "5.2.0",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-crypto/util": "^5.2.0",
-        "@aws-sdk/types": "^3.222.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-crypto/supports-web-crypto": {
-      "version": "5.2.0",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      }
-    },
-    "node_modules/@aws-crypto/util": {
-      "version": "5.2.0",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "^3.222.0",
-        "@smithy/util-utf8": "^2.0.0",
-        "tslib": "^2.6.2"
-      }
-    },
-    "node_modules/@aws-crypto/util/node_modules/@smithy/is-array-buffer": {
-      "version": "2.2.0",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-crypto/util/node_modules/@smithy/util-buffer-from": {
-      "version": "2.2.0",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/is-array-buffer": "^2.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-crypto/util/node_modules/@smithy/util-utf8": {
-      "version": "2.3.0",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/util-buffer-from": "^2.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
     "node_modules/@aws-sdk/client-bedrock-runtime": {
-      "version": "3.982.0",
+      "version": "3.1123.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-bedrock-runtime/-/client-bedrock-runtime-3.1123.0.tgz",
+      "integrity": "sha512-eXRTxNIhgZ2js/1f0j29uu9v5H8DIAzg0acjBdbehK9vFIu9Vv1WPGYXLijz2auN9dzLvKMcpWmrBJJ1DFrGEw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-crypto/sha256-browser": "5.2.0",
-        "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.973.6",
-        "@aws-sdk/credential-provider-node": "^3.972.5",
-        "@aws-sdk/eventstream-handler-node": "^3.972.4",
-        "@aws-sdk/middleware-eventstream": "^3.972.3",
-        "@aws-sdk/middleware-host-header": "^3.972.3",
-        "@aws-sdk/middleware-logger": "^3.972.3",
-        "@aws-sdk/middleware-recursion-detection": "^3.972.3",
-        "@aws-sdk/middleware-user-agent": "^3.972.6",
-        "@aws-sdk/middleware-websocket": "^3.972.4",
-        "@aws-sdk/region-config-resolver": "^3.972.3",
-        "@aws-sdk/token-providers": "3.982.0",
-        "@aws-sdk/types": "^3.973.1",
-        "@aws-sdk/util-endpoints": "3.982.0",
-        "@aws-sdk/util-user-agent-browser": "^3.972.3",
-        "@aws-sdk/util-user-agent-node": "^3.972.4",
-        "@smithy/config-resolver": "^4.4.6",
-        "@smithy/core": "^3.22.0",
-        "@smithy/eventstream-serde-browser": "^4.2.8",
-        "@smithy/eventstream-serde-config-resolver": "^4.3.8",
-        "@smithy/eventstream-serde-node": "^4.2.8",
-        "@smithy/fetch-http-handler": "^5.3.9",
-        "@smithy/hash-node": "^4.2.8",
-        "@smithy/invalid-dependency": "^4.2.8",
-        "@smithy/middleware-content-length": "^4.2.8",
-        "@smithy/middleware-endpoint": "^4.4.12",
-        "@smithy/middleware-retry": "^4.4.29",
-        "@smithy/middleware-serde": "^4.2.9",
-        "@smithy/middleware-stack": "^4.2.8",
-        "@smithy/node-config-provider": "^4.3.8",
-        "@smithy/node-http-handler": "^4.4.8",
-        "@smithy/protocol-http": "^5.3.8",
-        "@smithy/smithy-client": "^4.11.1",
-        "@smithy/types": "^4.12.0",
-        "@smithy/url-parser": "^4.2.8",
-        "@smithy/util-base64": "^4.3.0",
-        "@smithy/util-body-length-browser": "^4.2.0",
-        "@smithy/util-body-length-node": "^4.2.1",
-        "@smithy/util-defaults-mode-browser": "^4.3.28",
-        "@smithy/util-defaults-mode-node": "^4.2.31",
-        "@smithy/util-endpoints": "^3.2.8",
-        "@smithy/util-middleware": "^4.2.8",
-        "@smithy/util-retry": "^4.2.8",
-        "@smithy/util-stream": "^4.5.10",
-        "@smithy/util-utf8": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sso": {
-      "version": "3.982.0",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-crypto/sha256-browser": "5.2.0",
-        "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.973.6",
-        "@aws-sdk/middleware-host-header": "^3.972.3",
-        "@aws-sdk/middleware-logger": "^3.972.3",
-        "@aws-sdk/middleware-recursion-detection": "^3.972.3",
-        "@aws-sdk/middleware-user-agent": "^3.972.6",
-        "@aws-sdk/region-config-resolver": "^3.972.3",
-        "@aws-sdk/types": "^3.973.1",
-        "@aws-sdk/util-endpoints": "3.982.0",
-        "@aws-sdk/util-user-agent-browser": "^3.972.3",
-        "@aws-sdk/util-user-agent-node": "^3.972.4",
-        "@smithy/config-resolver": "^4.4.6",
-        "@smithy/core": "^3.22.0",
-        "@smithy/fetch-http-handler": "^5.3.9",
-        "@smithy/hash-node": "^4.2.8",
-        "@smithy/invalid-dependency": "^4.2.8",
-        "@smithy/middleware-content-length": "^4.2.8",
-        "@smithy/middleware-endpoint": "^4.4.12",
-        "@smithy/middleware-retry": "^4.4.29",
-        "@smithy/middleware-serde": "^4.2.9",
-        "@smithy/middleware-stack": "^4.2.8",
-        "@smithy/node-config-provider": "^4.3.8",
-        "@smithy/node-http-handler": "^4.4.8",
-        "@smithy/protocol-http": "^5.3.8",
-        "@smithy/smithy-client": "^4.11.1",
-        "@smithy/types": "^4.12.0",
-        "@smithy/url-parser": "^4.2.8",
-        "@smithy/util-base64": "^4.3.0",
-        "@smithy/util-body-length-browser": "^4.2.0",
-        "@smithy/util-body-length-node": "^4.2.1",
-        "@smithy/util-defaults-mode-browser": "^4.3.28",
-        "@smithy/util-defaults-mode-node": "^4.2.31",
-        "@smithy/util-endpoints": "^3.2.8",
-        "@smithy/util-middleware": "^4.2.8",
-        "@smithy/util-retry": "^4.2.8",
-        "@smithy/util-utf8": "^4.2.0",
+        "@aws-sdk/core": "^3.977.9",
+        "@aws-sdk/credential-provider-node": "^3.972.82",
+        "@aws-sdk/eventstream-handler-node": "^3.972.34",
+        "@aws-sdk/middleware-eventstream": "^3.972.29",
+        "@aws-sdk/middleware-websocket": "^3.972.52",
+        "@aws-sdk/token-providers": "3.1123.0",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/fetch-http-handler": "^5.7.2",
+        "@smithy/node-http-handler": "^4.11.3",
+        "@smithy/types": "^4.17.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -337,21 +140,18 @@
       }
     },
     "node_modules/@aws-sdk/core": {
-      "version": "3.973.6",
+      "version": "3.977.9",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.977.9.tgz",
+      "integrity": "sha512-reqPFEQrZxDZpeGj4PFMepBeR5LGYHRqq/L0motTzgFkCRBA4rFdaVXDSLYyGHhxVz7sT2PDnPN9CluGSfgyJA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.1",
-        "@aws-sdk/xml-builder": "^3.972.4",
-        "@smithy/core": "^3.22.0",
-        "@smithy/node-config-provider": "^4.3.8",
-        "@smithy/property-provider": "^4.2.8",
-        "@smithy/protocol-http": "^5.3.8",
-        "@smithy/signature-v4": "^5.3.8",
-        "@smithy/smithy-client": "^4.11.1",
-        "@smithy/types": "^4.12.0",
-        "@smithy/util-base64": "^4.3.0",
-        "@smithy/util-middleware": "^4.2.8",
-        "@smithy/util-utf8": "^4.2.0",
+        "@aws-sdk/types": "^3.974.5",
+        "@aws-sdk/xml-builder": "^3.972.40",
+        "@aws/lambda-invoke-store": "^0.3.0",
+        "@smithy/core": "^3.33.3",
+        "@smithy/signature-v4": "^5.6.12",
+        "@smithy/types": "^4.17.2",
+        "bowser": "^2.11.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -359,13 +159,15 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.972.4",
+      "version": "3.972.70",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.70.tgz",
+      "integrity": "sha512-H404B7dJl2mCrBqahDEYsanB0xhdDp6tXnXcTUnXmmpy2Q3J0Ho0bUajZ2jr/RdwzCyS59Gi8xXIFwPLGBl6Uw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.6",
-        "@aws-sdk/types": "^3.973.1",
-        "@smithy/property-provider": "^4.2.8",
-        "@smithy/types": "^4.12.0",
+        "@aws-sdk/core": "^3.977.9",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.17.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -373,18 +175,17 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-http": {
-      "version": "3.972.6",
+      "version": "3.972.72",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.72.tgz",
+      "integrity": "sha512-X98zYOrVOeuosCX+6ktf29FC2N2GHPLia7qv6mzPzTc+RPAuHWCDS++Z6JK7eGYqb/v6uaW7bAXaOvDBfol+0w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.6",
-        "@aws-sdk/types": "^3.973.1",
-        "@smithy/fetch-http-handler": "^5.3.9",
-        "@smithy/node-http-handler": "^4.4.8",
-        "@smithy/property-provider": "^4.2.8",
-        "@smithy/protocol-http": "^5.3.8",
-        "@smithy/smithy-client": "^4.11.1",
-        "@smithy/types": "^4.12.0",
-        "@smithy/util-stream": "^4.5.10",
+        "@aws-sdk/core": "^3.977.9",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/fetch-http-handler": "^5.7.2",
+        "@smithy/node-http-handler": "^4.11.3",
+        "@smithy/types": "^4.17.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -392,22 +193,23 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.972.4",
+      "version": "3.973.15",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.973.15.tgz",
+      "integrity": "sha512-Rykg6s5ceBuynMOGWgoowO4N+27JfnqXAnVaSunZl0hOO1XodSrxGNz6sCEbnmS0lAfQZDKyb3fbr46gSuv6Sg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.6",
-        "@aws-sdk/credential-provider-env": "^3.972.4",
-        "@aws-sdk/credential-provider-http": "^3.972.6",
-        "@aws-sdk/credential-provider-login": "^3.972.4",
-        "@aws-sdk/credential-provider-process": "^3.972.4",
-        "@aws-sdk/credential-provider-sso": "^3.972.4",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.4",
-        "@aws-sdk/nested-clients": "3.982.0",
-        "@aws-sdk/types": "^3.973.1",
-        "@smithy/credential-provider-imds": "^4.2.8",
-        "@smithy/property-provider": "^4.2.8",
-        "@smithy/shared-ini-file-loader": "^4.4.3",
-        "@smithy/types": "^4.12.0",
+        "@aws-sdk/core": "^3.977.9",
+        "@aws-sdk/credential-provider-env": "^3.972.70",
+        "@aws-sdk/credential-provider-http": "^3.972.72",
+        "@aws-sdk/credential-provider-login": "^3.972.77",
+        "@aws-sdk/credential-provider-process": "^3.972.70",
+        "@aws-sdk/credential-provider-sso": "^3.973.14",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.76",
+        "@aws-sdk/nested-clients": "^3.997.44",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/credential-provider-imds": "^4.4.16",
+        "@smithy/types": "^4.17.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -415,16 +217,16 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-login": {
-      "version": "3.972.4",
+      "version": "3.972.77",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.77.tgz",
+      "integrity": "sha512-Jb59xfEISoN5mmbnA+HYqdtrSX3CgCtJoof+V5D8/TgUI56W63GEEd5Y58WijU3Ou6+WEgaLD1feVzaRXV5IDQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.6",
-        "@aws-sdk/nested-clients": "3.982.0",
-        "@aws-sdk/types": "^3.973.1",
-        "@smithy/property-provider": "^4.2.8",
-        "@smithy/protocol-http": "^5.3.8",
-        "@smithy/shared-ini-file-loader": "^4.4.3",
-        "@smithy/types": "^4.12.0",
+        "@aws-sdk/core": "^3.977.9",
+        "@aws-sdk/nested-clients": "^3.997.44",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.17.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -432,20 +234,21 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.972.5",
+      "version": "3.972.82",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.82.tgz",
+      "integrity": "sha512-znDkEOGXB8W3kG1LJUKP3foBZY/9qLM0eil/DxWXSp37XsdsRLQHE/d/OaCGGVgKpA6znR38h/+INk8do1FjiA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "^3.972.4",
-        "@aws-sdk/credential-provider-http": "^3.972.6",
-        "@aws-sdk/credential-provider-ini": "^3.972.4",
-        "@aws-sdk/credential-provider-process": "^3.972.4",
-        "@aws-sdk/credential-provider-sso": "^3.972.4",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.4",
-        "@aws-sdk/types": "^3.973.1",
-        "@smithy/credential-provider-imds": "^4.2.8",
-        "@smithy/property-provider": "^4.2.8",
-        "@smithy/shared-ini-file-loader": "^4.4.3",
-        "@smithy/types": "^4.12.0",
+        "@aws-sdk/credential-provider-env": "^3.972.70",
+        "@aws-sdk/credential-provider-http": "^3.972.72",
+        "@aws-sdk/credential-provider-ini": "^3.973.15",
+        "@aws-sdk/credential-provider-process": "^3.972.70",
+        "@aws-sdk/credential-provider-sso": "^3.973.14",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.76",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/credential-provider-imds": "^4.4.16",
+        "@smithy/types": "^4.17.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -453,14 +256,15 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.972.4",
+      "version": "3.972.70",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.70.tgz",
+      "integrity": "sha512-2ry03fGRJr4sV3jI+ocjj5JqALnFD6ymM5KiNCDZMvq8bX2GSbE0vji4aM43TVCl2nXqqLRZaUxdq/KeWRAY4Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.6",
-        "@aws-sdk/types": "^3.973.1",
-        "@smithy/property-provider": "^4.2.8",
-        "@smithy/shared-ini-file-loader": "^4.4.3",
-        "@smithy/types": "^4.12.0",
+        "@aws-sdk/core": "^3.977.9",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.17.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -468,16 +272,34 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.972.4",
+      "version": "3.973.14",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.973.14.tgz",
+      "integrity": "sha512-jkhg/8ocAAoc0RFyLMhCw+/zZh7gystQgd4F4hznNa8P4Cc501PQmxd+jGLiMHodPJ+7Zv/3znM62gZojyasmA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/client-sso": "3.982.0",
-        "@aws-sdk/core": "^3.973.6",
-        "@aws-sdk/token-providers": "3.982.0",
-        "@aws-sdk/types": "^3.973.1",
-        "@smithy/property-provider": "^4.2.8",
-        "@smithy/shared-ini-file-loader": "^4.4.3",
-        "@smithy/types": "^4.12.0",
+        "@aws-sdk/core": "^3.977.9",
+        "@aws-sdk/nested-clients": "^3.997.44",
+        "@aws-sdk/token-providers": "3.1116.0",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-sso/node_modules/@aws-sdk/token-providers": {
+      "version": "3.1116.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1116.0.tgz",
+      "integrity": "sha512-ygIivKqh8aHzNkucOCXHyIBgBpLPfrSI0mCqXF+vLBsPTUKqj0VSqAY0GFPe7lQl4HntjOcQ+KSyS7oUV2C54Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.9",
+        "@aws-sdk/nested-clients": "^3.997.44",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.17.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -485,15 +307,16 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.972.4",
+      "version": "3.972.76",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.76.tgz",
+      "integrity": "sha512-d3AGyVu759PGr35mEB2s22xxlNEA5rpdxtSPJthfPFJvoQ8dt357iVPECqWfUxXp1toJAvKmbtcIYVGigaGsCA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.6",
-        "@aws-sdk/nested-clients": "3.982.0",
-        "@aws-sdk/types": "^3.973.1",
-        "@smithy/property-provider": "^4.2.8",
-        "@smithy/shared-ini-file-loader": "^4.4.3",
-        "@smithy/types": "^4.12.0",
+        "@aws-sdk/core": "^3.977.9",
+        "@aws-sdk/nested-clients": "^3.997.44",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.17.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -501,12 +324,14 @@
       }
     },
     "node_modules/@aws-sdk/eventstream-handler-node": {
-      "version": "3.972.4",
+      "version": "3.972.34",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-handler-node/-/eventstream-handler-node-3.972.34.tgz",
+      "integrity": "sha512-cTeVzpu1xEAkryTZBYhGwnQ6gOGyp8ZYZvmn0Sg/nI/ABmy/CRHHxPDJDUi9PxwxUtGGaatvfRUB3FCgT/rSWw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.1",
-        "@smithy/eventstream-codec": "^4.2.8",
-        "@smithy/types": "^4.12.0",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.17.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -514,67 +339,14 @@
       }
     },
     "node_modules/@aws-sdk/middleware-eventstream": {
-      "version": "3.972.3",
+      "version": "3.972.29",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-eventstream/-/middleware-eventstream-3.972.29.tgz",
+      "integrity": "sha512-dlRzHCgyB8W6hLuDC5pcT5q+ziPt00n4QGgGBE17ucLVU4zMa6lsbuUdQ2Pm75Z5VA8GF+R/+SgrRcaTdIzSIQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.1",
-        "@smithy/protocol-http": "^5.3.8",
-        "@smithy/types": "^4.12.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-host-header": {
-      "version": "3.972.3",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "^3.973.1",
-        "@smithy/protocol-http": "^5.3.8",
-        "@smithy/types": "^4.12.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-logger": {
-      "version": "3.972.3",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "^3.973.1",
-        "@smithy/types": "^4.12.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-recursion-detection": {
-      "version": "3.972.3",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "^3.973.1",
-        "@aws/lambda-invoke-store": "^0.2.2",
-        "@smithy/protocol-http": "^5.3.8",
-        "@smithy/types": "^4.12.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-user-agent": {
-      "version": "3.972.6",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "^3.973.6",
-        "@aws-sdk/types": "^3.973.1",
-        "@aws-sdk/util-endpoints": "3.982.0",
-        "@smithy/core": "^3.22.0",
-        "@smithy/protocol-http": "^5.3.8",
-        "@smithy/types": "^4.12.0",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.17.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -582,18 +354,17 @@
       }
     },
     "node_modules/@aws-sdk/middleware-websocket": {
-      "version": "3.972.4",
+      "version": "3.972.52",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-websocket/-/middleware-websocket-3.972.52.tgz",
+      "integrity": "sha512-vsPPM+nMbKJlUCFU+eoGZbdxdxDIAX9LbpjSXaR5Ufpmqgp8TdYQnoExhLu4T3umW/JIIPny1ydbhWidZZYokQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.1",
-        "@aws-sdk/util-format-url": "^3.972.3",
-        "@smithy/eventstream-codec": "^4.2.8",
-        "@smithy/eventstream-serde-browser": "^4.2.8",
-        "@smithy/fetch-http-handler": "^5.3.9",
-        "@smithy/protocol-http": "^5.3.8",
-        "@smithy/signature-v4": "^5.3.8",
-        "@smithy/types": "^4.12.0",
-        "@smithy/util-hex-encoding": "^4.2.0",
+        "@aws-sdk/core": "^3.977.9",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/fetch-http-handler": "^5.7.2",
+        "@smithy/signature-v4": "^5.6.12",
+        "@smithy/types": "^4.17.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -601,60 +372,33 @@
       }
     },
     "node_modules/@aws-sdk/nested-clients": {
-      "version": "3.982.0",
+      "version": "3.997.44",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.44.tgz",
+      "integrity": "sha512-NhEgryjlBF9w38ZXqGymQV28IhkYa1mKhlbYnqIis57AYwWGVYfUPgg/qC2rLRqOUfblxx++irvju10kVTa8Vw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-crypto/sha256-browser": "5.2.0",
-        "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.973.6",
-        "@aws-sdk/middleware-host-header": "^3.972.3",
-        "@aws-sdk/middleware-logger": "^3.972.3",
-        "@aws-sdk/middleware-recursion-detection": "^3.972.3",
-        "@aws-sdk/middleware-user-agent": "^3.972.6",
-        "@aws-sdk/region-config-resolver": "^3.972.3",
-        "@aws-sdk/types": "^3.973.1",
-        "@aws-sdk/util-endpoints": "3.982.0",
-        "@aws-sdk/util-user-agent-browser": "^3.972.3",
-        "@aws-sdk/util-user-agent-node": "^3.972.4",
-        "@smithy/config-resolver": "^4.4.6",
-        "@smithy/core": "^3.22.0",
-        "@smithy/fetch-http-handler": "^5.3.9",
-        "@smithy/hash-node": "^4.2.8",
-        "@smithy/invalid-dependency": "^4.2.8",
-        "@smithy/middleware-content-length": "^4.2.8",
-        "@smithy/middleware-endpoint": "^4.4.12",
-        "@smithy/middleware-retry": "^4.4.29",
-        "@smithy/middleware-serde": "^4.2.9",
-        "@smithy/middleware-stack": "^4.2.8",
-        "@smithy/node-config-provider": "^4.3.8",
-        "@smithy/node-http-handler": "^4.4.8",
-        "@smithy/protocol-http": "^5.3.8",
-        "@smithy/smithy-client": "^4.11.1",
-        "@smithy/types": "^4.12.0",
-        "@smithy/url-parser": "^4.2.8",
-        "@smithy/util-base64": "^4.3.0",
-        "@smithy/util-body-length-browser": "^4.2.0",
-        "@smithy/util-body-length-node": "^4.2.1",
-        "@smithy/util-defaults-mode-browser": "^4.3.28",
-        "@smithy/util-defaults-mode-node": "^4.2.31",
-        "@smithy/util-endpoints": "^3.2.8",
-        "@smithy/util-middleware": "^4.2.8",
-        "@smithy/util-retry": "^4.2.8",
-        "@smithy/util-utf8": "^4.2.0",
+        "@aws-sdk/core": "^3.977.9",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.46",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/fetch-http-handler": "^5.7.2",
+        "@smithy/node-http-handler": "^4.11.3",
+        "@smithy/types": "^4.17.2",
         "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=20.0.0"
       }
     },
-    "node_modules/@aws-sdk/region-config-resolver": {
-      "version": "3.972.3",
+    "node_modules/@aws-sdk/signature-v4-multi-region": {
+      "version": "3.996.46",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.46.tgz",
+      "integrity": "sha512-L+2xZTye/2T96f3lwCws0Zw6GG2JHZW9e8FpVgGBeeExSKyeoZ6CWRpBml/7DNiK/O26jrgPM9F+Ay8VkgzUWQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.1",
-        "@smithy/config-resolver": "^4.4.6",
-        "@smithy/node-config-provider": "^4.3.8",
-        "@smithy/types": "^4.12.0",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/signature-v4": "^5.6.12",
+        "@smithy/types": "^4.17.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -662,15 +406,16 @@
       }
     },
     "node_modules/@aws-sdk/token-providers": {
-      "version": "3.982.0",
+      "version": "3.1123.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1123.0.tgz",
+      "integrity": "sha512-Boa6K6YuxMcoIIW9HyPvPeMH/5A7VMNSEGk7d/iLYoyb8k0TtcTZ4jKdAJ3k5T9e5hjopmwtS6tbYQEOtc+VvA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.6",
-        "@aws-sdk/nested-clients": "3.982.0",
-        "@aws-sdk/types": "^3.973.1",
-        "@smithy/property-provider": "^4.2.8",
-        "@smithy/shared-ini-file-loader": "^4.4.3",
-        "@smithy/types": "^4.12.0",
+        "@aws-sdk/core": "^3.977.9",
+        "@aws-sdk/nested-clients": "^3.997.44",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.17.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -678,92 +423,25 @@
       }
     },
     "node_modules/@aws-sdk/types": {
-      "version": "3.973.1",
+      "version": "3.974.5",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.974.5.tgz",
+      "integrity": "sha512-LkwLL2BLbC6wNNm4JaH9mbEqBMdOZCct6VAYqhdN4U1xrWM+fUJQEfbHwQgDypapOWTRtlk25akb5afM0P8CIQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.12.0",
+        "@smithy/types": "^4.17.2",
         "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-endpoints": {
-      "version": "3.982.0",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "^3.973.1",
-        "@smithy/types": "^4.12.0",
-        "@smithy/url-parser": "^4.2.8",
-        "@smithy/util-endpoints": "^3.2.8",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-format-url": {
-      "version": "3.972.3",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "^3.973.1",
-        "@smithy/querystring-builder": "^4.2.8",
-        "@smithy/types": "^4.12.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-locate-window": {
-      "version": "3.965.4",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-user-agent-browser": {
-      "version": "3.972.3",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "^3.973.1",
-        "@smithy/types": "^4.12.0",
-        "bowser": "^2.11.0",
-        "tslib": "^2.6.2"
-      }
-    },
-    "node_modules/@aws-sdk/util-user-agent-node": {
-      "version": "3.972.4",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/middleware-user-agent": "^3.972.6",
-        "@aws-sdk/types": "^3.973.1",
-        "@smithy/node-config-provider": "^4.3.8",
-        "@smithy/types": "^4.12.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      },
-      "peerDependencies": {
-        "aws-crt": ">=1.0.0"
-      },
-      "peerDependenciesMeta": {
-        "aws-crt": {
-          "optional": true
-        }
       }
     },
     "node_modules/@aws-sdk/xml-builder": {
-      "version": "3.972.24",
+      "version": "3.972.40",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.40.tgz",
+      "integrity": "sha512-wlFmCIGUlwF4zx/kncw+bmxTQh1HeSJq4mYV/V5cZUSJadDP3kXvGW8Rn21cimj/7y9ju+47oYWXi97vF7czaA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@nodable/entities": "2.1.0",
-        "@smithy/types": "^4.14.1",
-        "fast-xml-parser": "5.7.3",
+        "@smithy/types": "^4.17.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -771,7 +449,9 @@
       }
     },
     "node_modules/@aws/lambda-invoke-store": {
-      "version": "0.2.3",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.3.0.tgz",
+      "integrity": "sha512-sl4Bm6yiMNYrZKkqqDFWN0UfnWhlS8ivKxrYl+6t0gCLrqr8y3B2IqZZbFRkfaVVp7C/baApyh71P+LeE1A2sQ==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=18.0.0"
@@ -2593,16 +2273,6 @@
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
-    },
-    "node_modules/@nodable/entities": {
-      "version": "2.1.0",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/nodable"
-        }
-      ],
-      "license": "MIT"
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -4744,45 +4414,13 @@
         "url": "https://ko-fi.com/dangreen"
       }
     },
-    "node_modules/@smithy/abort-controller": {
-      "version": "4.2.8",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.12.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/config-resolver": {
-      "version": "4.4.6",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/node-config-provider": "^4.3.8",
-        "@smithy/types": "^4.12.0",
-        "@smithy/util-config-provider": "^4.2.0",
-        "@smithy/util-endpoints": "^3.2.8",
-        "@smithy/util-middleware": "^4.2.8",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
     "node_modules/@smithy/core": {
-      "version": "3.22.1",
+      "version": "3.33.3",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.33.3.tgz",
+      "integrity": "sha512-CsOeKq/9kA3y6VJHt+/+VTCtBaxJ4OTFpgrjIUhPpDIKxBci1k2bJaQASF2h/ELWrulGp+t97DZ0mevfAD8idg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/middleware-serde": "^4.2.9",
-        "@smithy/protocol-http": "^5.3.8",
-        "@smithy/types": "^4.12.0",
-        "@smithy/util-base64": "^4.3.0",
-        "@smithy/util-body-length-browser": "^4.2.0",
-        "@smithy/util-middleware": "^4.2.8",
-        "@smithy/util-stream": "^4.5.11",
-        "@smithy/util-utf8": "^4.2.0",
-        "@smithy/uuid": "^1.1.0",
+        "@smithy/types": "^4.17.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4790,73 +4428,13 @@
       }
     },
     "node_modules/@smithy/credential-provider-imds": {
-      "version": "4.2.8",
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.5.2.tgz",
+      "integrity": "sha512-A9uSdn72ozbRUSit0eib0TW7nXuNPlaeM0zcGkJ+nE6tFcSDbnmtwoxbTCFBukVQcszDAyvsd7+rTduPTXpygg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/node-config-provider": "^4.3.8",
-        "@smithy/property-provider": "^4.2.8",
-        "@smithy/types": "^4.12.0",
-        "@smithy/url-parser": "^4.2.8",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/eventstream-codec": {
-      "version": "4.2.8",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-crypto/crc32": "5.2.0",
-        "@smithy/types": "^4.12.0",
-        "@smithy/util-hex-encoding": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/eventstream-serde-browser": {
-      "version": "4.2.8",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/eventstream-serde-universal": "^4.2.8",
-        "@smithy/types": "^4.12.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/eventstream-serde-config-resolver": {
-      "version": "4.3.8",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.12.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/eventstream-serde-node": {
-      "version": "4.2.8",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/eventstream-serde-universal": "^4.2.8",
-        "@smithy/types": "^4.12.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/eventstream-serde-universal": {
-      "version": "4.2.8",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/eventstream-codec": "^4.2.8",
-        "@smithy/types": "^4.12.0",
+        "@smithy/core": "^3.33.2",
+        "@smithy/types": "^4.17.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4864,130 +4442,13 @@
       }
     },
     "node_modules/@smithy/fetch-http-handler": {
-      "version": "5.3.9",
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.7.2.tgz",
+      "integrity": "sha512-nZyWTmSpJEXl6VtWVMBJve/7x12DZu6sIX1z1a+ZMaHlQQRs9Zpu6NbTe/gmxYXVRpkjxyDYpZ5gx2IM6f/Wkw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/protocol-http": "^5.3.8",
-        "@smithy/querystring-builder": "^4.2.8",
-        "@smithy/types": "^4.12.0",
-        "@smithy/util-base64": "^4.3.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/hash-node": {
-      "version": "4.2.8",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.12.0",
-        "@smithy/util-buffer-from": "^4.2.0",
-        "@smithy/util-utf8": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/invalid-dependency": {
-      "version": "4.2.8",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.12.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/is-array-buffer": {
-      "version": "4.2.0",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/middleware-content-length": {
-      "version": "4.2.8",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/protocol-http": "^5.3.8",
-        "@smithy/types": "^4.12.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/middleware-endpoint": {
-      "version": "4.4.13",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/core": "^3.22.1",
-        "@smithy/middleware-serde": "^4.2.9",
-        "@smithy/node-config-provider": "^4.3.8",
-        "@smithy/shared-ini-file-loader": "^4.4.3",
-        "@smithy/types": "^4.12.0",
-        "@smithy/url-parser": "^4.2.8",
-        "@smithy/util-middleware": "^4.2.8",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/middleware-retry": {
-      "version": "4.4.30",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/node-config-provider": "^4.3.8",
-        "@smithy/protocol-http": "^5.3.8",
-        "@smithy/service-error-classification": "^4.2.8",
-        "@smithy/smithy-client": "^4.11.2",
-        "@smithy/types": "^4.12.0",
-        "@smithy/util-middleware": "^4.2.8",
-        "@smithy/util-retry": "^4.2.8",
-        "@smithy/uuid": "^1.1.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/middleware-serde": {
-      "version": "4.2.9",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/protocol-http": "^5.3.8",
-        "@smithy/types": "^4.12.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/middleware-stack": {
-      "version": "4.2.8",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.12.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/node-config-provider": {
-      "version": "4.3.8",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/property-provider": "^4.2.8",
-        "@smithy/shared-ini-file-loader": "^4.4.3",
-        "@smithy/types": "^4.12.0",
+        "@smithy/core": "^3.33.2",
+        "@smithy/types": "^4.17.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4995,79 +4456,13 @@
       }
     },
     "node_modules/@smithy/node-http-handler": {
-      "version": "4.4.9",
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.12.0.tgz",
+      "integrity": "sha512-0mq1pHadfyXCYCqm2cNpbjNIT+fbaUpNxewZb/YNr2L0IrEVMOb8gM/Fl4K6XvHCW3uSNDFwPl/+iKm0bx9jYg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/abort-controller": "^4.2.8",
-        "@smithy/protocol-http": "^5.3.8",
-        "@smithy/querystring-builder": "^4.2.8",
-        "@smithy/types": "^4.12.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/property-provider": {
-      "version": "4.2.8",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.12.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/protocol-http": {
-      "version": "5.3.8",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.12.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/querystring-builder": {
-      "version": "4.2.8",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.12.0",
-        "@smithy/util-uri-escape": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/querystring-parser": {
-      "version": "4.2.8",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.12.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/service-error-classification": {
-      "version": "4.2.8",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.12.0"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/shared-ini-file-loader": {
-      "version": "4.4.3",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.12.0",
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.17.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -5075,32 +4470,13 @@
       }
     },
     "node_modules/@smithy/signature-v4": {
-      "version": "5.3.8",
+      "version": "5.7.3",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.7.3.tgz",
+      "integrity": "sha512-7ImGm+FkHRLcBaRttIAMZ6bzJZWb2cJGoYjq46F2UjycujWzrL9GEN9h4w7eQyXJYnltrUhxbbieBAIRrdqpow==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/is-array-buffer": "^4.2.0",
-        "@smithy/protocol-http": "^5.3.8",
-        "@smithy/types": "^4.12.0",
-        "@smithy/util-hex-encoding": "^4.2.0",
-        "@smithy/util-middleware": "^4.2.8",
-        "@smithy/util-uri-escape": "^4.2.0",
-        "@smithy/util-utf8": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/smithy-client": {
-      "version": "4.11.2",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/core": "^3.22.1",
-        "@smithy/middleware-endpoint": "^4.4.13",
-        "@smithy/middleware-stack": "^4.2.8",
-        "@smithy/protocol-http": "^5.3.8",
-        "@smithy/types": "^4.12.0",
-        "@smithy/util-stream": "^4.5.11",
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.17.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -5108,194 +4484,9 @@
       }
     },
     "node_modules/@smithy/types": {
-      "version": "4.14.2",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/url-parser": {
-      "version": "4.2.8",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/querystring-parser": "^4.2.8",
-        "@smithy/types": "^4.12.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/util-base64": {
-      "version": "4.3.0",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/util-buffer-from": "^4.2.0",
-        "@smithy/util-utf8": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/util-body-length-browser": {
-      "version": "4.2.0",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/util-body-length-node": {
-      "version": "4.2.1",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/util-buffer-from": {
-      "version": "4.2.0",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/is-array-buffer": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/util-config-provider": {
-      "version": "4.2.0",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/util-defaults-mode-browser": {
-      "version": "4.3.29",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/property-provider": "^4.2.8",
-        "@smithy/smithy-client": "^4.11.2",
-        "@smithy/types": "^4.12.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/util-defaults-mode-node": {
-      "version": "4.2.32",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/config-resolver": "^4.4.6",
-        "@smithy/credential-provider-imds": "^4.2.8",
-        "@smithy/node-config-provider": "^4.3.8",
-        "@smithy/property-provider": "^4.2.8",
-        "@smithy/smithy-client": "^4.11.2",
-        "@smithy/types": "^4.12.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/util-endpoints": {
-      "version": "3.2.8",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/node-config-provider": "^4.3.8",
-        "@smithy/types": "^4.12.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/util-hex-encoding": {
-      "version": "4.2.0",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/util-middleware": {
-      "version": "4.2.8",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.12.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/util-retry": {
-      "version": "4.2.8",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/service-error-classification": "^4.2.8",
-        "@smithy/types": "^4.12.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/util-stream": {
-      "version": "4.5.11",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/fetch-http-handler": "^5.3.9",
-        "@smithy/node-http-handler": "^4.4.9",
-        "@smithy/types": "^4.12.0",
-        "@smithy/util-base64": "^4.3.0",
-        "@smithy/util-buffer-from": "^4.2.0",
-        "@smithy/util-hex-encoding": "^4.2.0",
-        "@smithy/util-utf8": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/util-uri-escape": {
-      "version": "4.2.0",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/util-utf8": {
-      "version": "4.2.0",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/util-buffer-from": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/uuid": {
-      "version": "1.1.0",
+      "version": "4.17.2",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.17.2.tgz",
+      "integrity": "sha512-FOKpVZob9MPTn2znRzGrnsMHv7BOsKVw3XiP/cOyYLDVZ9qKp4nifIiSCuUU/fIj5Vu0UOAxCFr+qRAtG0NUkA==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -6092,7 +5283,9 @@
       "license": "ISC"
     },
     "node_modules/bowser": {
-      "version": "2.13.1",
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
+      "integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==",
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
@@ -8131,39 +7324,6 @@
         }
       ],
       "license": "BSD-3-Clause"
-    },
-    "node_modules/fast-xml-builder": {
-      "version": "1.2.0",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "path-expression-matcher": "^1.5.0",
-        "xml-naming": "^0.1.0"
-      }
-    },
-    "node_modules/fast-xml-parser": {
-      "version": "5.7.3",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "@nodable/entities": "^2.1.0",
-        "fast-xml-builder": "^1.1.7",
-        "path-expression-matcher": "^1.5.0",
-        "strnum": "^2.2.3"
-      },
-      "bin": {
-        "fxparser": "src/cli/cli.js"
-      }
     },
     "node_modules/fastq": {
       "version": "1.19.1",
@@ -10485,19 +9645,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/path-expression-matcher": {
-      "version": "1.5.0",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
     "node_modules/path-key": {
       "version": "3.1.1",
       "dev": true,
@@ -11681,16 +10828,6 @@
     "node_modules/strip-literal/node_modules/js-tokens": {
       "version": "9.0.1",
       "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/strnum": {
-      "version": "2.3.0",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
       "license": "MIT"
     },
     "node_modules/stylis": {
@@ -13642,19 +12779,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/xml-naming": {
-      "version": "0.1.0",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
     "node_modules/y18n": {
       "version": "5.0.8",
       "license": "ISC",
@@ -13739,12 +12863,12 @@
     },
     "src/aisdk": {
       "name": "@ax-llm/ax-ai-sdk-provider",
-      "version": "23.0.6",
+      "version": "24.0.16",
       "license": "Apache-2.0",
       "dependencies": {
         "@ai-sdk/provider": "^4.0.0",
         "@ai-sdk/provider-utils": "^5.0.0",
-        "@ax-llm/ax": "23.0.6",
+        "@ax-llm/ax": "24.0.16",
         "ai": "^7.0.2",
         "zod": "^3.25.76"
       },
@@ -13757,19 +12881,19 @@
     },
     "src/aws-bedrock": {
       "name": "@ax-llm/ax-ai-aws-bedrock",
-      "version": "23.0.6",
+      "version": "24.0.16",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/client-bedrock-runtime": "^3.709.0",
-        "@ax-llm/ax": "23.0.6"
+        "@aws-sdk/client-bedrock-runtime": "^3.1122.0",
+        "@ax-llm/ax": "24.0.16"
       },
-      "peerDependencies": {
-        "@ax-llm/ax": "14.0.31"
+      "engines": {
+        "node": ">=20"
       }
     },
     "src/ax": {
       "name": "@ax-llm/ax",
-      "version": "23.0.6",
+      "version": "24.0.16",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/api": "^1.9.0"
@@ -13789,8 +12913,9 @@
       "version": "11.0.61",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ax-llm/ax": "23.0.6",
-        "@ax-llm/ax-tools": "23.0.6",
+        "@ax-llm/ax": "24.0.16",
+        "@ax-llm/ax-ai-aws-bedrock": "24.0.16",
+        "@ax-llm/ax-tools": "24.0.16",
         "@opentelemetry/exporter-metrics-otlp-http": "^0.208.0",
         "@opentelemetry/exporter-prometheus": "^0.218.0",
         "@opentelemetry/exporter-trace-otlp-http": "^0.203.0",
@@ -13809,10 +12934,10 @@
     },
     "src/tools": {
       "name": "@ax-llm/ax-tools",
-      "version": "23.0.6",
+      "version": "24.0.16",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ax-llm/ax": "23.0.6",
+        "@ax-llm/ax": "24.0.16",
         "better-sqlite3": "^12.11.1"
       },
       "devDependencies": {

--- a/src/aws-bedrock/README.md
+++ b/src/aws-bedrock/README.md
@@ -1,75 +1,140 @@
-# AWS Bedrock Provider for AX
+# AWS Bedrock Provider for Ax
 
-Production-ready AWS Bedrock integration for AX library. Supports Claude, GPT OSS, and Titan Embed models.
+Native Amazon Bedrock integration for Ax using the AWS SDK `Converse`,
+`ConverseStream`, and Titan embedding APIs. It ships separately so
+`@ax-llm/ax` remains free of AWS SDK dependencies.
 
 ## Features
 
-- **Claude models**: Opus 4.5, Sonnet 4.0, Sonnet 3.7, Sonnet 3.5
-- **GPT OSS models**: 120B, 20B
-- **Embeddings**: Titan Embed V2
-- Regional failover (separate configs for Claude and GPT)
-- Token usage tracking
-- Works with AX signatures, flows, and optimizers
+- Claude and GPT OSS chat models, plus Titan Embed V2
+- Native streaming with cancellation and pre-output regional failover
+- Claude tool use and tool-result round trips
+- Claude image and document inputs, including inline base64 and `s3://` documents
+- Bedrock prompt-cache checkpoints with verified 5-minute and 1-hour TTLs
+- Budget and adaptive Claude thinking, including signed reasoning round trips
+- Model-specific native structured output and service tiers
+- Token, cache-token, request ID, finish-reason, and applied-tier mapping
+
+Capabilities differ by model. Use `ai.getFeatures(model)` before requiring a
+feature; unsupported capabilities are deliberately not advertised.
 
 ## Installation
 
 ```bash
-npm install @ax-llm/ax-ai-aws-bedrock @ax-llm/ax @aws-sdk/client-bedrock-runtime
+npm install @ax-llm/ax @ax-llm/ax-ai-aws-bedrock
 ```
 
-## Quick Start
+The Bedrock package installs `@aws-sdk/client-bedrock-runtime` as its own
+runtime dependency. Applications do not need to add the SDK separately.
+
+## Authentication
+
+The client uses the standard AWS SDK credential chain. Configure credentials
+through your environment, shared AWS config, workload role, or another SDK-
+supported credential source.
+
+## Quick start
 
 ```typescript
-import { AxAIBedrock, AxAIBedrockModel } from '@ax-llm/ax-ai-aws-bedrock';
+import {
+  AxAIBedrock,
+  AxAIBedrockModel,
+} from '@ax-llm/ax-ai-aws-bedrock';
 
 const ai = new AxAIBedrock({
-  region: 'us-east-2',
+  region: process.env.AWS_REGION ?? 'us-east-2',
   fallbackRegions: ['us-west-2', 'us-east-1'],
   config: {
-    model: AxAIBedrockModel.ClaudeOpus45,
-    temperature: 0.7,
+    model: AxAIBedrockModel.ClaudeSonnet5,
     maxTokens: 4096,
   },
 });
 
 const response = await ai.chat({
+  chatPrompt: [{ role: 'user', content: 'What is Amazon Bedrock?' }],
+});
+
+if (response instanceof ReadableStream) {
+  throw new Error('Expected a non-streaming response.');
+}
+
+console.log(response.results[0]?.content);
+```
+
+## Streaming, tools, caching, and thinking
+
+```typescript
+const weatherTool = {
+  name: 'weather',
+  description: 'Read the current weather for a city',
+  parameters: {
+    type: 'object',
+    properties: {
+      city: { type: 'string', description: 'City name' },
+    },
+    required: ['city'],
+  },
+} as const;
+
+const stream = await ai.chat(
+  {
+    chatPrompt: [
+      { role: 'system', content: 'Use tools for live facts.', cache: true },
+      { role: 'user', content: 'What is the weather in Vancouver?' },
+    ],
+    functions: [weatherTool],
+  },
+  {
+    stream: true,
+    contextCache: { ttlSeconds: 3600 },
+    thinkingTokenBudget: 'medium',
+  }
+);
+```
+
+Cache checkpoints can be set on system messages, content blocks, messages, and
+functions with `cache: true`. Bedrock accepts at most four checkpoints per
+request; the provider validates that combined limit before sending.
+
+Claude Sonnet 5 always uses adaptive thinking, so
+`thinkingTokenBudget: 'none'` is rejected for that model. Claude Opus 5 allows
+adaptive thinking to be disabled.
+
+## Native image and document input
+
+```typescript
+const response = await ai.chat({
   chatPrompt: [
-    { role: 'system', content: 'You are a helpful assistant.' },
-    { role: 'user', content: 'What is AWS Bedrock?' },
+    {
+      role: 'user',
+      content: [
+        { type: 'text', text: 'Compare these inputs.' },
+        { type: 'image', image: imageBase64, mimeType: 'image/png' },
+        {
+          type: 'file',
+          fileUri: 's3://my-bucket/policy.pdf',
+          filename: 'policy.pdf',
+          mimeType: 'application/pdf',
+        },
+      ],
+    },
   ],
 });
 ```
 
-## With AX Signatures
+Supported document formats are CSV, DOC, DOCX, HTML, Markdown, PDF, TXT, XLS,
+and XLSX. Image formats are GIF, JPEG, PNG, and WebP.
 
-```typescript
-import { AxSignature, AxGen } from '@ax-llm/ax';
+## Models
 
-const ai = new AxAIBedrock({ config: { model: AxAIBedrockModel.ClaudeOpus45 } });
-const summarize = AxSignature.from('document: string -> summary: string');
-const program = new AxGen(summarize, { ai });
+Current Claude enum members include Sonnet 5, Opus 5, Opus 4.8, Sonnet 4.6,
+Haiku 4.5, Opus 4.5, Sonnet 4, and retained 3.x compatibility models. GPT OSS
+120B and 20B and Titan Embed V2 remain available.
 
-const result = await program.forward({ document: 'Your text...' });
-```
+## Verification
 
-## Recommended Models
-
-```typescript
-// Claude
-AxAIBedrockModel.ClaudeOpus45; // us.anthropic.claude-opus-4-5-20251101-v1:0
-
-// GPT OSS
-AxAIBedrockModel.GptOss120B; // openai.gpt-oss-120b-1:0
-AxAIBedrockModel.GptOss20B; // openai.gpt-oss-20b-1:0
-
-// Embeddings
-AxAIBedrockEmbedModel.TitanEmbedV2; // amazon.titan-embed-text-v2:0
-```
-
-## Testing
+From the repository root:
 
 ```bash
-bun test packages/api/src/agent/ax-main/src/ax/ai/bedrock/api.test.ts
+npm test --workspace=@ax-llm/ax-ai-aws-bedrock
 ```
-
-See `examples.ts` and `QUICKSTART.md` for more examples.

--- a/src/aws-bedrock/api.test.ts
+++ b/src/aws-bedrock/api.test.ts
@@ -1,8 +1,51 @@
+import type {
+  ConverseCommandOutput,
+  ConverseRequest,
+  ConverseStreamOutput,
+} from '@aws-sdk/client-bedrock-runtime';
+import type {
+  AxAIServiceOptions,
+  AxChatRequest,
+  AxChatResponse,
+} from '@ax-llm/ax';
 import { describe, expect, it } from 'vitest';
 
 import { AxAIBedrock } from './api.js';
 import type { BedrockTitanEmbedRequest } from './types.js';
 import { AxAIBedrockEmbedModel, AxAIBedrockModel } from './types.js';
+
+type BedrockChatRequest = AxChatRequest<AxAIBedrockModel> & {
+  model: AxAIBedrockModel;
+};
+
+type BedrockImpl = {
+  createChatReq: (
+    req: Readonly<BedrockChatRequest>,
+    options?: Readonly<AxAIServiceOptions>
+  ) => Promise<[unknown, ConverseRequest]>;
+  createChatResp: (resp: {
+    response: ConverseCommandOutput;
+    model: AxAIBedrockModel;
+    showThoughts: boolean;
+  }) => AxChatResponse;
+  createChatStreamResp: (
+    resp: {
+      event: ConverseStreamOutput;
+      model: AxAIBedrockModel;
+      requestId?: string;
+      showThoughts: boolean;
+    },
+    state: object
+  ) => AxChatResponse;
+};
+
+function getImpl(ai: AxAIBedrock): BedrockImpl {
+  return (ai as unknown as { aiImpl: BedrockImpl }).aiImpl;
+}
+
+function createAI(model = AxAIBedrockModel.ClaudeSonnet5): AxAIBedrock {
+  return new AxAIBedrock({ config: { model } });
+}
 
 // Access the private implementation's request builder without hitting AWS.
 // createEmbedReq only assembles the Titan request body; the AWS SDK call is
@@ -69,5 +112,439 @@ describe('AxAIBedrock Titan embeddings dimensions', () => {
     expect(JSON.parse(JSON.stringify(embedRequest))).not.toHaveProperty(
       'dimensions'
     );
+  });
+});
+
+describe('AxAIBedrock Converse capabilities', () => {
+  it('advertises native Claude capabilities per model', () => {
+    const ai = createAI();
+    const features = ai.getFeatures(AxAIBedrockModel.ClaudeSonnet5);
+
+    expect(features).toMatchObject({
+      functions: true,
+      streaming: true,
+      functionCot: true,
+      structuredOutputs: false,
+      thinking: true,
+      multiTurn: true,
+      serviceTiers: ['standard'],
+      media: {
+        images: { supported: true },
+        files: { supported: true, uploadMethod: 'inline' },
+      },
+      caching: { supported: true, types: ['ephemeral'] },
+    });
+  });
+
+  it('keeps GPT OSS capabilities conservative and model-specific', () => {
+    const ai = createAI(AxAIBedrockModel.GptOss120B);
+    const features = ai.getFeatures(AxAIBedrockModel.GptOss120B);
+
+    expect(features).toMatchObject({
+      functions: false,
+      streaming: true,
+      structuredOutputs: true,
+      structuredOutputModes: ['native'],
+      thinking: false,
+      serviceTiers: ['standard', 'flex', 'priority'],
+      media: {
+        images: { supported: false },
+        files: { supported: false },
+      },
+      caching: { supported: false },
+    });
+  });
+
+  it('advertises Haiku 4.5 native structured output support', () => {
+    const features = createAI(AxAIBedrockModel.ClaudeHaiku45).getFeatures(
+      AxAIBedrockModel.ClaudeHaiku45
+    );
+
+    expect(features).toMatchObject({
+      structuredOutputs: true,
+      structuredOutputModes: ['native', 'function'],
+    });
+  });
+});
+
+describe('AxAIBedrock Converse request mapping', () => {
+  it('maps tools, native media, caching, thinking, and service tier', async () => {
+    const ai = createAI();
+    const image = Buffer.from('image-bytes').toString('base64');
+    const document = Buffer.from('document-bytes').toString('base64');
+    const [, request] = await getImpl(ai).createChatReq(
+      {
+        model: AxAIBedrockModel.ClaudeSonnet5,
+        modelConfig: { maxTokens: 8192, temperature: 0.4 },
+        chatPrompt: [
+          { role: 'system', content: 'Use the supplied evidence.' },
+          {
+            role: 'user',
+            content: [
+              { type: 'text', text: 'Inspect both attachments.' },
+              { type: 'image', image, mimeType: 'image/png' },
+              {
+                type: 'file',
+                data: document,
+                filename: 'notes.md',
+                mimeType: 'text/markdown',
+              },
+            ],
+          },
+          {
+            role: 'assistant',
+            thoughtBlocks: [
+              { data: 'signed reasoning', encrypted: false, signature: 'sig' },
+            ],
+            functionCalls: [
+              {
+                id: 'tool-1',
+                type: 'function',
+                function: { name: 'lookup', params: { id: 7 } },
+              },
+            ],
+          },
+          {
+            role: 'function',
+            functionId: 'tool-1',
+            result: '{"name":"Ax"}',
+          },
+        ],
+        functions: [
+          {
+            name: 'lookup',
+            description: 'Look up a record',
+            parameters: {
+              type: 'object',
+              properties: {
+                id: { type: 'number', description: 'Record ID' },
+              },
+              required: ['id'],
+            },
+          },
+        ],
+        functionCall: 'required',
+      },
+      {
+        contextCache: { ttlSeconds: 3600 },
+        thinkingTokenBudget: 'high',
+        showThoughts: true,
+        serviceTier: 'standard',
+      }
+    );
+
+    expect(request.modelId).toBe(AxAIBedrockModel.ClaudeSonnet5);
+    expect(request.inferenceConfig).toEqual({ maxTokens: 8192 });
+    expect(request.additionalModelRequestFields).toEqual({
+      thinking: { type: 'adaptive' },
+    });
+    expect(request.outputConfig).toEqual({ effort: 'high' });
+    expect(request.serviceTier).toEqual({ type: 'default' });
+    expect(request.system).toEqual([
+      { text: 'Use the supplied evidence.' },
+      { cachePoint: { type: 'default', ttl: '1h' } },
+    ]);
+    expect(request.toolConfig?.toolChoice).toEqual({ any: {} });
+    expect(request.toolConfig?.tools?.at(-1)).toEqual({
+      cachePoint: { type: 'default', ttl: '1h' },
+    });
+
+    const userContent = request.messages?.[0]?.content ?? [];
+    expect(userContent[0]).toEqual({ text: 'Inspect both attachments.' });
+    expect(Array.from(userContent[1].image?.source.bytes ?? [])).toEqual(
+      Array.from(Buffer.from('image-bytes'))
+    );
+    expect(userContent[2].document).toMatchObject({
+      format: 'md',
+      name: 'notes md',
+    });
+    expect(Array.from(userContent[2].document?.source.bytes ?? [])).toEqual(
+      Array.from(Buffer.from('document-bytes'))
+    );
+    expect(request.messages?.[1]?.content).toEqual([
+      {
+        reasoningContent: {
+          reasoningText: { text: 'signed reasoning', signature: 'sig' },
+        },
+      },
+      {
+        toolUse: { toolUseId: 'tool-1', name: 'lookup', input: { id: 7 } },
+      },
+    ]);
+    expect(request.messages?.[2]?.content).toEqual([
+      {
+        toolResult: {
+          toolUseId: 'tool-1',
+          content: [{ json: { name: 'Ax' } }],
+        },
+      },
+    ]);
+  });
+
+  it('maps native structured output and GPT service tiers without tools', async () => {
+    const ai = createAI(AxAIBedrockModel.GptOss120B);
+    const [, request] = await getImpl(ai).createChatReq(
+      {
+        model: AxAIBedrockModel.GptOss120B,
+        chatPrompt: [{ role: 'user', content: 'Return a count.' }],
+        functions: [
+          { name: 'ignored', description: 'Not native on this model' },
+        ],
+        responseFormat: {
+          type: 'json_schema',
+          schema: {
+            title: 'count_response',
+            type: 'object',
+            properties: { count: { type: 'number' } },
+            required: ['count'],
+          },
+        },
+      },
+      { serviceTier: 'flex' }
+    );
+
+    expect(request.toolConfig).toBeUndefined();
+    expect(request.serviceTier).toEqual({ type: 'flex' });
+    expect(request.outputConfig).toEqual({
+      textFormat: {
+        type: 'json_schema',
+        structure: {
+          jsonSchema: {
+            name: 'count_response',
+            schema: JSON.stringify({
+              title: 'count_response',
+              type: 'object',
+              properties: { count: { type: 'number' } },
+              required: ['count'],
+            }),
+          },
+        },
+      },
+    });
+  });
+
+  it('rejects disabling Sonnet 5 adaptive thinking', async () => {
+    await expect(
+      getImpl(createAI()).createChatReq(
+        {
+          model: AxAIBedrockModel.ClaudeSonnet5,
+          chatPrompt: [{ role: 'user', content: 'Answer briefly.' }],
+        },
+        { thinkingTokenBudget: 'none' }
+      )
+    ).rejects.toThrow('Adaptive thinking cannot be disabled');
+  });
+
+  it('allows disabling Opus 5 adaptive thinking', async () => {
+    const [, request] = await getImpl(
+      createAI(AxAIBedrockModel.ClaudeOpus5)
+    ).createChatReq(
+      {
+        model: AxAIBedrockModel.ClaudeOpus5,
+        chatPrompt: [{ role: 'user', content: 'Answer briefly.' }],
+      },
+      { thinkingTokenBudget: 'none' }
+    );
+
+    expect(request.additionalModelRequestFields).toEqual({
+      thinking: { type: 'disabled' },
+    });
+  });
+
+  it('rejects unsupported cache TTLs and service tiers', async () => {
+    const ai = createAI(AxAIBedrockModel.ClaudeSonnet4);
+    const request: BedrockChatRequest = {
+      model: AxAIBedrockModel.ClaudeSonnet4,
+      chatPrompt: [{ role: 'user', content: 'Hello' }],
+    };
+
+    await expect(
+      getImpl(ai).createChatReq(request, {
+        contextCache: { ttlSeconds: 3600 },
+      })
+    ).rejects.toThrow('Prompt-cache TTL 3600s is not supported');
+    await expect(
+      getImpl(ai).createChatReq(request, { serviceTier: 'priority' })
+    ).rejects.toThrow('Service tier priority is not supported');
+  });
+
+  it('adds a message checkpoint when context caching has no system or tools', async () => {
+    const [, request] = await getImpl(createAI()).createChatReq(
+      {
+        model: AxAIBedrockModel.ClaudeSonnet5,
+        chatPrompt: [{ role: 'user', content: 'Cache this prefix.' }],
+      },
+      { contextCache: { ttlSeconds: 300 } }
+    );
+
+    expect(request.messages?.[0]?.content).toEqual([
+      { text: 'Cache this prefix.' },
+      { cachePoint: { type: 'default', ttl: '5m' } },
+    ]);
+  });
+
+  it('counts a cached tool schema toward the four-checkpoint limit', async () => {
+    const ai = createAI();
+    await expect(
+      getImpl(ai).createChatReq({
+        model: AxAIBedrockModel.ClaudeSonnet5,
+        chatPrompt: [
+          { role: 'system', content: 'System', cache: true },
+          {
+            role: 'user',
+            content: [
+              { type: 'text', text: 'one', cache: true },
+              { type: 'text', text: 'two', cache: true },
+              { type: 'text', text: 'three', cache: true },
+            ],
+          },
+        ],
+        functions: [{ name: 'lookup', description: 'Lookup', cache: true }],
+      })
+    ).rejects.toThrow('at most four cache checkpoints');
+  });
+});
+
+describe('AxAIBedrock Converse response mapping', () => {
+  it('maps text, tool calls, reasoning, usage, and stop reason', () => {
+    const ai = createAI();
+    const response = getImpl(ai).createChatResp({
+      model: AxAIBedrockModel.ClaudeSonnet5,
+      showThoughts: true,
+      response: {
+        $metadata: { requestId: 'request-1' },
+        output: {
+          message: {
+            role: 'assistant',
+            content: [
+              {
+                reasoningContent: {
+                  reasoningText: { text: 'considering', signature: 'sig' },
+                },
+              },
+              { text: 'I need a record.' },
+              {
+                toolUse: {
+                  toolUseId: 'tool-1',
+                  name: 'lookup',
+                  input: { id: 7 },
+                },
+              },
+            ],
+          },
+        },
+        stopReason: 'tool_use',
+        usage: {
+          inputTokens: 10,
+          outputTokens: 4,
+          totalTokens: 14,
+          cacheReadInputTokens: 6,
+          cacheWriteInputTokens: 2,
+        },
+        serviceTier: { type: 'default' },
+      },
+    });
+
+    expect(response).toMatchObject({
+      remoteId: 'request-1',
+      remoteRequestId: 'request-1',
+      results: [
+        {
+          content: 'I need a record.',
+          thought: 'considering',
+          thoughtBlocks: [
+            { data: 'considering', encrypted: false, signature: 'sig' },
+          ],
+          functionCalls: [
+            {
+              id: 'tool-1',
+              type: 'function',
+              function: { name: 'lookup', params: { id: 7 } },
+            },
+          ],
+          finishReason: 'function_call',
+        },
+      ],
+    });
+  });
+
+  it('maps streaming text, tools, reasoning, usage, and finish events', () => {
+    const impl = getImpl(createAI());
+    const state = {};
+    const envelope = (event: ConverseStreamOutput) => ({
+      event,
+      model: AxAIBedrockModel.ClaudeSonnet5,
+      requestId: 'request-stream',
+      showThoughts: true,
+    });
+
+    expect(
+      impl.createChatStreamResp(
+        envelope({ messageStart: { role: 'assistant' } }),
+        state
+      ).results[0]
+    ).toMatchObject({ id: 'request-stream', content: '' });
+    expect(
+      impl.createChatStreamResp(
+        envelope({
+          contentBlockDelta: { contentBlockIndex: 0, delta: { text: 'Hi' } },
+        }),
+        state
+      ).results[0]
+    ).toMatchObject({ content: 'Hi' });
+    expect(
+      impl.createChatStreamResp(
+        envelope({
+          contentBlockStart: {
+            contentBlockIndex: 1,
+            start: { toolUse: { toolUseId: 'tool-1', name: 'lookup' } },
+          },
+        }),
+        state
+      ).results[0]?.functionCalls?.[0]
+    ).toMatchObject({ id: 'tool-1', function: { name: 'lookup', params: '' } });
+    expect(
+      impl.createChatStreamResp(
+        envelope({
+          contentBlockDelta: {
+            contentBlockIndex: 1,
+            delta: { toolUse: { input: '{"id":7}' } },
+          },
+        }),
+        state
+      ).results[0]?.functionCalls?.[0]
+    ).toMatchObject({ id: 'tool-1', function: { params: '{"id":7}' } });
+    expect(
+      impl.createChatStreamResp(
+        envelope({
+          contentBlockDelta: {
+            contentBlockIndex: 2,
+            delta: { reasoningContent: { text: 'thinking' } },
+          },
+        }),
+        state
+      ).results[0]
+    ).toMatchObject({
+      thought: 'thinking',
+      thoughtBlocks: [{ data: 'thinking', encrypted: false }],
+    });
+    expect(
+      impl.createChatStreamResp(
+        envelope({
+          metadata: {
+            usage: { inputTokens: 5, outputTokens: 3, totalTokens: 8 },
+            metrics: { latencyMs: 12 },
+            serviceTier: { type: 'priority' },
+          },
+        }),
+        state
+      ).results[0]
+    ).toMatchObject({ content: '' });
+    expect(
+      impl.createChatStreamResp(
+        envelope({ messageStop: { stopReason: 'end_turn' } }),
+        state
+      ).results[0]
+    ).toMatchObject({ content: '', finishReason: 'stop' });
   });
 });

--- a/src/aws-bedrock/api.ts
+++ b/src/aws-bedrock/api.ts
@@ -76,6 +76,7 @@ const IMAGE_FORMATS: Record<string, ImageFormat> = {
   'image/webp': 'webp',
 };
 
+// cspell:ignore msword openxmlformats officedocument spreadsheetml wordprocessingml
 const DOCUMENT_FORMATS: Record<string, DocumentFormat> = {
   'application/msword': 'doc',
   'application/pdf': 'pdf',
@@ -406,13 +407,13 @@ class AxAIBedrockImpl
     const cachingRequested =
       hasExplicitBreakpoint || options?.contextCache !== undefined;
     if (!cachingRequested) return undefined;
-    if (capabilities.cacheTtls.length === 0) {
+    if (capabilities.cacheTTLs.length === 0) {
       throw new Error(`Prompt caching is not supported for ${model}`);
     }
 
     const ttlSeconds = options?.contextCache?.ttlSeconds ?? 300;
     if (ttlSeconds <= 300) return '5m';
-    if (ttlSeconds <= 3600 && capabilities.cacheTtls.includes('1h')) {
+    if (ttlSeconds <= 3600 && capabilities.cacheTTLs.includes('1h')) {
       return '1h';
     }
     throw new Error(
@@ -1079,7 +1080,7 @@ class AxAIBedrockImpl
   };
 
   supportsImplicitCaching = (model: AxAIBedrockModel): boolean =>
-    axGetBedrockModelCapabilities(model).cacheTtls.length > 0;
+    axGetBedrockModelCapabilities(model).cacheTTLs.length > 0;
 
   createEmbedReq = async (
     req: Readonly<AxBedrockEmbedRequest>
@@ -1196,8 +1197,8 @@ export class AxAIBedrock extends AxBaseAI<
           },
         },
         caching: {
-          supported: capabilities.cacheTtls.length > 0,
-          types: capabilities.cacheTtls.length ? ['ephemeral'] : [],
+          supported: capabilities.cacheTTLs.length > 0,
+          types: capabilities.cacheTTLs.length ? ['ephemeral'] : [],
           cacheBreakpoints: true,
         },
         thinking: capabilities.thinking !== 'none',

--- a/src/aws-bedrock/api.ts
+++ b/src/aws-bedrock/api.ts
@@ -1,23 +1,24 @@
-/**
- * AWS Bedrock Provider for AX Library
- *
- * Supports Claude, GPT OSS, and Titan Embed models for use with AX's
- * compiler, signatures, flows, and optimization features.
- *
- * Usage:
- *   const ai = new AxAIBedrock({
- *     region: 'us-east-2',
- *     config: { model: AxAIBedrockModel.ClaudeOpus45 }
- *   });
- *
- *   const sig = AxSignature.from('input -> output');
- *   const gen = new AxGen(sig, { ai });
- *   const result = await gen.forward({ input: 'test' });
- */
+/** AWS Bedrock provider backed by the native AWS SDK Converse API. */
 
+import { Buffer } from 'node:buffer';
 import {
   BedrockRuntimeClient,
+  type ContentBlock,
+  ConverseCommand,
+  type ConverseCommandOutput,
+  type ConverseRequest,
+  ConverseStreamCommand,
+  type ConverseStreamOutput,
+  type DocumentBlock,
+  type DocumentFormat,
+  type ImageBlock,
+  type ImageFormat,
   InvokeModelCommand,
+  type Message,
+  type SystemContentBlock,
+  type TokenUsage,
+  type ToolConfiguration,
+  type ToolResultContentBlock,
 } from '@aws-sdk/client-bedrock-runtime';
 import type {
   AxAIServiceImpl,
@@ -29,27 +30,22 @@ import type {
   AxEmbedRequest,
   AxEmbedResponse,
   AxModelConfig,
+  AxServiceTier,
   AxTokenUsage,
 } from '@ax-llm/ax';
 import { type AxAIFeatures, AxBaseAI, axBaseAIDefaultConfig } from '@ax-llm/ax';
-import { axModelInfoBedrock } from './info.js';
+import {
+  type AxAIBedrockModelCapabilities,
+  axGetBedrockModelCapabilities,
+  axModelInfoBedrock,
+} from './info.js';
 import {
   type AxAIBedrockConfig,
   type AxAIBedrockEmbedModel,
   AxAIBedrockModel,
-  type BedrockChatRequest,
-  type BedrockChatResponse,
-  type BedrockClaudeRequest,
-  type BedrockClaudeResponse,
-  type BedrockGptRequest,
-  type BedrockGptResponse,
   type BedrockTitanEmbedRequest,
   type BedrockTitanEmbedResponse,
 } from './types.js';
-
-// ============================================================================
-// IMPLEMENTATION - Converts between AX format and Bedrock format
-// ============================================================================
 
 type AxBedrockChatRequest = Omit<AxChatRequest, 'model'> &
   Required<Pick<AxChatRequest<AxAIBedrockModel>, 'model'>>;
@@ -57,21 +53,292 @@ type AxBedrockChatRequest = Omit<AxChatRequest, 'model'> &
 type AxBedrockEmbedRequest = Omit<AxEmbedRequest, 'embedModel'> &
   Required<Pick<AxEmbedRequest<AxAIBedrockEmbedModel>, 'embedModel'>>;
 
-type ModelFamily = 'claude' | 'gpt' | 'titan';
+type BedrockConverseResponse = {
+  response: ConverseCommandOutput;
+  model: AxAIBedrockModel;
+  showThoughts: boolean;
+};
+
+type BedrockConverseStreamEvent = {
+  event: ConverseStreamOutput;
+  model: AxAIBedrockModel;
+  requestId?: string;
+  showThoughts: boolean;
+};
+
+type CacheTtl = '5m' | '1h';
+
+const IMAGE_FORMATS: Record<string, ImageFormat> = {
+  'image/gif': 'gif',
+  'image/jpeg': 'jpeg',
+  'image/jpg': 'jpeg',
+  'image/png': 'png',
+  'image/webp': 'webp',
+};
+
+const DOCUMENT_FORMATS: Record<string, DocumentFormat> = {
+  'application/msword': 'doc',
+  'application/pdf': 'pdf',
+  'application/vnd.ms-excel': 'xls',
+  'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet': 'xlsx',
+  'application/vnd.openxmlformats-officedocument.wordprocessingml.document':
+    'docx',
+  'text/csv': 'csv',
+  'text/html': 'html',
+  'text/markdown': 'md',
+  'text/plain': 'txt',
+};
+
+const THINKING_BUDGETS = {
+  minimal: 1024,
+  low: 4096,
+  medium: 10000,
+  high: 20000,
+  highest: 32000,
+} as const;
+
+const THINKING_EFFORT = {
+  minimal: 'low',
+  low: 'low',
+  medium: 'medium',
+  high: 'high',
+  highest: 'max',
+} as const;
+
+function decodeBase64(value: string): Uint8Array {
+  const payload = value.startsWith('data:')
+    ? value.slice(value.indexOf(',') + 1)
+    : value;
+  return Uint8Array.from(Buffer.from(payload, 'base64'));
+}
+
+function encodeBase64(value: Uint8Array): string {
+  return Buffer.from(value).toString('base64');
+}
+
+function toBedrockDocument(
+  value: string | object | undefined
+): NonNullable<ConverseRequest['additionalModelRequestFields']> {
+  if (value === undefined) return {};
+  if (typeof value !== 'string') {
+    return value as NonNullable<
+      ConverseRequest['additionalModelRequestFields']
+    >;
+  }
+  try {
+    return JSON.parse(value) as NonNullable<
+      ConverseRequest['additionalModelRequestFields']
+    >;
+  } catch {
+    return value;
+  }
+}
+
+function fromBedrockDocument(
+  value: NonNullable<ConverseRequest['additionalModelRequestFields']>
+): string | object {
+  if (typeof value === 'string' || typeof value === 'object') return value;
+  return JSON.stringify(value);
+}
+
+function imageFormat(mimeType: string): ImageFormat {
+  const format = IMAGE_FORMATS[mimeType.toLowerCase()];
+  if (!format) {
+    throw new Error(`Unsupported Bedrock image MIME type: ${mimeType}`);
+  }
+  return format;
+}
+
+function documentFormat(mimeType: string, filename?: string): DocumentFormat {
+  const fromMime = DOCUMENT_FORMATS[mimeType.toLowerCase()];
+  if (fromMime) return fromMime;
+
+  const extension = filename?.split('.').pop()?.toLowerCase();
+  if (
+    extension &&
+    ['csv', 'doc', 'docx', 'html', 'md', 'pdf', 'txt', 'xls', 'xlsx'].includes(
+      extension
+    )
+  ) {
+    return extension as DocumentFormat;
+  }
+  throw new Error(`Unsupported Bedrock document MIME type: ${mimeType}`);
+}
+
+function documentName(filename?: string): string {
+  const name = (filename ?? 'document')
+    .replace(/[^A-Za-z0-9\s\-()[\]]/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+  return name || 'document';
+}
+
+function imageBlock(item: { image: string; mimeType: string }): ImageBlock {
+  return {
+    format: imageFormat(item.mimeType),
+    source: { bytes: decodeBase64(item.image) },
+  };
+}
+
+function documentBlock(item: {
+  data?: string;
+  fileUri?: string;
+  filename?: string;
+  mimeType: string;
+}): DocumentBlock {
+  const source = item.data
+    ? { bytes: decodeBase64(item.data) }
+    : item.fileUri?.startsWith('s3://')
+      ? { s3Location: { uri: item.fileUri } }
+      : undefined;
+  if (!source) {
+    throw new Error(
+      'Bedrock document inputs require inline base64 data or an s3:// URI'
+    );
+  }
+  return {
+    format: documentFormat(item.mimeType, item.filename),
+    name: documentName(item.filename),
+    source,
+  };
+}
+
+function cachePoint(ttl: CacheTtl): ContentBlock {
+  return { cachePoint: { type: 'default', ttl } };
+}
+
+function mapStopReason(
+  reason: ConverseCommandOutput['stopReason']
+): AxChatResponseResult['finishReason'] {
+  switch (reason) {
+    case 'end_turn':
+    case 'stop_sequence':
+      return 'stop';
+    case 'max_tokens':
+    case 'model_context_window_exceeded':
+      return 'length';
+    case 'tool_use':
+      return 'function_call';
+    case 'content_filtered':
+    case 'guardrail_intervened':
+      return 'content_filter';
+    case 'malformed_model_output':
+    case 'malformed_tool_use':
+      return 'error';
+    default:
+      return undefined;
+  }
+}
+
+function mapServiceTier(
+  tier?: string
+): AxTokenUsage['serviceTier'] | undefined {
+  switch (tier) {
+    case 'flex':
+      return 'flex';
+    case 'priority':
+      return 'priority';
+    case 'default':
+    case 'reserved':
+      return 'standard';
+    default:
+      return undefined;
+  }
+}
+
+function mapTokenUsage(
+  usage: TokenUsage | undefined,
+  serviceTier?: string
+): AxTokenUsage {
+  const promptTokens = usage?.inputTokens ?? 0;
+  const completionTokens = usage?.outputTokens ?? 0;
+  return {
+    promptTokens,
+    completionTokens,
+    totalTokens: usage?.totalTokens ?? promptTokens + completionTokens,
+    cacheCreationTokens: usage?.cacheWriteInputTokens,
+    cacheReadTokens: usage?.cacheReadInputTokens,
+    serviceTier: mapServiceTier(serviceTier),
+  };
+}
+
+function requestedServiceTier(
+  tier: AxServiceTier | undefined
+): ConverseRequest['serviceTier'] | undefined {
+  switch (tier) {
+    case 'standard':
+      return { type: 'default' };
+    case 'flex':
+      return { type: 'flex' };
+    case 'priority':
+      return { type: 'priority' };
+    default:
+      return undefined;
+  }
+}
+
+function streamError(
+  event: ConverseStreamOutput
+): { error: Error; status?: number } | undefined {
+  if ('throttlingException' in event && event.throttlingException) {
+    return {
+      error: new Error(
+        event.throttlingException.message ?? 'Bedrock throttled'
+      ),
+      status: 429,
+    };
+  }
+  if (
+    'serviceUnavailableException' in event &&
+    event.serviceUnavailableException
+  ) {
+    return {
+      error: new Error(
+        event.serviceUnavailableException.message ?? 'Bedrock unavailable'
+      ),
+      status: 503,
+    };
+  }
+  if ('internalServerException' in event && event.internalServerException) {
+    return {
+      error: new Error(
+        event.internalServerException.message ?? 'Bedrock internal error'
+      ),
+      status: 500,
+    };
+  }
+  if ('modelStreamErrorException' in event && event.modelStreamErrorException) {
+    return {
+      error: new Error(
+        event.modelStreamErrorException.message ?? 'Bedrock stream error'
+      ),
+      status: event.modelStreamErrorException.originalStatusCode,
+    };
+  }
+  if ('validationException' in event && event.validationException) {
+    return {
+      error: new Error(
+        event.validationException.message ?? 'Invalid Bedrock stream request'
+      ),
+      status: 400,
+    };
+  }
+  return undefined;
+}
 
 class AxAIBedrockImpl
   implements
     AxAIServiceImpl<
       AxAIBedrockModel,
       AxAIBedrockEmbedModel,
-      BedrockChatRequest,
+      ConverseRequest,
       BedrockTitanEmbedRequest,
-      BedrockChatResponse,
-      never, // No streaming for now
+      BedrockConverseResponse,
+      BedrockConverseStreamEvent,
       BedrockTitanEmbedResponse
     >
 {
-  private clients: Map<string, BedrockRuntimeClient> = new Map();
+  private clients = new Map<string, BedrockRuntimeClient>();
   private tokensUsed?: AxTokenUsage;
 
   constructor(
@@ -91,7 +358,9 @@ class AxAIBedrockImpl
       maxTokens: this.config.maxTokens,
       temperature: this.config.temperature,
       topP: this.config.topP,
+      topK: this.config.topK,
       stopSequences: this.config.stopSequences,
+      effort: this.config.effort,
     };
   }
 
@@ -104,357 +373,761 @@ class AxAIBedrockImpl
     return client;
   }
 
-  /**
-   * Detect model family from model ID
-   */
-  private getModelFamily(modelId: string): ModelFamily {
-    if (
-      modelId.includes('anthropic.claude') ||
-      modelId.includes('us.anthropic.claude')
-    ) {
-      return 'claude';
-    }
-    if (modelId.includes('openai.gpt')) {
-      return 'gpt';
-    }
-    if (modelId.includes('amazon.titan-embed')) {
-      return 'titan';
-    }
-    throw new Error(`Unknown model family for: ${modelId}`);
+  private getRegionsForModel(model: AxAIBedrockModel): string[] {
+    const capabilities = axGetBedrockModelCapabilities(model);
+    return capabilities.family === 'gpt'
+      ? [this.gptRegion, ...this.gptFallbackRegions]
+      : [this.primaryRegion, ...this.fallbackRegions];
   }
 
-  /**
-   * Get appropriate regions for model
-   */
-  private getRegionsForModel(modelId: string): string[] {
-    const family = this.getModelFamily(modelId);
-    if (family === 'gpt') {
-      return [this.gptRegion, ...this.gptFallbackRegions];
-    }
-    return [this.primaryRegion, ...this.fallbackRegions];
-  }
-
-  /**
-   * Regional failover logic - tries primary region, then fallbacks
-   */
   private async invokeWithFailover<T>(
-    modelId: string,
+    model: AxAIBedrockModel | AxAIBedrockEmbedModel,
+    regions: readonly string[],
     handler: (client: BedrockRuntimeClient) => Promise<T>
   ): Promise<T> {
-    const regions = this.getRegionsForModel(modelId);
     let lastError: Error | undefined;
-
     for (const region of regions) {
       try {
-        const client = this.getClient(region);
-        return await handler(client);
+        return await handler(this.getClient(region));
       } catch (error) {
         lastError = error as Error;
-        console.warn(
-          `[Bedrock] Region ${region} failed for ${modelId}:`,
-          error
-        );
+        console.warn(`[Bedrock] Region ${region} failed for ${model}:`, error);
       }
     }
-
-    throw lastError || new Error(`All Bedrock regions failed for ${modelId}`);
+    throw lastError ?? new Error(`All Bedrock regions failed for ${model}`);
   }
 
-  /**
-   * Transform AX chat request → Bedrock request (Claude or GPT)
-   */
+  private resolveCacheTtl(
+    model: AxAIBedrockModel,
+    options: Readonly<AxAIServiceOptions> | undefined,
+    hasExplicitBreakpoint: boolean
+  ): CacheTtl | undefined {
+    const capabilities = axGetBedrockModelCapabilities(model);
+    const cachingRequested =
+      hasExplicitBreakpoint || options?.contextCache !== undefined;
+    if (!cachingRequested) return undefined;
+    if (capabilities.cacheTtls.length === 0) {
+      throw new Error(`Prompt caching is not supported for ${model}`);
+    }
+
+    const ttlSeconds = options?.contextCache?.ttlSeconds ?? 300;
+    if (ttlSeconds <= 300) return '5m';
+    if (ttlSeconds <= 3600 && capabilities.cacheTtls.includes('1h')) {
+      return '1h';
+    }
+    throw new Error(
+      `Prompt-cache TTL ${ttlSeconds}s is not supported for ${model}`
+    );
+  }
+
+  private createMessages(
+    req: Readonly<AxBedrockChatRequest>,
+    capabilities: Readonly<AxAIBedrockModelCapabilities>,
+    ttl: CacheTtl | undefined,
+    autoCache: boolean,
+    maxMessageCachePoints: number
+  ): { messages: Message[]; system: SystemContentBlock[] } {
+    const messages: Message[] = [];
+    const system: SystemContentBlock[] = [];
+    let cachePoints = 0;
+
+    const addCachePoint = <T extends ContentBlock | SystemContentBlock>(
+      target: T[],
+      requested: boolean
+    ) => {
+      if (!requested) return;
+      if (!ttl) {
+        throw new Error(`Prompt caching is not supported for ${req.model}`);
+      }
+      if (cachePoints >= maxMessageCachePoints) {
+        throw new Error('Bedrock supports at most four cache checkpoints');
+      }
+      target.push(cachePoint(ttl) as T);
+      cachePoints++;
+    };
+
+    const pushMessage = (
+      role: 'user' | 'assistant',
+      content: ContentBlock[]
+    ) => {
+      const previous = messages.at(-1);
+      if (previous?.role === role) {
+        previous.content = [...(previous.content ?? []), ...content];
+      } else {
+        messages.push({ role, content });
+      }
+    };
+
+    const systemMessages = req.chatPrompt.filter(
+      (message) => message.role === 'system'
+    );
+    for (const [index, message] of systemMessages.entries()) {
+      system.push({ text: message.content });
+      addCachePoint(
+        system,
+        Boolean(message.cache) ||
+          (autoCache && index === systemMessages.length - 1)
+      );
+    }
+
+    for (const message of req.chatPrompt) {
+      if (message.role === 'system') continue;
+
+      if (message.role === 'user') {
+        const content: ContentBlock[] = [];
+        let hasDocument = false;
+        let hasText = false;
+        if (typeof message.content === 'string') {
+          content.push({ text: message.content });
+          hasText = true;
+        } else {
+          for (const item of message.content) {
+            switch (item.type) {
+              case 'text':
+                content.push({ text: item.text });
+                hasText = true;
+                addCachePoint(content, Boolean(item.cache));
+                break;
+              case 'image':
+                if (!capabilities.images) {
+                  throw new Error(
+                    `Image input is not supported for ${req.model}`
+                  );
+                }
+                content.push({ image: imageBlock(item) });
+                addCachePoint(content, Boolean(item.cache));
+                break;
+              case 'file':
+                if (!capabilities.files) {
+                  throw new Error(
+                    `Document input is not supported for ${req.model}`
+                  );
+                }
+                content.push({ document: documentBlock(item) });
+                hasDocument = true;
+                addCachePoint(content, Boolean(item.cache));
+                break;
+              case 'audio':
+                throw new Error(
+                  `Audio input is not supported for ${req.model}`
+                );
+              case 'url':
+                throw new Error(`URL input is not supported for ${req.model}`);
+            }
+          }
+        }
+        if (hasDocument && !hasText) {
+          content.unshift({
+            text: 'Use the attached document to answer the request.',
+          });
+        }
+        addCachePoint(content, Boolean(message.cache));
+        pushMessage('user', content);
+        continue;
+      }
+
+      if (message.role === 'assistant') {
+        const content: ContentBlock[] = [];
+        for (const block of message.thoughtBlocks ?? []) {
+          content.push({
+            reasoningContent: block.encrypted
+              ? { redactedContent: decodeBase64(block.data) }
+              : {
+                  reasoningText: {
+                    text: block.data,
+                    ...(block.signature ? { signature: block.signature } : {}),
+                  },
+                },
+          });
+        }
+        if (message.content) content.push({ text: message.content });
+        for (const call of message.functionCalls ?? []) {
+          content.push({
+            toolUse: {
+              toolUseId: call.id,
+              name: call.function.name,
+              input: toBedrockDocument(call.function.params),
+            },
+          });
+        }
+        addCachePoint(content, Boolean(message.cache));
+        pushMessage('assistant', content);
+        continue;
+      }
+
+      const toolContent: ToolResultContentBlock[] = [];
+      if (message.content?.length) {
+        for (const item of message.content) {
+          switch (item.type) {
+            case 'text':
+              toolContent.push({ text: item.text });
+              break;
+            case 'image':
+              toolContent.push({ image: imageBlock(item) });
+              break;
+            case 'file':
+              toolContent.push({ document: documentBlock(item) });
+              break;
+            case 'audio':
+              toolContent.push({
+                text:
+                  item.transcription ??
+                  `[Audio result: ${item.mimeType ?? 'application/octet-stream'}]`,
+              });
+              break;
+            case 'url':
+              toolContent.push({
+                text:
+                  item.cachedContent ??
+                  [item.title, item.description, item.url]
+                    .filter(Boolean)
+                    .join('\n'),
+              });
+              break;
+          }
+        }
+      } else {
+        try {
+          toolContent.push({ json: JSON.parse(message.result) });
+        } catch {
+          toolContent.push({ text: message.result });
+        }
+      }
+      const isClaude5 =
+        req.model.includes('claude-sonnet-5') ||
+        req.model.includes('claude-opus-5');
+      const content: ContentBlock[] = [
+        {
+          toolResult: {
+            toolUseId: message.functionId,
+            content: toolContent,
+            ...(!isClaude5
+              ? {
+                  status: message.isError
+                    ? ('error' as const)
+                    : ('success' as const),
+                }
+              : {}),
+          },
+        },
+      ];
+      addCachePoint(content, Boolean(message.cache));
+      pushMessage('user', content);
+    }
+
+    // A contextCache option must always produce at least one native checkpoint.
+    // System and tool schemas are preferred stable prefixes; without either,
+    // cache the final message prefix instead of silently disabling caching.
+    if (autoCache && ttl && cachePoints === 0 && maxMessageCachePoints === 4) {
+      const lastMessage = messages.at(-1);
+      if (lastMessage?.content) addCachePoint(lastMessage.content, true);
+    }
+
+    return { messages, system };
+  }
+
+  private createToolConfig(
+    req: Readonly<AxBedrockChatRequest>,
+    ttl: CacheTtl | undefined,
+    autoCache: boolean
+  ): ToolConfiguration | undefined {
+    if (!req.functions?.length || req.functionCall === 'none') return undefined;
+
+    const tools: NonNullable<ToolConfiguration['tools']> = req.functions.map(
+      (fn) => ({
+        toolSpec: {
+          name: fn.name,
+          description: fn.description,
+          inputSchema: {
+            json: fn.parameters ?? { type: 'object', properties: {} },
+          },
+        },
+      })
+    );
+    if (ttl && (autoCache || req.functions.some((fn) => Boolean(fn.cache)))) {
+      tools.push({ cachePoint: { type: 'default', ttl } });
+    }
+
+    const toolChoice: ToolConfiguration['toolChoice'] =
+      req.functionCall === 'required'
+        ? { any: {} }
+        : typeof req.functionCall === 'object'
+          ? { tool: { name: req.functionCall.function.name } }
+          : { auto: {} };
+    return { tools, toolChoice };
+  }
+
   createChatReq = async (
     req: Readonly<AxBedrockChatRequest>,
-    _config: Readonly<AxAIServiceOptions>
-  ): Promise<[AxAPI, BedrockChatRequest]> => {
-    const family = this.getModelFamily(req.model);
-    const maxTokens =
-      req.modelConfig?.maxTokens ?? this.config.maxTokens ?? 4096;
-    const temperature = req.modelConfig?.temperature ?? this.config.temperature;
-    const topP = req.modelConfig?.topP ?? this.config.topP;
+    options?: Readonly<AxAIServiceOptions>
+  ): Promise<[AxAPI, ConverseRequest]> => {
+    const capabilities = axGetBedrockModelCapabilities(req.model);
+    const hasExplicitBreakpoint =
+      req.chatPrompt.some((message) => Boolean(message.cache)) ||
+      Boolean(req.functions?.some((fn) => fn.cache));
+    const ttl = this.resolveCacheTtl(req.model, options, hasExplicitBreakpoint);
+    const autoCache = options?.contextCache !== undefined;
+    const toolCacheRequested = Boolean(
+      capabilities.functions &&
+        ttl &&
+        req.functions?.length &&
+        req.functionCall !== 'none' &&
+        (autoCache || req.functions.some((fn) => Boolean(fn.cache)))
+    );
+    const { messages, system } = this.createMessages(
+      req,
+      capabilities,
+      ttl,
+      autoCache,
+      toolCacheRequested ? 3 : 4
+    );
 
-    let bedrockRequest: BedrockChatRequest;
+    const modelConfig = { ...this.config, ...req.modelConfig };
+    const thinkingBudget = options?.thinkingTokenBudget;
+    let thinkingActive = false;
+    let additionalModelRequestFields: Record<string, unknown> | undefined;
+    let effort = modelConfig.effort;
 
-    if (family === 'claude') {
-      // Extract system messages for Claude
-      const systemMessages = req.chatPrompt
-        .filter((msg) => msg.role === 'system')
-        .map((msg) => msg.content)
-        .join('\n\n');
-
-      // Convert other messages to Claude format
-      const messages = req.chatPrompt
-        .filter((msg) => msg.role !== 'system')
-        .map((msg) => {
-          if (msg.role === 'user') {
-            return {
-              role: 'user' as const,
-              content:
-                typeof msg.content === 'string'
-                  ? msg.content
-                  : JSON.stringify(msg.content),
-            };
-          }
-          if (msg.role === 'assistant') {
-            return {
-              role: 'assistant' as const,
-              content: msg.content || '',
-            };
-          }
-          throw new Error(`Unsupported role: ${msg.role}`);
-        });
-
-      bedrockRequest = {
-        anthropic_version: 'bedrock-2023-05-31',
-        max_tokens: maxTokens,
-        messages,
-        ...(systemMessages ? { system: systemMessages } : {}),
-        ...(temperature !== undefined ? { temperature } : {}),
-        ...(topP !== undefined ? { top_p: topP } : {}),
-      } as BedrockClaudeRequest;
-    } else if (family === 'gpt') {
-      // GPT uses OpenAI-style format with system messages in array
-      const messages = req.chatPrompt
-        .filter((msg) => msg.role !== 'function') // Skip function messages
-        .map((msg) => {
-          // Get content based on role
-          let content: string;
-          if ('content' in msg) {
-            content =
-              typeof msg.content === 'string'
-                ? msg.content
-                : JSON.stringify(msg.content);
-          } else {
-            content = '';
-          }
-
-          return {
-            role: msg.role as 'system' | 'user' | 'assistant',
-            content,
-          };
-        });
-
-      bedrockRequest = {
-        messages,
-        max_tokens: maxTokens,
-        ...(temperature !== undefined ? { temperature } : {}),
-        ...(topP !== undefined ? { top_p: topP } : {}),
-      } as BedrockGptRequest;
-    } else {
-      throw new Error(`Chat not supported for model family: ${family}`);
-    }
-
-    // Create API config with local call (uses SDK instead of HTTP)
-    const apiConfig: AxAPI = {
-      name: `bedrock-${family}`,
-      localCall: async <TRequest, TResponse>(data: TRequest) => {
-        const reqBody = data as unknown as BedrockChatRequest;
-        const result = await this.invokeWithFailover(
-          req.model,
-          async (client) => {
-            const command = new InvokeModelCommand({
-              modelId: req.model,
-              body: JSON.stringify(reqBody),
-              contentType: 'application/json',
-              accept: 'application/json',
-            });
-            const response = await client.send(command);
-            return JSON.parse(new TextDecoder().decode(response.body));
-          }
-        );
-        return result as TResponse;
-      },
-    };
-
-    return [apiConfig, bedrockRequest];
-  };
-
-  /**
-   * Transform Bedrock response → AX chat response (Claude or GPT)
-   */
-  createChatResp(resp: Readonly<BedrockChatResponse>): AxChatResponse {
-    // Detect response type
-    if ('content' in resp && Array.isArray(resp.content)) {
-      // Claude response
-      return this.createClaudeChatResp(resp as BedrockClaudeResponse);
-    } else if ('choices' in resp && Array.isArray(resp.choices)) {
-      // GPT response
-      return this.createGptChatResp(resp as BedrockGptResponse);
-    }
-    throw new Error('Unknown response format');
-  }
-
-  /**
-   * Handle Claude-specific response format
-   */
-  private createClaudeChatResp(
-    resp: Readonly<BedrockClaudeResponse>
-  ): AxChatResponse {
-    // Extract text content from response
-    let content = '';
-    for (const block of resp.content) {
-      if (block.type === 'text') {
-        content += block.text;
+    if (capabilities.thinking === 'adaptive') {
+      if (thinkingBudget === 'none') {
+        if (capabilities.thinkingAlwaysOn) {
+          throw new Error(
+            `Adaptive thinking cannot be disabled for ${req.model}`
+          );
+        }
+        if (capabilities.thinkingDefault) {
+          additionalModelRequestFields = { thinking: { type: 'disabled' } };
+        }
+      } else if (
+        capabilities.thinkingDefault ||
+        thinkingBudget !== undefined ||
+        effort !== undefined
+      ) {
+        thinkingActive = true;
+        additionalModelRequestFields = { thinking: { type: 'adaptive' } };
+        if (thinkingBudget) effort = THINKING_EFFORT[thinkingBudget];
       }
-    }
-
-    // Track token usage for AX's optimizer
-    this.tokensUsed = {
-      promptTokens: resp.usage.input_tokens,
-      completionTokens: resp.usage.output_tokens,
-      totalTokens: resp.usage.input_tokens + resp.usage.output_tokens,
-    };
-
-    // Map finish reason
-    let finishReason: AxChatResponseResult['finishReason'];
-    switch (resp.stop_reason) {
-      case 'end_turn':
-      case 'stop_sequence':
-        finishReason = 'stop';
-        break;
-      case 'max_tokens':
-        finishReason = 'length';
-        break;
-      default:
-        finishReason = undefined;
-    }
-
-    return {
-      results: [
-        {
-          index: 0,
-          id: resp.id,
-          content,
-          finishReason,
+    } else if (
+      capabilities.thinking === 'budget' &&
+      thinkingBudget &&
+      thinkingBudget !== 'none'
+    ) {
+      thinkingActive = true;
+      additionalModelRequestFields = {
+        thinking: {
+          type: 'enabled',
+          budget_tokens: THINKING_BUDGETS[thinkingBudget],
         },
-      ],
-      remoteId: resp.id,
-    };
-  }
-
-  /**
-   * Handle GPT-specific response format
-   */
-  private createGptChatResp(
-    resp: Readonly<BedrockGptResponse>
-  ): AxChatResponse {
-    const choice = resp.choices[0];
-    if (!choice) {
-      throw new Error('No choices in GPT response');
-    }
-
-    // Extract content (can be string or array)
-    let content = '';
-    if (typeof choice.message.content === 'string') {
-      content = choice.message.content;
-    } else if (Array.isArray(choice.message.content)) {
-      content = choice.message.content
-        .map((part) => {
-          if (typeof part === 'string') return part;
-          return part.text || part.content || '';
-        })
-        .join('');
-    }
-
-    // Track token usage if available
-    if (resp.usage) {
-      this.tokensUsed = {
-        promptTokens: resp.usage.prompt_tokens,
-        completionTokens: resp.usage.completion_tokens,
-        totalTokens: resp.usage.total_tokens,
       };
     }
 
-    // Map finish reason
-    let finishReason: AxChatResponseResult['finishReason'];
-    switch (choice.finish_reason) {
-      case 'stop':
-        finishReason = 'stop';
-        break;
-      case 'length':
-        finishReason = 'length';
-        break;
-      case 'content_filter':
-        finishReason = 'content_filter';
-        break;
-      default:
-        finishReason = undefined;
+    if (modelConfig.topK !== undefined && !thinkingActive) {
+      additionalModelRequestFields = {
+        ...additionalModelRequestFields,
+        top_k: modelConfig.topK,
+      };
     }
 
-    return {
-      results: [
-        {
-          index: choice.index,
-          id: resp.id,
-          content,
-          finishReason,
+    const outputConfig: ConverseRequest['outputConfig'] = {};
+    if (effort && capabilities.thinking === 'adaptive') {
+      outputConfig.effort = effort;
+    }
+    if (
+      req.responseFormat?.type === 'json_schema' &&
+      req.responseFormat.schema &&
+      capabilities.structuredOutputModes.includes('native')
+    ) {
+      const schema =
+        req.responseFormat.schema.schema ?? req.responseFormat.schema;
+      outputConfig.textFormat = {
+        type: 'json_schema',
+        structure: {
+          jsonSchema: {
+            schema: JSON.stringify(schema),
+            name:
+              typeof schema.title === 'string' && schema.title.length > 0
+                ? schema.title
+                : 'ax_response',
+          },
         },
-      ],
-      remoteId: resp.id,
-    };
-  }
-
-  /**
-   * Create embed request for Titan
-   */
-  createEmbedReq = async (
-    req: Readonly<AxBedrockEmbedRequest>
-  ): Promise<[AxAPI, BedrockTitanEmbedRequest]> => {
-    if (!req.texts || req.texts.length === 0) {
-      throw new Error('No texts provided for embedding');
+      };
     }
 
-    const embedRequest: BedrockTitanEmbedRequest = {
-      inputText: req.texts[0], // Take first text
-      dimensions: this.config.dimensions,
-      normalize: true,
+    const toolConfig = capabilities.functions
+      ? this.createToolConfig(req, ttl, autoCache)
+      : undefined;
+    if (
+      options?.serviceTier &&
+      options.serviceTier !== 'auto' &&
+      !capabilities.serviceTiers.includes(options.serviceTier)
+    ) {
+      throw new Error(
+        `Service tier ${options.serviceTier} is not supported for ${req.model}`
+      );
+    }
+    const serviceTier = requestedServiceTier(options?.serviceTier);
+    const request: ConverseRequest = {
+      modelId: req.model,
+      messages,
+      ...(system.length ? { system } : {}),
+      inferenceConfig: {
+        maxTokens: modelConfig.maxTokens ?? 4096,
+        ...(!thinkingActive && modelConfig.temperature !== undefined
+          ? { temperature: modelConfig.temperature }
+          : {}),
+        ...(!thinkingActive && modelConfig.topP !== undefined
+          ? { topP: modelConfig.topP }
+          : {}),
+        ...(modelConfig.stopSequences?.length
+          ? { stopSequences: modelConfig.stopSequences }
+          : {}),
+      },
+      ...(toolConfig ? { toolConfig } : {}),
+      ...(additionalModelRequestFields
+        ? {
+            additionalModelRequestFields:
+              additionalModelRequestFields as NonNullable<
+                ConverseRequest['additionalModelRequestFields']
+              >,
+          }
+        : {}),
+      ...(Object.keys(outputConfig).length ? { outputConfig } : {}),
+      ...(serviceTier ? { serviceTier } : {}),
     };
 
+    const showThoughts = options?.showThoughts === true;
+    const abortSignal = options?.abortSignal;
     const apiConfig: AxAPI = {
-      name: 'bedrock-titan-embed',
-      localCall: async <TRequest, TResponse>(data: TRequest) => {
-        const reqBody = data as unknown as BedrockTitanEmbedRequest;
-        const result = await this.invokeWithFailover(
-          req.embedModel,
-          async (client) => {
-            const command = new InvokeModelCommand({
-              modelId: req.embedModel,
-              body: JSON.stringify(reqBody),
-              contentType: 'application/json',
-              accept: 'application/json',
-            });
-            const response = await client.send(command);
-            return JSON.parse(new TextDecoder().decode(response.body));
-          }
+      name: 'bedrock-converse',
+      localCall: async <TRequest, TResponse>(
+        data: TRequest,
+        stream?: boolean
+      ) => {
+        const requestData = data as ConverseRequest;
+        if (stream) {
+          return this.createConverseStream(
+            req.model,
+            requestData,
+            showThoughts,
+            abortSignal
+          ) as ReadableStream<TResponse>;
+        }
+        const response = await this.invokeWithFailover(
+          req.model,
+          this.getRegionsForModel(req.model),
+          async (client) =>
+            await client.send(new ConverseCommand(requestData), { abortSignal })
         );
-        return result as TResponse;
+        return {
+          response,
+          model: req.model,
+          showThoughts,
+        } as TResponse;
       },
     };
 
+    return [apiConfig, request];
+  };
+
+  private createConverseStream(
+    model: AxAIBedrockModel,
+    request: ConverseRequest,
+    showThoughts: boolean,
+    parentSignal?: AbortSignal
+  ): ReadableStream<BedrockConverseStreamEvent> {
+    const regions = this.getRegionsForModel(model);
+    let currentAbort: AbortController | undefined;
+    let cancelled = false;
+
+    return new ReadableStream<BedrockConverseStreamEvent>({
+      start: (controller) => {
+        const run = async () => {
+          let lastError: Error | undefined;
+          let emitted = false;
+          for (const region of regions) {
+            if (cancelled || parentSignal?.aborted) break;
+            currentAbort = new AbortController();
+            const onAbort = () => currentAbort?.abort(parentSignal?.reason);
+            parentSignal?.addEventListener('abort', onAbort, { once: true });
+            try {
+              const output = await this.getClient(region).send(
+                new ConverseStreamCommand(request),
+                { abortSignal: currentAbort.signal }
+              );
+              if (!output.stream) {
+                throw new Error('Bedrock returned no Converse stream');
+              }
+              for await (const event of output.stream) {
+                const failure = streamError(event);
+                if (
+                  failure &&
+                  !emitted &&
+                  failure.status &&
+                  failure.status >= 500
+                ) {
+                  throw failure.error;
+                }
+                controller.enqueue({
+                  event,
+                  model,
+                  requestId: output.$metadata.requestId,
+                  showThoughts,
+                });
+                emitted = true;
+              }
+              controller.close();
+              return;
+            } catch (error) {
+              lastError = error as Error;
+              if (emitted || cancelled || parentSignal?.aborted) {
+                controller.error(error);
+                return;
+              }
+              console.warn(
+                `[Bedrock] Region ${region} failed for ${model}:`,
+                error
+              );
+            } finally {
+              parentSignal?.removeEventListener('abort', onAbort);
+            }
+          }
+          controller.error(
+            lastError ?? new DOMException('Aborted', 'AbortError')
+          );
+        };
+        void run();
+      },
+      cancel: (reason) => {
+        cancelled = true;
+        currentAbort?.abort(reason);
+      },
+    });
+  }
+
+  createChatResp(resp: Readonly<BedrockConverseResponse>): AxChatResponse {
+    const message =
+      resp.response.output && 'message' in resp.response.output
+        ? resp.response.output.message
+        : undefined;
+    const result: AxChatResponseResult = {
+      index: 0,
+      id: resp.response.$metadata.requestId,
+      finishReason: mapStopReason(resp.response.stopReason),
+    };
+    let content = '';
+    const functionCalls: NonNullable<AxChatResponseResult['functionCalls']> =
+      [];
+    const thoughtBlocks: NonNullable<AxChatResponseResult['thoughtBlocks']> =
+      [];
+
+    for (const block of message?.content ?? []) {
+      if ('text' in block && typeof block.text === 'string') {
+        content += block.text;
+      } else if ('toolUse' in block && block.toolUse) {
+        functionCalls.push({
+          id: block.toolUse.toolUseId ?? '',
+          type: 'function',
+          function: {
+            name: block.toolUse.name ?? '',
+            params:
+              block.toolUse.input === undefined || block.toolUse.input === null
+                ? undefined
+                : fromBedrockDocument(block.toolUse.input),
+          },
+        });
+      } else if ('reasoningContent' in block && block.reasoningContent) {
+        const reasoning = block.reasoningContent;
+        if ('reasoningText' in reasoning && reasoning.reasoningText) {
+          thoughtBlocks.push({
+            data: reasoning.reasoningText.text ?? '',
+            encrypted: false,
+            ...(reasoning.reasoningText.signature
+              ? { signature: reasoning.reasoningText.signature }
+              : {}),
+          });
+        } else if (
+          'redactedContent' in reasoning &&
+          reasoning.redactedContent
+        ) {
+          thoughtBlocks.push({
+            data: encodeBase64(reasoning.redactedContent),
+            encrypted: true,
+          });
+        }
+      }
+    }
+
+    if (content) result.content = content;
+    if (functionCalls.length) result.functionCalls = functionCalls;
+    if (thoughtBlocks.length) {
+      result.thoughtBlocks = thoughtBlocks;
+      if (resp.showThoughts) {
+        result.thought = thoughtBlocks
+          .filter((block) => !block.encrypted)
+          .map((block) => block.data)
+          .join('');
+      }
+    }
+
+    this.tokensUsed = mapTokenUsage(
+      resp.response.usage,
+      resp.response.serviceTier?.type
+    );
+    return {
+      results: [result],
+      remoteId: resp.response.$metadata.requestId,
+      remoteRequestId: resp.response.$metadata.requestId,
+    };
+  }
+
+  classifyStreamErrorStatus = (
+    resp: Readonly<BedrockConverseStreamEvent>
+  ): number | undefined => streamError(resp.event)?.status;
+
+  createChatStreamResp = (
+    resp: Readonly<BedrockConverseStreamEvent>,
+    state: object
+  ): AxChatResponse => {
+    const failure = streamError(resp.event);
+    if (failure) throw failure.error;
+
+    const streamState = state as { toolIds?: Record<number, string> };
+    streamState.toolIds ??= {};
+    const result: AxChatResponseResult = { index: 0 };
+    const event = resp.event;
+
+    if ('messageStart' in event && event.messageStart) {
+      result.id = resp.requestId;
+      result.content = '';
+    } else if ('contentBlockStart' in event && event.contentBlockStart) {
+      const blockIndex = event.contentBlockStart.contentBlockIndex ?? 0;
+      const start = event.contentBlockStart.start;
+      if (start && 'toolUse' in start && start.toolUse) {
+        const id = start.toolUse.toolUseId ?? '';
+        streamState.toolIds[blockIndex] = id;
+        result.functionCalls = [
+          {
+            id,
+            type: 'function',
+            function: { name: start.toolUse.name ?? '', params: '' },
+          },
+        ];
+      } else {
+        result.content = '';
+      }
+    } else if ('contentBlockDelta' in event && event.contentBlockDelta) {
+      const blockIndex = event.contentBlockDelta.contentBlockIndex ?? 0;
+      const delta = event.contentBlockDelta.delta;
+      if (delta && 'text' in delta && typeof delta.text === 'string') {
+        result.content = delta.text;
+      } else if (delta && 'toolUse' in delta && delta.toolUse) {
+        result.functionCalls = [
+          {
+            id: streamState.toolIds[blockIndex] ?? '',
+            type: 'function',
+            function: { name: '', params: delta.toolUse.input ?? '' },
+          },
+        ];
+      } else if (
+        delta &&
+        'reasoningContent' in delta &&
+        delta.reasoningContent
+      ) {
+        const reasoning = delta.reasoningContent;
+        if ('text' in reasoning && typeof reasoning.text === 'string') {
+          result.thoughtBlocks = [{ data: reasoning.text, encrypted: false }];
+          if (resp.showThoughts) result.thought = reasoning.text;
+        } else if (
+          'signature' in reasoning &&
+          typeof reasoning.signature === 'string'
+        ) {
+          result.thoughtBlocks = [
+            { data: '', encrypted: false, signature: reasoning.signature },
+          ];
+        } else if (
+          'redactedContent' in reasoning &&
+          reasoning.redactedContent
+        ) {
+          result.thoughtBlocks = [
+            {
+              data: encodeBase64(reasoning.redactedContent),
+              encrypted: true,
+            },
+          ];
+        }
+      } else {
+        result.content = '';
+      }
+    } else if ('messageStop' in event && event.messageStop) {
+      result.content = '';
+      result.finishReason = mapStopReason(event.messageStop.stopReason);
+    } else if ('metadata' in event && event.metadata) {
+      this.tokensUsed = mapTokenUsage(
+        event.metadata.usage,
+        event.metadata.serviceTier?.type
+      );
+      result.content = '';
+    } else {
+      result.content = '';
+    }
+
+    return {
+      results: [result],
+      remoteId: resp.requestId,
+      remoteRequestId: resp.requestId,
+    };
+  };
+
+  supportsImplicitCaching = (model: AxAIBedrockModel): boolean =>
+    axGetBedrockModelCapabilities(model).cacheTtls.length > 0;
+
+  createEmbedReq = async (
+    req: Readonly<AxBedrockEmbedRequest>
+  ): Promise<[AxAPI, BedrockTitanEmbedRequest]> => {
+    if (!req.texts?.length) throw new Error('No texts provided for embedding');
+
+    const embedRequest: BedrockTitanEmbedRequest = {
+      inputText: req.texts[0],
+      dimensions: this.config.dimensions,
+      normalize: true,
+    };
+    const apiConfig: AxAPI = {
+      name: 'bedrock-titan-embed',
+      localCall: async <TRequest, TResponse>(data: TRequest) => {
+        const request = data as BedrockTitanEmbedRequest;
+        const regions = [this.primaryRegion, ...this.fallbackRegions];
+        return (await this.invokeWithFailover(
+          req.embedModel,
+          regions,
+          async (client) => {
+            const response = await client.send(
+              new InvokeModelCommand({
+                modelId: req.embedModel,
+                body: JSON.stringify(request),
+                contentType: 'application/json',
+                accept: 'application/json',
+              })
+            );
+            return JSON.parse(new TextDecoder().decode(response.body));
+          }
+        )) as TResponse;
+      },
+    };
     return [apiConfig, embedRequest];
   };
 
-  /**
-   * Create embed response from Titan
-   */
   createEmbedResp(resp: Readonly<BedrockTitanEmbedResponse>): AxEmbedResponse {
-    return {
-      embeddings: [resp.embedding],
-    };
+    return { embeddings: [resp.embedding] };
   }
 }
-
-// ============================================================================
-// PROVIDER CLASS - Main entry point
-// ============================================================================
 
 export class AxAIBedrock extends AxBaseAI<
   AxAIBedrockModel,
   AxAIBedrockEmbedModel,
-  BedrockChatRequest,
+  ConverseRequest,
   BedrockTitanEmbedRequest,
-  BedrockChatResponse,
-  never, // No streaming yet
+  BedrockConverseResponse,
+  BedrockConverseStreamEvent,
   BedrockTitanEmbedResponse,
   string
 > {
@@ -473,10 +1146,9 @@ export class AxAIBedrock extends AxBaseAI<
     config: Readonly<Partial<AxAIBedrockConfig>>;
     options?: Readonly<AxAIServiceOptions>;
   }>) {
-    // Merge user config with defaults
     const fullConfig: AxAIBedrockConfig = {
       ...axBaseAIDefaultConfig(),
-      model: AxAIBedrockModel.ClaudeOpus45,
+      model: AxAIBedrockModel.ClaudeSonnet5,
       region,
       fallbackRegions,
       gptRegion,
@@ -484,7 +1156,6 @@ export class AxAIBedrock extends AxBaseAI<
       ...config,
     };
 
-    // Create implementation
     const aiImpl = new AxAIBedrockImpl(
       fullConfig,
       region,
@@ -493,46 +1164,52 @@ export class AxAIBedrock extends AxBaseAI<
       gptFallbackRegions
     );
 
-    // Define feature support
-    const supportFor = (): AxAIFeatures => ({
-      functions: false, // Not implemented yet - add when needed
-      streaming: false, // Not implemented yet - add when needed
-      functionCot: false,
-      hasThinkingBudget: false,
-      hasShowThoughts: false,
-      media: {
-        images: {
-          supported: false, // Add when needed
-          formats: [],
+    const supportFor = (model: AxAIBedrockModel): AxAIFeatures => {
+      const capabilities = axGetBedrockModelCapabilities(model);
+      return {
+        functions: capabilities.functions,
+        streaming: capabilities.streaming,
+        functionCot: capabilities.functionCot,
+        hasThinkingBudget: capabilities.thinking === 'budget',
+        hasShowThoughts: capabilities.showThoughts,
+        structuredOutputs:
+          capabilities.structuredOutputModes.includes('native'),
+        structuredOutputModes: capabilities.structuredOutputModes,
+        media: {
+          images: {
+            supported: capabilities.images,
+            formats: capabilities.images ? Object.keys(IMAGE_FORMATS) : [],
+            maxSize: capabilities.images ? 3.75 * 1024 * 1024 : 0,
+            detailLevels: capabilities.images ? ['high', 'low', 'auto'] : [],
+          },
+          audio: { supported: false, formats: [] },
+          files: {
+            supported: capabilities.files,
+            formats: capabilities.files ? Object.keys(DOCUMENT_FORMATS) : [],
+            maxSize: capabilities.files ? 4.5 * 1024 * 1024 : 0,
+            uploadMethod: capabilities.files ? 'inline' : 'none',
+          },
+          urls: {
+            supported: false,
+            webSearch: false,
+            contextFetching: false,
+          },
         },
-        audio: {
-          supported: false,
-          formats: [],
+        caching: {
+          supported: capabilities.cacheTtls.length > 0,
+          types: capabilities.cacheTtls.length ? ['ephemeral'] : [],
+          cacheBreakpoints: true,
         },
-        files: {
-          supported: false,
-          formats: [],
-          uploadMethod: 'none',
-        },
-        urls: {
-          supported: false,
-          webSearch: false,
-          contextFetching: false,
-        },
-      },
-      caching: {
-        supported: false,
-        types: [],
-      },
-      thinking: false,
-      multiTurn: true, // All models support multi-turn conversations
-    });
+        thinking: capabilities.thinking !== 'none',
+        multiTurn: true,
+        serviceTiers: capabilities.serviceTiers,
+      };
+    };
 
-    // Initialize base class
     super(aiImpl, {
       name: 'Bedrock',
-      apiURL: '', // Not used - we use SDK directly
-      headers: async () => ({}), // AWS SDK handles auth
+      apiURL: '',
+      headers: async () => ({}),
       modelInfo: axModelInfoBedrock,
       defaults: {
         model: fullConfig.model,
@@ -545,5 +1222,4 @@ export class AxAIBedrock extends AxBaseAI<
 }
 
 export type { AxAIBedrockConfig } from './types.js';
-// Re-export types for convenience
 export { AxAIBedrockEmbedModel, AxAIBedrockModel } from './types.js';

--- a/src/aws-bedrock/index.ts
+++ b/src/aws-bedrock/index.ts
@@ -9,7 +9,7 @@
  *
  * const ai = new AxAIBedrock({
  *   region: 'us-east-2',
- *   config: { model: AxAIBedrockModel.ClaudeOpus45 }
+ *   config: { model: AxAIBedrockModel.ClaudeSonnet5 }
  * });
  *
  * const response = await ai.chat({

--- a/src/aws-bedrock/info.ts
+++ b/src/aws-bedrock/info.ts
@@ -22,7 +22,7 @@ export type AxAIBedrockModelCapabilities = {
   functionCot: boolean;
   images: boolean;
   files: boolean;
-  cacheTtls: readonly ('5m' | '1h')[];
+  cacheTTLs: readonly ('5m' | '1h')[];
   thinking: AxAIBedrockThinkingMode;
   thinkingDefault: boolean;
   thinkingAlwaysOn: boolean;
@@ -40,7 +40,7 @@ const claude = (
   functionCot: true,
   images: true,
   files: true,
-  cacheTtls: ['5m'],
+  cacheTTLs: ['5m'],
   thinking: 'budget',
   thinkingDefault: false,
   thinkingAlwaysOn: false,
@@ -57,7 +57,7 @@ const gpt = (): AxAIBedrockModelCapabilities => ({
   functionCot: false,
   images: false,
   files: false,
-  cacheTtls: [],
+  cacheTTLs: [],
   thinking: 'none',
   thinkingDefault: false,
   thinkingAlwaysOn: false,
@@ -71,38 +71,38 @@ export const axBedrockModelCapabilities: Readonly<
   Record<AxAIBedrockModel, AxAIBedrockModelCapabilities>
 > = {
   [AxAIBedrockModel.ClaudeSonnet5]: claude({
-    cacheTtls: ['5m', '1h'],
+    cacheTTLs: ['5m', '1h'],
     thinking: 'adaptive',
     thinkingDefault: true,
     thinkingAlwaysOn: true,
   }),
   [AxAIBedrockModel.ClaudeOpus5]: claude({
-    cacheTtls: ['5m', '1h'],
+    cacheTTLs: ['5m', '1h'],
     thinking: 'adaptive',
     thinkingDefault: true,
   }),
   [AxAIBedrockModel.ClaudeOpus48]: claude({
-    cacheTtls: ['5m', '1h'],
+    cacheTTLs: ['5m', '1h'],
     thinking: 'adaptive',
   }),
   [AxAIBedrockModel.ClaudeSonnet46]: claude({
-    cacheTtls: ['5m', '1h'],
+    cacheTTLs: ['5m', '1h'],
     thinking: 'adaptive',
     structuredOutputModes: ['native', 'function'],
   }),
   [AxAIBedrockModel.ClaudeHaiku45]: claude({
-    cacheTtls: ['5m', '1h'],
+    cacheTTLs: ['5m', '1h'],
     structuredOutputModes: ['native', 'function'],
   }),
   [AxAIBedrockModel.ClaudeOpus45]: claude({
-    cacheTtls: ['5m', '1h'],
+    cacheTTLs: ['5m', '1h'],
     structuredOutputModes: ['native', 'function'],
   }),
   [AxAIBedrockModel.ClaudeSonnet4]: claude(),
   [AxAIBedrockModel.Claude37Sonnet]: claude({ functionCot: false }),
   [AxAIBedrockModel.Claude35Sonnet]: claude({
     functionCot: false,
-    cacheTtls: [],
+    cacheTTLs: [],
     thinking: 'none',
     showThoughts: false,
   }),

--- a/src/aws-bedrock/info.ts
+++ b/src/aws-bedrock/info.ts
@@ -2,13 +2,198 @@
  * Bedrock model information (pricing, limits, features)
  */
 
-import type { AxModelInfo } from '@ax-llm/ax';
+import type {
+  AxModelInfo,
+  AxServiceTier,
+  AxStructuredOutputRung,
+} from '@ax-llm/ax';
 import { AxAIBedrockEmbedModel, AxAIBedrockModel } from './types.js';
+
+export type AxAIBedrockThinkingMode =
+  | 'none'
+  | 'budget'
+  | 'adaptive'
+  | 'provider';
+
+export type AxAIBedrockModelCapabilities = {
+  family: 'claude' | 'gpt';
+  functions: boolean;
+  streaming: boolean;
+  functionCot: boolean;
+  images: boolean;
+  files: boolean;
+  cacheTtls: readonly ('5m' | '1h')[];
+  thinking: AxAIBedrockThinkingMode;
+  thinkingDefault: boolean;
+  thinkingAlwaysOn: boolean;
+  showThoughts: boolean;
+  structuredOutputModes: readonly AxStructuredOutputRung[];
+  serviceTiers: readonly AxServiceTier[];
+};
+
+const claude = (
+  overrides: Partial<AxAIBedrockModelCapabilities> = {}
+): AxAIBedrockModelCapabilities => ({
+  family: 'claude',
+  functions: true,
+  streaming: true,
+  functionCot: true,
+  images: true,
+  files: true,
+  cacheTtls: ['5m'],
+  thinking: 'budget',
+  thinkingDefault: false,
+  thinkingAlwaysOn: false,
+  showThoughts: true,
+  structuredOutputModes: ['function'],
+  serviceTiers: ['standard'],
+  ...overrides,
+});
+
+const gpt = (): AxAIBedrockModelCapabilities => ({
+  family: 'gpt',
+  functions: false,
+  streaming: true,
+  functionCot: false,
+  images: false,
+  files: false,
+  cacheTtls: [],
+  thinking: 'none',
+  thinkingDefault: false,
+  thinkingAlwaysOn: false,
+  showThoughts: false,
+  structuredOutputModes: ['native'],
+  serviceTiers: ['standard', 'flex', 'priority'],
+});
+
+/** Exact native-runtime capabilities verified per Bedrock model. */
+export const axBedrockModelCapabilities: Readonly<
+  Record<AxAIBedrockModel, AxAIBedrockModelCapabilities>
+> = {
+  [AxAIBedrockModel.ClaudeSonnet5]: claude({
+    cacheTtls: ['5m', '1h'],
+    thinking: 'adaptive',
+    thinkingDefault: true,
+    thinkingAlwaysOn: true,
+  }),
+  [AxAIBedrockModel.ClaudeOpus5]: claude({
+    cacheTtls: ['5m', '1h'],
+    thinking: 'adaptive',
+    thinkingDefault: true,
+  }),
+  [AxAIBedrockModel.ClaudeOpus48]: claude({
+    cacheTtls: ['5m', '1h'],
+    thinking: 'adaptive',
+  }),
+  [AxAIBedrockModel.ClaudeSonnet46]: claude({
+    cacheTtls: ['5m', '1h'],
+    thinking: 'adaptive',
+    structuredOutputModes: ['native', 'function'],
+  }),
+  [AxAIBedrockModel.ClaudeHaiku45]: claude({
+    cacheTtls: ['5m', '1h'],
+    structuredOutputModes: ['native', 'function'],
+  }),
+  [AxAIBedrockModel.ClaudeOpus45]: claude({
+    cacheTtls: ['5m', '1h'],
+    structuredOutputModes: ['native', 'function'],
+  }),
+  [AxAIBedrockModel.ClaudeSonnet4]: claude(),
+  [AxAIBedrockModel.Claude37Sonnet]: claude({ functionCot: false }),
+  [AxAIBedrockModel.Claude35Sonnet]: claude({
+    functionCot: false,
+    cacheTtls: [],
+    thinking: 'none',
+    showThoughts: false,
+  }),
+  [AxAIBedrockModel.GptOss120B]: gpt(),
+  [AxAIBedrockModel.GptOss20B]: gpt(),
+};
+
+export function axGetBedrockModelCapabilities(
+  model: AxAIBedrockModel
+): AxAIBedrockModelCapabilities {
+  const capabilities = axBedrockModelCapabilities[model];
+  if (!capabilities) {
+    throw new Error(`Unsupported Bedrock model: ${model}`);
+  }
+  return capabilities;
+}
 
 export const axModelInfoBedrock: AxModelInfo[] = [
   // ========================================================================
   // Claude Models
   // ========================================================================
+  {
+    name: AxAIBedrockModel.ClaudeSonnet5,
+    currency: 'usd',
+    promptTokenCostPer1M: 2.0,
+    completionTokenCostPer1M: 10.0,
+    maxTokens: 128000,
+    contextWindow: 1000000,
+    supported: {
+      showThoughts: true,
+      structuredOutputModes: ['function'],
+      serviceTiers: ['standard'],
+    },
+  },
+  {
+    name: AxAIBedrockModel.ClaudeOpus5,
+    currency: 'usd',
+    promptTokenCostPer1M: 5.0,
+    completionTokenCostPer1M: 25.0,
+    maxTokens: 128000,
+    contextWindow: 1000000,
+    isExpensive: true,
+    supported: {
+      showThoughts: true,
+      structuredOutputModes: ['function'],
+      serviceTiers: ['standard'],
+    },
+  },
+  {
+    name: AxAIBedrockModel.ClaudeOpus48,
+    currency: 'usd',
+    promptTokenCostPer1M: 5.0,
+    completionTokenCostPer1M: 25.0,
+    maxTokens: 128000,
+    contextWindow: 1000000,
+    isExpensive: true,
+    supported: {
+      showThoughts: true,
+      structuredOutputModes: ['function'],
+      serviceTiers: ['standard'],
+    },
+  },
+  {
+    name: AxAIBedrockModel.ClaudeSonnet46,
+    currency: 'usd',
+    promptTokenCostPer1M: 3.0,
+    completionTokenCostPer1M: 15.0,
+    maxTokens: 64000,
+    contextWindow: 1000000,
+    supported: {
+      showThoughts: true,
+      structuredOutputs: true,
+      structuredOutputModes: ['native', 'function'],
+      serviceTiers: ['standard'],
+    },
+  },
+  {
+    name: AxAIBedrockModel.ClaudeHaiku45,
+    currency: 'usd',
+    promptTokenCostPer1M: 1.0,
+    completionTokenCostPer1M: 5.0,
+    maxTokens: 64000,
+    contextWindow: 200000,
+    supported: {
+      thinkingBudget: true,
+      showThoughts: true,
+      structuredOutputs: true,
+      structuredOutputModes: ['native', 'function'],
+      serviceTiers: ['standard'],
+    },
+  },
   {
     name: AxAIBedrockModel.ClaudeOpus45,
     currency: 'usd',
@@ -16,7 +201,13 @@ export const axModelInfoBedrock: AxModelInfo[] = [
     completionTokenCostPer1M: 25.0,
     maxTokens: 64000,
     contextWindow: 200000,
-    supported: { thinkingBudget: true, showThoughts: true },
+    supported: {
+      thinkingBudget: true,
+      showThoughts: true,
+      structuredOutputs: true,
+      structuredOutputModes: ['native', 'function'],
+      serviceTiers: ['standard'],
+    },
   },
   {
     name: AxAIBedrockModel.ClaudeSonnet4,
@@ -25,7 +216,12 @@ export const axModelInfoBedrock: AxModelInfo[] = [
     completionTokenCostPer1M: 15.0,
     maxTokens: 64000,
     contextWindow: 200000,
-    supported: { thinkingBudget: true, showThoughts: true },
+    supported: {
+      thinkingBudget: true,
+      showThoughts: true,
+      structuredOutputModes: ['function'],
+      serviceTiers: ['standard'],
+    },
   },
   {
     name: AxAIBedrockModel.Claude37Sonnet,
@@ -34,6 +230,12 @@ export const axModelInfoBedrock: AxModelInfo[] = [
     completionTokenCostPer1M: 15.0,
     maxTokens: 64000,
     contextWindow: 200000,
+    supported: {
+      thinkingBudget: true,
+      showThoughts: true,
+      structuredOutputModes: ['function'],
+      serviceTiers: ['standard'],
+    },
   },
   {
     name: AxAIBedrockModel.Claude35Sonnet,
@@ -42,6 +244,12 @@ export const axModelInfoBedrock: AxModelInfo[] = [
     completionTokenCostPer1M: 15.0,
     maxTokens: 8192,
     contextWindow: 200000,
+    isDeprecated: true,
+    deprecatedOn: '2026-07-30',
+    supported: {
+      structuredOutputModes: ['function'],
+      serviceTiers: ['standard'],
+    },
   },
 
   // ========================================================================
@@ -54,6 +262,11 @@ export const axModelInfoBedrock: AxModelInfo[] = [
     completionTokenCostPer1M: 1.5,
     maxTokens: 16384,
     contextWindow: 128000,
+    supported: {
+      structuredOutputs: true,
+      structuredOutputModes: ['native'],
+      serviceTiers: ['standard', 'flex', 'priority'],
+    },
   },
   {
     name: AxAIBedrockModel.GptOss20B,
@@ -62,6 +275,11 @@ export const axModelInfoBedrock: AxModelInfo[] = [
     completionTokenCostPer1M: 0.75,
     maxTokens: 16384,
     contextWindow: 128000,
+    supported: {
+      structuredOutputs: true,
+      structuredOutputModes: ['native'],
+      serviceTiers: ['standard', 'flex', 'priority'],
+    },
   },
 
   // ========================================================================

--- a/src/aws-bedrock/package.json
+++ b/src/aws-bedrock/package.json
@@ -11,6 +11,9 @@
     "access": "public"
   },
   "license": "Apache-2.0",
+  "engines": {
+    "node": ">=20"
+  },
   "keywords": [
     "ax",
     "aws",
@@ -38,11 +41,8 @@
     "postbuild": "node ../../scripts/postbuild.js"
   },
   "dependencies": {
-    "@aws-sdk/client-bedrock-runtime": "^3.709.0",
+    "@aws-sdk/client-bedrock-runtime": "^3.1122.0",
     "@ax-llm/ax": "24.0.16"
-  },
-  "peerDependencies": {
-    "@ax-llm/ax": "14.0.31"
   },
   "bugs": {
     "url": "https://github.com/@ax-llm/ax/issues"

--- a/src/aws-bedrock/types.ts
+++ b/src/aws-bedrock/types.ts
@@ -8,6 +8,11 @@ import type { AxModelConfig } from '@ax-llm/ax';
 // All Bedrock models
 export enum AxAIBedrockModel {
   // Claude models
+  ClaudeSonnet5 = 'us.anthropic.claude-sonnet-5',
+  ClaudeOpus5 = 'us.anthropic.claude-opus-5',
+  ClaudeOpus48 = 'us.anthropic.claude-opus-4-8',
+  ClaudeSonnet46 = 'us.anthropic.claude-sonnet-4-6',
+  ClaudeHaiku45 = 'us.anthropic.claude-haiku-4-5-20251001-v1:0',
   ClaudeOpus45 = 'us.anthropic.claude-opus-4-5-20251101-v1:0',
   ClaudeSonnet4 = 'us.anthropic.claude-sonnet-4-20250514-v1:0',
   Claude37Sonnet = 'anthropic.claude-3-7-sonnet-20250219-v1:0',
@@ -37,6 +42,7 @@ export interface AxAIBedrockConfig extends AxModelConfig {
 // Claude Request/Response Types
 // ============================================================================
 
+/** @deprecated Internal chat transport now uses the AWS Converse API. */
 export interface BedrockClaudeRequest {
   anthropic_version: string;
   max_tokens: number;
@@ -49,6 +55,7 @@ export interface BedrockClaudeRequest {
   top_p?: number;
 }
 
+/** @deprecated Internal chat transport now uses the AWS Converse API. */
 export interface BedrockClaudeResponse {
   id: string;
   type: 'message';
@@ -66,6 +73,7 @@ export interface BedrockClaudeResponse {
 // GPT OSS Request/Response Types (OpenAI-compatible format)
 // ============================================================================
 
+/** @deprecated Internal chat transport now uses the AWS Converse API. */
 export interface BedrockGptRequest {
   messages: Array<{
     role: 'system' | 'user' | 'assistant';
@@ -76,6 +84,7 @@ export interface BedrockGptRequest {
   top_p?: number;
 }
 
+/** @deprecated Internal chat transport now uses the AWS Converse API. */
 export interface BedrockGptResponse {
   id?: string;
   choices: Array<{
@@ -111,5 +120,7 @@ export interface BedrockTitanEmbedResponse {
 }
 
 // Union types for all models
+/** @deprecated Internal chat transport now uses the AWS Converse API. */
 export type BedrockChatRequest = BedrockClaudeRequest | BedrockGptRequest;
+/** @deprecated Internal chat transport now uses the AWS Converse API. */
 export type BedrockChatResponse = BedrockClaudeResponse | BedrockGptResponse;

--- a/src/ax/ai/processor.test.ts
+++ b/src/ax/ai/processor.test.ts
@@ -1,11 +1,11 @@
-import { describe, it, expect, vi } from 'vitest';
-import {
-  axProcessContentForProvider,
-  axAnalyzeChatPromptRequirements,
-} from './processor.js';
-import { axSelectOptimalProvider } from './capabilities.js';
+import { describe, expect, it, vi } from 'vitest';
 import { AxMediaNotSupportedError } from '../util/apicall.js';
-import type { AxAIService, AxAIFeatures } from './types.js';
+import { axSelectOptimalProvider } from './capabilities.js';
+import {
+  axAnalyzeChatPromptRequirements,
+  axProcessContentForProvider,
+} from './processor.js';
+import type { AxAIFeatures, AxAIService } from './types.js';
 
 // Mock provider factory
 function createMockProvider(name: string, features: AxAIFeatures): AxAIService {
@@ -61,6 +61,19 @@ const mockTextOnlyProvider = createMockProvider('TextOnly', {
   caching: { supported: false, types: [] },
   thinking: false,
   multiTurn: true,
+});
+
+const mockFileSupportedProvider = createMockProvider('FileProvider', {
+  ...mockTextOnlyProvider.getFeatures(),
+  media: {
+    ...mockTextOnlyProvider.getFeatures().media,
+    files: {
+      supported: true,
+      formats: ['application/pdf'],
+      maxSize: 5 * 1024 * 1024,
+      uploadMethod: 'inline',
+    },
+  },
 });
 
 describe('axProcessContentForProvider', () => {
@@ -199,6 +212,24 @@ describe('axProcessContentForProvider', () => {
     );
 
     expect(result).toEqual([{ type: 'text', text: 'Document content' }]);
+  });
+
+  it('preserves native file content for a file-capable provider', async () => {
+    const file = {
+      type: 'file' as const,
+      data: 'base64data',
+      filename: 'document.pdf',
+      mimeType: 'application/pdf',
+      extractedText: 'Fallback text',
+      cache: true,
+    };
+
+    const result = await axProcessContentForProvider(
+      [file],
+      mockFileSupportedProvider
+    );
+
+    expect(result).toEqual([file]);
   });
 
   it('should handle URLs with cached content', async () => {

--- a/src/ax/ai/processor.ts
+++ b/src/ax/ai/processor.ts
@@ -10,6 +10,7 @@ type AxUserMessage = Extract<
 >;
 type AxUserContentItem = Exclude<AxUserMessage['content'], string>[number];
 type AxUserImageContent = Extract<AxUserContentItem, { type: 'image' }>;
+type AxUserFileContent = Extract<AxUserContentItem, { type: 'file' }>;
 
 /**
  * Configuration options for content processing and fallback behavior
@@ -28,12 +29,13 @@ export interface ProcessingOptions {
 }
 
 /**
- * Represents content after provider-specific processing. Native image content
- * is retained when the provider advertises image support.
+ * Represents content after provider-specific processing. Native image and file
+ * content is retained when the provider advertises support.
  */
 export type ProcessedContent =
   | { type: 'text'; text: string }
-  | AxUserImageContent;
+  | AxUserImageContent
+  | AxUserFileContent;
 
 /**
  * Indicates what types of media content are present in a request
@@ -198,18 +200,8 @@ export async function axProcessContentForProvider(
 
         case 'file':
           if (features.media.files.supported) {
-            // Provider supports files - use extracted text if available
-            if (item.extractedText) {
-              processedContent.push({
-                type: 'text',
-                text: item.extractedText,
-              });
-            } else {
-              processedContent.push({
-                type: 'text',
-                text: `[File: ${item.filename}]`,
-              });
-            }
+            // Preserve native file content for providers that support it.
+            processedContent.push(item as AxUserFileContent);
           } else if (item.extractedText) {
             processedContent.push({ type: 'text', text: item.extractedText });
           } else if (options.fileToText) {

--- a/src/ax/ai/router.test.ts
+++ b/src/ax/ai/router.test.ts
@@ -286,6 +286,36 @@ describe('AxProviderRouter', () => {
       });
     });
 
+    it('preserves native files for a file-capable provider', async () => {
+      const request: AxChatRequest = {
+        chatPrompt: [
+          {
+            role: 'user',
+            content: [
+              { type: 'text', text: 'Summarize this file.' },
+              {
+                type: 'file',
+                data: 'base64data',
+                filename: 'report.pdf',
+                mimeType: 'application/pdf',
+                extractedText: 'Fallback text',
+                cache: true,
+              },
+            ],
+          },
+        ],
+      };
+
+      (mockMultiModalProvider.chat as ReturnType<typeof vi.fn>).mockClear();
+      await router.chat(request);
+
+      const sentRequest = (
+        mockMultiModalProvider.chat as ReturnType<typeof vi.fn>
+      ).mock.calls[0][0] as AxChatRequest;
+      expect(sentRequest.chatPrompt[0]).toEqual(request.chatPrompt[0]);
+      expect(mockFileToText).not.toHaveBeenCalled();
+    });
+
     it('should apply content processing when provider lacks capability', async () => {
       // Create router with text-only primary provider
       const textOnlyRouter = new AxProviderRouter({

--- a/src/ax/ai/router.ts
+++ b/src/ax/ai/router.ts
@@ -263,9 +263,9 @@ export class AxProviderRouter {
           processedChatPrompt.push({
             ...message,
             content: processedContent.map((item) =>
-              item.type === 'image'
-                ? item
-                : { type: 'text' as const, text: item.text }
+              item.type === 'text'
+                ? { type: 'text' as const, text: item.text }
+                : item
             ),
           });
         }

--- a/src/ax/skills/ax-ai.md
+++ b/src/ax/skills/ax-ai.md
@@ -144,6 +144,15 @@ Filter with `{ type: 'all' | 'text' | 'embeddings' | 'code' | 'audio' }` or an a
 
 Dynamic providers such as Azure OpenAI deployments are marked with `isDynamic: true` and may have an empty or static-limited model list.
 
+The same AxIR-backed catalog is public in every generated package: Python
+`get_supported_ai_models()`, Java `Ax.getSupportedAIModels()`, C++
+`get_supported_ai_models()`, Go `GetSupportedAIModels(...)`, and Rust
+`get_supported_ai_models()` (with `get_supported_ai_models_with_options(...)`
+for filters). It includes the named OpenAI-compatible profiles accepted by
+`ai(...)`, including `azure-openai`, `openrouter`, `together`, `fireworks`, and
+the explicit `openai-compatible` fallback. These entries are usually dynamic,
+so inspect provider-level `capabilities` even when `models` is empty.
+
 ## Portable Inference Service Tiers
 
 Use the shared `serviceTier` option with `auto`, `standard`, `flex`, or
@@ -632,9 +641,40 @@ import { AxAIBedrock, AxAIBedrockModel } from '@ax-llm/ax-ai-aws-bedrock';
 const bedrock = new AxAIBedrock({
   region: 'us-east-2',
   fallbackRegions: ['us-west-2'],
-  config: { model: AxAIBedrockModel.ClaudeOpus45 },
+  config: { model: AxAIBedrockModel.ClaudeSonnet5 },
 });
 ```
+
+The native client uses Bedrock `Converse` and `ConverseStream`. Claude models
+advertise native functions, streaming, image/document input, prompt-cache
+breakpoints, and their verified thinking modes. Structured-output and service-
+tier support remain model-specific; query `bedrock.getFeatures(model)` instead
+of assuming every Bedrock model has the same capabilities. The AWS SDK remains
+a dependency of `@ax-llm/ax-ai-aws-bedrock` only and is not pulled into
+`@ax-llm/ax`.
+
+Use `contextCache.ttlSeconds` for a 5-minute or supported 1-hour cache point,
+and `thinkingTokenBudget` for legacy budget thinking or the corresponding
+adaptive-thinking effort on current Claude models:
+
+```typescript
+const response = await bedrock.chat(
+  {
+    chatPrompt: [
+      { role: 'system', content: 'Use the supplied policy.', cache: true },
+      { role: 'user', content: 'Summarize the policy.' },
+    ],
+  },
+  {
+    stream: true,
+    contextCache: { ttlSeconds: 3600 },
+    thinkingTokenBudget: 'medium',
+  }
+);
+```
+
+Claude Sonnet 5 always uses adaptive thinking and rejects
+`thinkingTokenBudget: 'none'`; Claude Opus 5 permits disabling it.
 
 ## Vercel AI SDK Integration
 
@@ -685,7 +725,7 @@ the event runtime sees the request.
 - Thinking constraints on Anthropic: every adaptive-thinking model omits
   `temperature`, `topP`, and `topK`; older thinking models ignore `temperature` and `topK`, with
   `topP` only sent if >= 0.95.
-- `ai({ name: 'amazon-bedrock', apiURL: ... })` targets Bedrock's OpenAI-compatible endpoint. `new AxAIBedrock()` remains the separate AWS-native runtime client.
+- `ai({ name: 'amazon-bedrock', apiURL: ... })` targets Bedrock's OpenAI-compatible endpoint. `new AxAIBedrock()` remains the separate AWS-native runtime client and keeps the AWS SDK out of core.
 - Vercel AI SDK uses `AxAIProvider` wrapper.
 
 ## Examples

--- a/src/examples/package.json
+++ b/src/examples/package.json
@@ -27,6 +27,7 @@
   },
   "dependencies": {
     "@ax-llm/ax": "24.0.16",
+    "@ax-llm/ax-ai-aws-bedrock": "24.0.16",
     "@ax-llm/ax-tools": "24.0.16",
     "@opentelemetry/exporter-metrics-otlp-http": "^0.208.0",
     "@opentelemetry/exporter-prometheus": "^0.218.0",

--- a/src/examples/typescript/generation/aws-bedrock-native.ts
+++ b/src/examples/typescript/generation/aws-bedrock-native.ts
@@ -1,0 +1,98 @@
+// ax-example:start
+// title: TypeScript Native AWS Bedrock Tools and Streaming
+// group: generation
+// description: Runs a Claude tool round trip and streams the final answer through Bedrock Converse.
+// provider: aws-bedrock
+// env: AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_REGION
+// level: intermediate
+// order: 60
+// ax-example:end
+import { AxAIBedrock, AxAIBedrockModel } from '@ax-llm/ax-ai-aws-bedrock';
+
+const model = AxAIBedrockModel.ClaudeSonnet5;
+const bedrock = new AxAIBedrock({
+  region: process.env.AWS_REGION ?? 'us-east-2',
+  fallbackRegions: ['us-west-2', 'us-east-1'],
+  config: { model, maxTokens: 4096 },
+});
+
+const weather = {
+  name: 'current_weather',
+  description: 'Read the current weather for a city',
+  parameters: {
+    type: 'object',
+    properties: {
+      city: { type: 'string', description: 'City name' },
+    },
+    required: ['city'],
+  },
+};
+
+const userMessage = {
+  role: 'user' as const,
+  content: 'What should I wear for today in Vancouver?',
+};
+const toolRequest = await bedrock.chat(
+  {
+    model,
+    chatPrompt: [
+      { role: 'system', content: 'Use tools for current facts.', cache: true },
+      userMessage,
+    ],
+    functions: [weather],
+    functionCall: 'required',
+  },
+  {
+    contextCache: { ttlSeconds: 3600 },
+    thinkingTokenBudget: 'medium',
+  }
+);
+
+if (toolRequest instanceof ReadableStream) {
+  throw new Error('Expected the tool request to be non-streaming.');
+}
+
+const assistant = toolRequest.results[0];
+const call = assistant?.functionCalls?.[0];
+if (!call) throw new Error('Claude did not request the weather tool.');
+
+const toolResult = JSON.stringify({
+  city: 'Vancouver',
+  conditions: 'light rain',
+  temperatureC: 14,
+});
+
+const stream = await bedrock.chat(
+  {
+    model,
+    chatPrompt: [
+      { role: 'system', content: 'Use tools for current facts.', cache: true },
+      userMessage,
+      {
+        role: 'assistant',
+        content: assistant.content,
+        functionCalls: assistant.functionCalls,
+        thoughtBlocks: assistant.thoughtBlocks,
+      },
+      { role: 'function', functionId: call.id, result: toolResult },
+    ],
+    functions: [weather],
+  },
+  {
+    stream: true,
+    contextCache: { ttlSeconds: 3600 },
+    thinkingTokenBudget: 'medium',
+  }
+);
+
+if (!(stream instanceof ReadableStream)) {
+  throw new Error('Expected a streaming Bedrock response.');
+}
+
+const reader = stream.getReader();
+while (true) {
+  const { done, value } = await reader.read();
+  if (done) break;
+  process.stdout.write(value.results[0]?.content ?? '');
+}
+process.stdout.write('\n');

--- a/website/static/typescript/.well-known/agent-skills/ax-agent-context/SKILL.md
+++ b/website/static/typescript/.well-known/agent-skills/ax-agent-context/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: ax-agent-context
 description: This skill helps an LLM pick the right AxAgent context tool for a job - contextMap for recurring corpora, contextPolicy presets for within-run trajectory compaction, agent.optimize for offline GEPA instruction/demo tuning, agent.playbook for an evolving context playbook (offline evolve + online update), and recall/memories + skills for per-turn retrieval. Use when the user asks "which context feature should I use", confuses contextMap with contextPolicy or memory, or wants a decision guide for long-context agents. For contextPolicy/contextMap codegen use ax-agent-rlm; for recall/skills use ax-agent-memory-skills; for agent.optimize or agent.playbook use ax-agent-optimize.
-version: "24.0.15"
+version: "24.0.16"
 ---
 
 # AxAgent Context Selection (@ax-llm/ax)

--- a/website/static/typescript/.well-known/agent-skills/ax-agent-memory-skills/SKILL.md
+++ b/website/static/typescript/.well-known/agent-skills/ax-agent-memory-skills/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: ax-agent-memory-skills
 description: This skill helps an LLM generate correct AxAgent memory retrieval, context-map, and dynamic skill-loading code using @ax-llm/ax. Use when the user asks about contextMap, AxAgentContextMap, onMemoriesSearch, memoriesCatalog, recall(...), inputs.memories, onLoadedMemories, onUsedMemories, onSkillsSearch, skillsCatalog, AxAgentCatalogSkill, discover({ skills }), onLoadedSkills, onUsedSkills, preloaded skills, preloading memories at forward time, relevanceRanking hints, loaded memory/skill IDs, or carrying memories across forward() calls.
-version: "24.0.15"
+version: "24.0.16"
 ---
 
 # AxAgent Memory And Skills Rules (@ax-llm/ax)

--- a/website/static/typescript/.well-known/agent-skills/ax-agent-observability/SKILL.md
+++ b/website/static/typescript/.well-known/agent-skills/ax-agent-observability/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: ax-agent-observability
 description: This skill helps an LLM generate correct AxAgent observability code using @ax-llm/ax. Use when the user asks about axGlobals.onUsage, usageContext, centralized or multi-tenant usage accounting, actorTurnCallback, onContextEvent, agentStatusCallback, onFunctionCall, reportSuccess, reportFailure, getChatLog(), getUsage(), resetUsage(), debug traces, progress updates, or telemetry for AxAgent runs.
-version: "24.0.15"
+version: "24.0.16"
 ---
 
 # AxAgent Observability Rules (@ax-llm/ax)

--- a/website/static/typescript/.well-known/agent-skills/ax-agent-optimize/SKILL.md
+++ b/website/static/typescript/.well-known/agent-skills/ax-agent-optimize/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: ax-agent-optimize
 description: This skill helps an LLM generate correct AxAgent tuning and evaluation code using @ax-llm/ax. Use when the user asks about agent.optimize(...), judgeOptions, eval datasets, optimization targets, saved optimizedProgram artifacts, or agent optimization guidance.
-version: "24.0.15"
+version: "24.0.16"
 ---
 
 # AxAgent Optimize Codegen Rules (@ax-llm/ax)

--- a/website/static/typescript/.well-known/agent-skills/ax-agent-rlm/SKILL.md
+++ b/website/static/typescript/.well-known/agent-skills/ax-agent-rlm/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: ax-agent-rlm
 description: This skill helps an LLM generate correct AxAgent RLM/runtime code using @ax-llm/ax. Use when the user asks about RLM code execution, AxJSRuntime, contextFields, contextPolicy, liveRuntimeState, promptLevel, stage prompt controls, executorModelPolicy, maxRuntimeChars, agent.test(...), llmQuery(...), recursionOptions, or long-running agent runtime behavior.
-version: "24.0.15"
+version: "24.0.16"
 ---
 
 # AxAgent RLM Runtime Rules (@ax-llm/ax)

--- a/website/static/typescript/.well-known/agent-skills/ax-agent/SKILL.md
+++ b/website/static/typescript/.well-known/agent-skills/ax-agent/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: ax-agent
 description: This skill helps an LLM generate correct core AxAgent code using @ax-llm/ax. Use when the user asks about agent(), child agents, namespaced functions, discovery mode, clarification, bubbleErrors, host-side final/clarification protocol, or ordinary agent runtime behavior. For MCP clients, native runtime modules, subscriptions, tasks, or authentication use ax-mcp alongside this skill. For RLM/code-runtime work use ax-agent-rlm; for callbacks and telemetry use ax-agent-observability; for recall/memory/skill loading use ax-agent-memory-skills; for agent.optimize(...) use ax-agent-optimize.
-version: "24.0.15"
+version: "24.0.16"
 ---
 
 # AxAgent Codegen Rules (@ax-llm/ax)

--- a/website/static/typescript/.well-known/agent-skills/ax-ai/SKILL.md
+++ b/website/static/typescript/.well-known/agent-skills/ax-ai/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: ax-ai
 description: This skill helps an LLM generate correct AI provider setup and configuration code using @ax-llm/ax. Use when the user asks about ai(), providers, models, routing, adaptive balancing, presets, embeddings, batch audio with ai.transcribe() or ai.speak(), extended thinking, context caching, or mentions OpenAI/Anthropic/Google/Azure/DeepSeek/Mistral/Cohere/Reka/Grok with @ax-llm/ax.
-version: "24.0.15"
+version: "24.0.16"
 ---
 
 # AI Provider Codegen Rules (@ax-llm/ax)
@@ -143,6 +143,15 @@ Provider groups and models are sorted cheapest to most expensive based on bundle
 Filter with `{ type: 'all' | 'text' | 'embeddings' | 'code' | 'audio' }` or an array of those values. The `'text'` filter includes code-capable models; use `'code'` to show only code-first models.
 
 Dynamic providers such as Azure OpenAI deployments are marked with `isDynamic: true` and may have an empty or static-limited model list.
+
+The same AxIR-backed catalog is public in every generated package: Python
+`get_supported_ai_models()`, Java `Ax.getSupportedAIModels()`, C++
+`get_supported_ai_models()`, Go `GetSupportedAIModels(...)`, and Rust
+`get_supported_ai_models()` (with `get_supported_ai_models_with_options(...)`
+for filters). It includes the named OpenAI-compatible profiles accepted by
+`ai(...)`, including `azure-openai`, `openrouter`, `together`, `fireworks`, and
+the explicit `openai-compatible` fallback. These entries are usually dynamic,
+so inspect provider-level `capabilities` even when `models` is empty.
 
 ## Portable Inference Service Tiers
 
@@ -632,9 +641,40 @@ import { AxAIBedrock, AxAIBedrockModel } from '@ax-llm/ax-ai-aws-bedrock';
 const bedrock = new AxAIBedrock({
   region: 'us-east-2',
   fallbackRegions: ['us-west-2'],
-  config: { model: AxAIBedrockModel.ClaudeOpus45 },
+  config: { model: AxAIBedrockModel.ClaudeSonnet5 },
 });
 ```
+
+The native client uses Bedrock `Converse` and `ConverseStream`. Claude models
+advertise native functions, streaming, image/document input, prompt-cache
+breakpoints, and their verified thinking modes. Structured-output and service-
+tier support remain model-specific; query `bedrock.getFeatures(model)` instead
+of assuming every Bedrock model has the same capabilities. The AWS SDK remains
+a dependency of `@ax-llm/ax-ai-aws-bedrock` only and is not pulled into
+`@ax-llm/ax`.
+
+Use `contextCache.ttlSeconds` for a 5-minute or supported 1-hour cache point,
+and `thinkingTokenBudget` for legacy budget thinking or the corresponding
+adaptive-thinking effort on current Claude models:
+
+```typescript
+const response = await bedrock.chat(
+  {
+    chatPrompt: [
+      { role: 'system', content: 'Use the supplied policy.', cache: true },
+      { role: 'user', content: 'Summarize the policy.' },
+    ],
+  },
+  {
+    stream: true,
+    contextCache: { ttlSeconds: 3600 },
+    thinkingTokenBudget: 'medium',
+  }
+);
+```
+
+Claude Sonnet 5 always uses adaptive thinking and rejects
+`thinkingTokenBudget: 'none'`; Claude Opus 5 permits disabling it.
 
 ## Vercel AI SDK Integration
 
@@ -685,7 +725,7 @@ the event runtime sees the request.
 - Thinking constraints on Anthropic: every adaptive-thinking model omits
   `temperature`, `topP`, and `topK`; older thinking models ignore `temperature` and `topK`, with
   `topP` only sent if >= 0.95.
-- `ai({ name: 'amazon-bedrock', apiURL: ... })` targets Bedrock's OpenAI-compatible endpoint. `new AxAIBedrock()` remains the separate AWS-native runtime client.
+- `ai({ name: 'amazon-bedrock', apiURL: ... })` targets Bedrock's OpenAI-compatible endpoint. `new AxAIBedrock()` remains the separate AWS-native runtime client and keeps the AWS SDK out of core.
 - Vercel AI SDK uses `AxAIProvider` wrapper.
 
 ## Examples

--- a/website/static/typescript/.well-known/agent-skills/ax-audio/SKILL.md
+++ b/website/static/typescript/.well-known/agent-skills/ax-audio/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: ax-audio
 description: This skill helps an LLM generate correct audio code with @ax-llm/ax. Use when the user asks about ai.transcribe(), ai.speak(), signature audio inputs or outputs, agent audio behavior, .chat() conversational audio, OpenAI audio or realtime models, Gemini Live native audio, Grok Voice Agent models, voices, formats, transcripts, or how audio fits with structured outputs.
-version: "24.0.15"
+version: "24.0.16"
 ---
 
 # Audio I/O Codegen Rules (@ax-llm/ax)

--- a/website/static/typescript/.well-known/agent-skills/ax-flow/SKILL.md
+++ b/website/static/typescript/.well-known/agent-skills/ax-flow/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: ax-flow
 description: This skill helps an LLM generate correct AxFlow workflow code using @ax-llm/ax. Use when the user asks about flow(), AxFlow, workflow orchestration, parallel execution, DAG workflows, conditional routing, map/reduce patterns, or multi-node AI pipelines.
-version: "24.0.15"
+version: "24.0.16"
 ---
 
 # AxFlow Codegen Rules (@ax-llm/ax)

--- a/website/static/typescript/.well-known/agent-skills/ax-gen/SKILL.md
+++ b/website/static/typescript/.well-known/agent-skills/ax-gen/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: ax-gen
 description: This skill helps an LLM generate correct AxGen code using @ax-llm/ax. Use when the user asks about ax(), AxGen, generators, forward(), streamingForward(), validation, assertions, streaming assertions, field processors, step hooks, self-tuning, or structured outputs. For MCP clients, transports, prompts, resources, tasks, subscriptions, or authentication use ax-mcp alongside this skill.
-version: "24.0.15"
+version: "24.0.16"
 ---
 
 # AxGen Codegen Rules (@ax-llm/ax)

--- a/website/static/typescript/.well-known/agent-skills/ax-gepa/SKILL.md
+++ b/website/static/typescript/.well-known/agent-skills/ax-gepa/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: ax-gepa
 description: This skill helps an LLM generate correct AxGEPA optimization code using @ax-llm/ax. Use when the user asks about AxGEPA, GEPA, Pareto optimization, multi-objective prompt tuning, reflective prompt evolution, validationExamples, maxMetricCalls, or optimizing a generator, flow, or agent tree.
-version: "24.0.15"
+version: "24.0.16"
 ---
 
 # GEPA Optimization Codegen Rules (@ax-llm/ax)

--- a/website/static/typescript/.well-known/agent-skills/ax-llm/SKILL.md
+++ b/website/static/typescript/.well-known/agent-skills/ax-llm/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: ax-llm
 description: This skill helps with using the @ax-llm/ax TypeScript library for building LLM applications. Use when the user asks about ax(), ai(), f(), s(), agent(), flow(), AxGen, AxAgent, AxFlow, signatures, streaming, or mentions @ax-llm/ax.
-version: "24.0.15"
+version: "24.0.16"
 ---
 
 # Ax Library (@ax-llm/ax) Quick Reference

--- a/website/static/typescript/.well-known/agent-skills/ax-mcp/SKILL.md
+++ b/website/static/typescript/.well-known/agent-skills/ax-mcp/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: ax-mcp
 description: This skill helps an LLM build correct native Model Context Protocol integrations with @ax-llm/ax. Use when the user asks about AxMCPClient, MCP transports, tools, prompts, resources, subscriptions, tasks, sampling, elicitation, roots, authentication, OAuth, MCP Apps, recording/replay, or MCP integration with AxGen, AxAgent, AxFlow, chat, optimization, and AxEventRuntime.
-version: "24.0.15"
+version: "24.0.16"
 ---
 
 # Native MCP With Ax

--- a/website/static/typescript/.well-known/agent-skills/ax-playbook/SKILL.md
+++ b/website/static/typescript/.well-known/agent-skills/ax-playbook/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: ax-playbook
 description: This skill helps an LLM generate correct playbook code using @ax-llm/ax. Use when the user asks about playbook(), AxPlaybook, context playbooks, evolving context, ACE / Agentic Context Engineering, agent.playbook(), or growing/applying task knowledge offline and online with evolve() and update().
-version: "24.0.15"
+version: "24.0.16"
 ---
 
 # Playbook Codegen Rules (@ax-llm/ax)

--- a/website/static/typescript/.well-known/agent-skills/ax-refine/SKILL.md
+++ b/website/static/typescript/.well-known/agent-skills/ax-refine/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: ax-refine
 description: Use this skill when writing or reviewing Ax bestOfN/refine code, reward functions, thresholds, native sample selection, serial attempts, generated advice, and attempt diagnostics.
-version: "24.0.15"
+version: "24.0.16"
 ---
 
 # Ax Refine And BestOfN

--- a/website/static/typescript/.well-known/agent-skills/ax-signature/SKILL.md
+++ b/website/static/typescript/.well-known/agent-skills/ax-signature/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: ax-signature
 description: This skill helps an LLM generate correct DSPy signature code using @ax-llm/ax. Use when the user asks about signatures, s(), f(), field types, string syntax, fluent builder API, validation constraints, or type-safe inputs/outputs.
-version: "24.0.15"
+version: "24.0.16"
 ---
 
 # Ax Signature Reference

--- a/website/static/typescript/.well-known/agent-skills/index.json
+++ b/website/static/typescript/.well-known/agent-skills/index.json
@@ -6,91 +6,91 @@
       "type": "skill-md",
       "description": "This skill helps with using the @ax-llm/ax TypeScript library for building LLM applications. Use when the user asks about ax(), ai(), f(), s(), agent(), flow(), AxGen, AxAgent, AxFlow, signatures, streaming, or mentions @ax-llm/ax.",
       "url": "ax-llm/SKILL.md",
-      "digest": "sha256:9d24b9c164c03a0345a498d098956aaec356d368e1aaf2f929967ccf257d44ff"
+      "digest": "sha256:3e5f4f04e547af563af72da95ecdf4d108edcb5a1998955c1b29441a9725f8c9"
     },
     {
       "name": "ax-ai",
       "type": "skill-md",
       "description": "This skill helps an LLM generate correct AI provider setup and configuration code using @ax-llm/ax. Use when the user asks about ai(), providers, models, routing, adaptive balancing, presets, embeddings, batch audio with ai.transcribe() or ai.speak(), extended thinking, context caching, or mentions OpenAI/Anthropic/Google/Azure/DeepSeek/Mistral/Cohere/Reka/Grok with @ax-llm/ax.",
       "url": "ax-ai/SKILL.md",
-      "digest": "sha256:d3241f0f22c050512799f3fd71eec98a1feb35e4dc08979cdeb55e016ef83aa9"
+      "digest": "sha256:33250cc27eca8ef8f234320aa64b9b5d56ba48240cdaaa21693db6e342454ef3"
     },
     {
       "name": "ax-audio",
       "type": "skill-md",
       "description": "This skill helps an LLM generate correct audio code with @ax-llm/ax. Use when the user asks about ai.transcribe(), ai.speak(), signature audio inputs or outputs, agent audio behavior, .chat() conversational audio, OpenAI audio or realtime models, Gemini Live native audio, Grok Voice Agent models, voices, formats, transcripts, or how audio fits with structured outputs.",
       "url": "ax-audio/SKILL.md",
-      "digest": "sha256:b38441b73877d58d3d4e4d12629c4ea8925cc22c6af9fd7ef8fec3570d86ff18"
+      "digest": "sha256:608b8cd8297d97c15ee69039a36d47bcab3990905564dff775f7f7d8df8bf2b5"
     },
     {
       "name": "ax-signature",
       "type": "skill-md",
       "description": "This skill helps an LLM generate correct DSPy signature code using @ax-llm/ax. Use when the user asks about signatures, s(), f(), field types, string syntax, fluent builder API, validation constraints, or type-safe inputs/outputs.",
       "url": "ax-signature/SKILL.md",
-      "digest": "sha256:0683cbc3979ecf2ca2dae93b46f3532e6d32578eb0917fcfb107f8cf167e185e"
+      "digest": "sha256:07a9aad0b016dc03a8f54c2a2d449b366c989abf355c546c5b10c02bb8ea3a61"
     },
     {
       "name": "ax-gen",
       "type": "skill-md",
       "description": "This skill helps an LLM generate correct AxGen code using @ax-llm/ax. Use when the user asks about ax(), AxGen, generators, forward(), streamingForward(), validation, assertions, streaming assertions, field processors, step hooks, self-tuning, or structured outputs. For MCP clients, transports, prompts, resources, tasks, subscriptions, or authentication use ax-mcp alongside this skill.",
       "url": "ax-gen/SKILL.md",
-      "digest": "sha256:0e7a3cedaa67b49a736af9212e06c5d2ff775360fed9b37bd4e829392b4449d9"
+      "digest": "sha256:b1dfd2fbbcb2f245473425b059d8628712b246e0107fde0aaa13df7d694e2927"
     },
     {
       "name": "ax-mcp",
       "type": "skill-md",
       "description": "This skill helps an LLM build correct native Model Context Protocol integrations with @ax-llm/ax. Use when the user asks about AxMCPClient, MCP transports, tools, prompts, resources, subscriptions, tasks, sampling, elicitation, roots, authentication, OAuth, MCP Apps, recording/replay, or MCP integration with AxGen, AxAgent, AxFlow, chat, optimization, and AxEventRuntime.",
       "url": "ax-mcp/SKILL.md",
-      "digest": "sha256:41d6020f297b252765a8177677475b88e0239b54fe8c8501db8152a83fef7867"
+      "digest": "sha256:8bd83b331180c203a8fedaf8770a8a482f11403292e02a9371c6bbcab2da1f4f"
     },
     {
       "name": "ax-flow",
       "type": "skill-md",
       "description": "This skill helps an LLM generate correct AxFlow workflow code using @ax-llm/ax. Use when the user asks about flow(), AxFlow, workflow orchestration, parallel execution, DAG workflows, conditional routing, map/reduce patterns, or multi-node AI pipelines.",
       "url": "ax-flow/SKILL.md",
-      "digest": "sha256:aa9e208eacbf5a91833e0666ddcb8d49f8eb06d3575e5a723e4f1d395fc24b28"
+      "digest": "sha256:674be774b2d8a4018896b3f0726f504cf9ce939241a0f051c01a2a1e5d6d9b32"
     },
     {
       "name": "ax-agent",
       "type": "skill-md",
       "description": "This skill helps an LLM generate correct core AxAgent code using @ax-llm/ax. Use when the user asks about agent(), child agents, namespaced functions, discovery mode, clarification, bubbleErrors, host-side final/clarification protocol, or ordinary agent runtime behavior. For MCP clients, native runtime modules, subscriptions, tasks, or authentication use ax-mcp alongside this skill. For RLM/code-runtime work use ax-agent-rlm; for callbacks and telemetry use ax-agent-observability; for recall/memory/skill loading use ax-agent-memory-skills; for agent.optimize(...) use ax-agent-optimize.",
       "url": "ax-agent/SKILL.md",
-      "digest": "sha256:6ee9ca78468a448bd54c6208bc6d0c0ac2846e1e4457dc741e70fd46a6f89bcf"
+      "digest": "sha256:0c5e6e8409440cae37623cf43d167db4bb15f3b4ee7b847e0e9e40388a91ba9b"
     },
     {
       "name": "ax-agent-rlm",
       "type": "skill-md",
       "description": "This skill helps an LLM generate correct AxAgent RLM/runtime code using @ax-llm/ax. Use when the user asks about RLM code execution, AxJSRuntime, contextFields, contextPolicy, liveRuntimeState, promptLevel, stage prompt controls, executorModelPolicy, maxRuntimeChars, agent.test(...), llmQuery(...), recursionOptions, or long-running agent runtime behavior.",
       "url": "ax-agent-rlm/SKILL.md",
-      "digest": "sha256:96705f269eac09760fde69fdbbc84d7643a810cba6b9b824b21b5dfc0fda01a9"
+      "digest": "sha256:c07d173e4b21ac0213de14f426f1e8fb466c945b06ec844c832dd1c124fd6903"
     },
     {
       "name": "ax-agent-memory-skills",
       "type": "skill-md",
       "description": "This skill helps an LLM generate correct AxAgent memory retrieval, context-map, and dynamic skill-loading code using @ax-llm/ax. Use when the user asks about contextMap, AxAgentContextMap, onMemoriesSearch, memoriesCatalog, recall(...), inputs.memories, onLoadedMemories, onUsedMemories, onSkillsSearch, skillsCatalog, AxAgentCatalogSkill, discover({ skills }), onLoadedSkills, onUsedSkills, preloaded skills, preloading memories at forward time, relevanceRanking hints, loaded memory/skill IDs, or carrying memories across forward() calls.",
       "url": "ax-agent-memory-skills/SKILL.md",
-      "digest": "sha256:122ce0c0fe02ad555eb315865f208643f306b431ad980af8c6a3baa02fc6b76d"
+      "digest": "sha256:ba35d6f1c63695928e8561b44e7d1eb472486d5d77849923dd9f59b10afbfad2"
     },
     {
       "name": "ax-agent-observability",
       "type": "skill-md",
       "description": "This skill helps an LLM generate correct AxAgent observability code using @ax-llm/ax. Use when the user asks about axGlobals.onUsage, usageContext, centralized or multi-tenant usage accounting, actorTurnCallback, onContextEvent, agentStatusCallback, onFunctionCall, reportSuccess, reportFailure, getChatLog(), getUsage(), resetUsage(), debug traces, progress updates, or telemetry for AxAgent runs.",
       "url": "ax-agent-observability/SKILL.md",
-      "digest": "sha256:45671e710d66b7f610389d771dcaaaeb78fa6b89594e45ebe1addc30932ce380"
+      "digest": "sha256:2c76c420966efd55ce973799efac37a430c21cec8f1f06bba5f03e262035f216"
     },
     {
       "name": "ax-agent-optimize",
       "type": "skill-md",
       "description": "This skill helps an LLM generate correct AxAgent tuning and evaluation code using @ax-llm/ax. Use when the user asks about agent.optimize(...), judgeOptions, eval datasets, optimization targets, saved optimizedProgram artifacts, or agent optimization guidance.",
       "url": "ax-agent-optimize/SKILL.md",
-      "digest": "sha256:5f1bc419a4e12dd3b8f064110d6b2684af96b99f9b9c0ede2785870a1a6dfe6f"
+      "digest": "sha256:2cee84aa66ee594317e2cb2a87bba29584e9009594294ad349e0b838f2b011ba"
     },
     {
       "name": "ax-agent-context",
       "type": "skill-md",
       "description": "This skill helps an LLM pick the right AxAgent context tool for a job - contextMap for recurring corpora, contextPolicy presets for within-run trajectory compaction, agent.optimize for offline GEPA instruction/demo tuning, agent.playbook for an evolving context playbook (offline evolve + online update), and recall/memories + skills for per-turn retrieval. Use when the user asks \"which context feature should I use\", confuses contextMap with contextPolicy or memory, or wants a decision guide for long-context agents. For contextPolicy/contextMap codegen use ax-agent-rlm; for recall/skills use ax-agent-memory-skills; for agent.optimize or agent.playbook use ax-agent-optimize.",
       "url": "ax-agent-context/SKILL.md",
-      "digest": "sha256:1afe82309827712a0f4695ebe1f739706069cbde288da7caaab498b7f3222dfc"
+      "digest": "sha256:fe26462fe20a9e18d133774d71ad80593db7533a0c0dc348de0e32b13da8482d"
     },
     {
       "name": "ax-event-runtime",
@@ -104,21 +104,21 @@
       "type": "skill-md",
       "description": "This skill helps an LLM generate correct AxGEPA optimization code using @ax-llm/ax. Use when the user asks about AxGEPA, GEPA, Pareto optimization, multi-objective prompt tuning, reflective prompt evolution, validationExamples, maxMetricCalls, or optimizing a generator, flow, or agent tree.",
       "url": "ax-gepa/SKILL.md",
-      "digest": "sha256:459e7b3e200dcb7d3a38ed3d861eacded9a705f59255ac7b0785c4aa2c8ab146"
+      "digest": "sha256:3918cd644aa424c5579920a8d8677735320658424a64b782aa6cae88829faf7f"
     },
     {
       "name": "ax-refine",
       "type": "skill-md",
       "description": "Use this skill when writing or reviewing Ax bestOfN/refine code, reward functions, thresholds, native sample selection, serial attempts, generated advice, and attempt diagnostics.",
       "url": "ax-refine/SKILL.md",
-      "digest": "sha256:063496895c20b0d16ac52820af343f608a37cf681ca0aaaee433f29cfddfa0e9"
+      "digest": "sha256:ecb16e65743bcebf5f4d29a9a20126d6d5d85ec7092f6602d6c1f590d0178ea4"
     },
     {
       "name": "ax-playbook",
       "type": "skill-md",
       "description": "This skill helps an LLM generate correct playbook code using @ax-llm/ax. Use when the user asks about playbook(), AxPlaybook, context playbooks, evolving context, ACE / Agentic Context Engineering, agent.playbook(), or growing/applying task knowledge offline and online with evolve() and update().",
       "url": "ax-playbook/SKILL.md",
-      "digest": "sha256:0e221c91ca6edc97f7ca609b23f798c9adc3bb05790403a42a288f69aa029b8a"
+      "digest": "sha256:23c83109dd81a2840cb036cca4b35c10800e038e28c0ba5bf72113a697066a90"
     }
   ]
 }


### PR DESCRIPTION
Closes #640

Summary:
- move the native Bedrock chat path to Converse and ConverseStream
- add model-specific functions, streaming, media, prompt caching, thinking, structured output, and service-tier capabilities
- keep @aws-sdk/client-bedrock-runtime isolated in @ax-llm/ax-ai-aws-bedrock; @ax-llm/ax remains AWS SDK-free
- preserve native file content through provider-aware core routing
- add a runnable native Bedrock tool/streaming example and public docs

Verification:
- npm test --workspace=@ax-llm/ax-ai-aws-bedrock
- npm run build --workspace=@ax-llm/ax-ai-aws-bedrock
- npm run test:type-check --workspace=@ax-llm/ax
- npm run test:unit --workspace=@ax-llm/ax -- ai/processor.test.ts ai/router.test.ts
- npm run test:type-check --workspace=@ax-llm/ax-examples
- npm run axir:backlog:validate
- npm run axir:check-packages
- npm run example -- list --json
- npm run doc:build:markdown
- npm run website:prepare
- npm run website:check
- npm run test:examples:generated
- repository website Biome check and git diff --check

No live billable AWS request was run; AWS request/response/stream behavior is covered with SDK-level contract tests.