### PR TITLE
fix(apicall): remove the abort-signal listener on every apiCall exit path

### DIFF
--- a/src/ax/util/apicall.test.ts
+++ b/src/ax/util/apicall.test.ts
@@ -700,3 +700,150 @@ describe('apiCall', () => {
     });
   });
 });
+
+// Regression coverage for the user-abort listener leak: apiCall registers a
+// listener on the caller-owned `abortSignal` on every attempt but, before the
+// fix, only detached it on an actual abort. On normal resolution — and on each
+// retry — the listener accumulated, producing a MaxListenersExceededWarning at
+// 11 and unbounded growth on a long-lived signal. Sibling of PR #632 (remove
+// abort listener on normal resolution in AxInMemoryEventStore.waitForWork).
+describe('apiCall user abort listener lifecycle', () => {
+  // Duck-typed AbortSignal that counts add/remove of its 'abort' listener.
+  // `removed` only increments on a listener that was actually attached, so a
+  // double-remove cannot mask a leak.
+  const makeCountingAbortSignal = () => {
+    const listeners = new Set<EventListenerOrEventListenerObject>();
+    let added = 0;
+    let removed = 0;
+    const signal = {
+      aborted: false,
+      reason: undefined as unknown,
+      onabort: null,
+      addEventListener(
+        _type: string,
+        listener: EventListenerOrEventListenerObject,
+        _options?: AddEventListenerOptions | boolean
+      ) {
+        added++;
+        listeners.add(listener);
+      },
+      removeEventListener(
+        _type: string,
+        listener: EventListenerOrEventListenerObject
+      ) {
+        if (listeners.delete(listener)) {
+          removed++;
+        }
+      },
+      dispatchEvent() {
+        return true;
+      },
+    };
+    return {
+      signal: signal as unknown as AbortSignal,
+      counts: {
+        get added() {
+          return added;
+        },
+        get removed() {
+          return removed;
+        },
+        get live() {
+          return listeners.size;
+        },
+      },
+    };
+  };
+
+  const jsonResponse = () =>
+    new Response(JSON.stringify({ result: 'success' }), {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    });
+
+  it('detaches the abort listener after a non-stream resolution', async () => {
+    const { signal, counts } = makeCountingAbortSignal();
+    const mockFetch = vi.fn().mockResolvedValue(jsonResponse());
+
+    await apiCall(
+      {
+        url: 'https://api.example.com/test',
+        fetch: mockFetch,
+        abortSignal: signal,
+      },
+      { test: 'data' }
+    );
+
+    expect(counts.added).toBe(1);
+    expect(counts.removed).toBe(counts.added);
+    expect(counts.live).toBe(0);
+  });
+
+  it('does not accumulate abort listeners across retries', async () => {
+    const { signal, counts } = makeCountingAbortSignal();
+    const mockFetch = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response('service unavailable', {
+          status: 503,
+          headers: { 'content-type': 'text/plain' },
+        })
+      )
+      .mockResolvedValueOnce(jsonResponse());
+
+    await apiCall(
+      {
+        url: 'https://api.example.com/test',
+        fetch: mockFetch,
+        abortSignal: signal,
+        retry: {
+          maxRetries: 3,
+          initialDelayMs: 1,
+          backoffFactor: 1,
+          maxDelayMs: 10,
+        },
+      },
+      { test: 'data' }
+    );
+
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+    // One listener registered per attempt, each detached again: net zero.
+    expect(counts.added).toBe(2);
+    expect(counts.removed).toBe(counts.added);
+    expect(counts.live).toBe(0);
+  });
+
+  it('detaches the abort listener after a stream is fully consumed', async () => {
+    const { signal, counts } = makeCountingAbortSignal();
+    const mockFetch = vi.fn().mockResolvedValue(
+      new Response('data: {"index":0}\n\ndata: [DONE]\n\n', {
+        status: 200,
+        headers: { 'content-type': 'text/event-stream' },
+      })
+    );
+
+    const stream = (await apiCall<{ test: string }, { index: number }>(
+      {
+        url: 'https://api.example.com/test',
+        fetch: mockFetch,
+        stream: true,
+        abortSignal: signal,
+      },
+      { test: 'data' }
+    )) as ReadableStream<{ index: number }>;
+
+    // The listener must stay attached while the stream is live so a mid-stream
+    // user abort still reaches the fetch signal.
+    expect(counts.live).toBe(1);
+
+    const reader = stream.getReader();
+    while (true) {
+      const { done } = await reader.read();
+      if (done) break;
+    }
+
+    expect(counts.added).toBe(1);
+    expect(counts.removed).toBe(counts.added);
+    expect(counts.live).toBe(0);
+  });
+});

--- a/src/ax/util/apicall.ts
+++ b/src/ax/util/apicall.ts
@@ -660,6 +660,19 @@ export const apiCall = async <TRequest = unknown, TResponse = unknown>(
     // Combine user abort signal with timeout signal
     const combinedAbortController = new AbortController();
 
+    // Idempotent removal of the user abort listener. Defined per attempt so
+    // every exit path (success, non-abort error, and each retry `continue`)
+    // can detach the listener it registered on the long-lived caller signal.
+    // `removeEventListener` is a no-op when the listener is already gone, so
+    // calling this more than once is safe.
+    let removeUserAbortHandler: (() => void) | undefined;
+
+    // The streaming response is consumed after this function returns, so the
+    // listener must outlive the outer `finally` and is instead detached by the
+    // stream's own teardown (its `finally`/`cancel`). This flag tells the outer
+    // `finally` to leave the listener in place for that case only.
+    let abortHandlerOwnedByStream = false;
+
     // Handle user abort signal
     if (api.abortSignal) {
       if (api.abortSignal.aborted) {
@@ -680,13 +693,16 @@ export const apiCall = async <TRequest = unknown, TResponse = unknown>(
       api.abortSignal.addEventListener('abort', userAbortHandler, {
         once: true,
       });
+      removeUserAbortHandler = () => {
+        api.abortSignal!.removeEventListener('abort', userAbortHandler);
+      };
 
       // Clean up listener if we complete before abort
       const originalAbort = combinedAbortController.abort.bind(
         combinedAbortController
       );
       combinedAbortController.abort = (reason?: string) => {
-        api.abortSignal!.removeEventListener('abort', userAbortHandler);
+        removeUserAbortHandler?.();
         originalAbort(reason);
       };
     }
@@ -934,6 +950,10 @@ export const apiCall = async <TRequest = unknown, TResponse = unknown>(
       let streamReader: ReadableStreamDefaultReader<TResponse> | undefined;
 
       // Enhanced wrapped stream
+      // The listener must stay attached while the stream is consumed (a user
+      // abort during streaming still needs to reach the fetch signal), so
+      // ownership transfers to the stream teardown below.
+      abortHandlerOwnedByStream = true;
       return new ReadableStream<TResponse>({
         start(controller) {
           const reader = res
@@ -1042,6 +1062,7 @@ export const apiCall = async <TRequest = unknown, TResponse = unknown>(
               if (timeoutId) {
                 clearTimeout(timeoutId);
               }
+              removeUserAbortHandler?.();
               reader.releaseLock();
               if (streamReader === reader) streamReader = undefined;
             }
@@ -1052,6 +1073,7 @@ export const apiCall = async <TRequest = unknown, TResponse = unknown>(
         // When the consumer cancels the stream, set our flag to stop processing further.
         cancel(reason) {
           closed = true;
+          removeUserAbortHandler?.();
           return streamReader?.cancel(reason);
         },
       });
@@ -1128,6 +1150,15 @@ export const apiCall = async <TRequest = unknown, TResponse = unknown>(
     } finally {
       if (timeoutId !== undefined) {
         clearTimeout(timeoutId);
+      }
+      // Detach the user abort listener on every non-streaming exit path
+      // (success, non-abort error, and each retry `continue`). Without this the
+      // `{ once: true }` listener registered above only ever detaches on an
+      // actual abort, so a long-lived caller signal accumulates one listener
+      // per attempt (MaxListenersExceededWarning at 11, then unbounded). For a
+      // streamed response the stream teardown owns the listener instead.
+      if (!abortHandlerOwnedByStream) {
+        removeUserAbortHandler?.();
       }
     }
   }


### PR DESCRIPTION
## Summary

`apiCall` (`src/ax/util/apicall.ts`) registers a `{ once: true }` abort listener on the caller-owned `api.abortSignal` on every attempt, but removes it only inside the monkey-patched `combinedAbortController.abort` — i.e. only on user-abort/timeout. On normal success, on non-abort errors, and on each retry (`continue` in the `while` loop), the listener stays attached, so a long-lived `AbortSignal` reused across many requests accumulates handlers → `MaxListenersExceededWarning` at 11 and unbounded growth.

Fix: remove the handler in the outer `finally` (covering success, non-abort errors and every retry) via an idempotent helper. The streaming path transfers listener ownership to the stream teardown, so a mid-stream user abort still reaches the fetch signal.

This is the HTTP-transport sibling of #632 (remove abort listener on normal resolution in `AxInMemoryEventStore.waitForWork`).

## Tests

Three discriminant tests (fake `abortSignal` with add/remove counters): non-stream, retry (503→200) and streaming — each asserts listeners net to 0 after completion. RED before, GREEN after. `util/apicall.test.ts` 46/46; neighbours (abort/retry/sse/rate-limit) 28/28; `tsc`, biome, cspell and `external-contribution-policy` all clean. Handwritten TS, non-vetoed path.
