### PR TITLE
fix(security): redact sensitive headers in verbose API request logs

### DIFF
--- a/src/ax/util/apicall.redact.test.ts
+++ b/src/ax/util/apicall.redact.test.ts
@@ -1,0 +1,81 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { apiCall } from './apicall.js';
+
+describe('apiCall verbose header redaction', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  const okFetch = () =>
+    vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      })
+    );
+
+  it('does not print the raw Authorization bearer token', async () => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const mockFetch = okFetch();
+
+    await apiCall(
+      {
+        url: 'https://api.example.com/test',
+        fetch: mockFetch,
+        verbose: true,
+        headers: { Authorization: 'Bearer sk-secret123' },
+      },
+      { test: 'data' }
+    );
+
+    const logged = logSpy.mock.calls
+      .map((call) => call.map((arg) => String(arg)).join(' '))
+      .join('\n');
+
+    expect(logged).not.toContain('sk-secret123');
+    expect(logged).toContain('***');
+  });
+
+  it('does not print the raw x-api-key value', async () => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const mockFetch = okFetch();
+
+    await apiCall(
+      {
+        url: 'https://api.example.com/test',
+        fetch: mockFetch,
+        verbose: true,
+        headers: { 'x-api-key': 'topsecretapikey' },
+      },
+      { test: 'data' }
+    );
+
+    const logged = logSpy.mock.calls
+      .map((call) => call.map((arg) => String(arg)).join(' '))
+      .join('\n');
+
+    expect(logged).not.toContain('topsecretapikey');
+    expect(logged).toContain('***');
+  });
+
+  it('still sends the real, unredacted credential to fetch', async () => {
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    const mockFetch = okFetch();
+
+    await apiCall(
+      {
+        url: 'https://api.example.com/test',
+        fetch: mockFetch,
+        verbose: true,
+        headers: { Authorization: 'Bearer sk-secret123' },
+      },
+      { test: 'data' }
+    );
+
+    const [, requestInit] = mockFetch.mock.calls[0];
+    expect((requestInit.headers as Record<string, string>).Authorization).toBe(
+      'Bearer sk-secret123'
+    );
+  });
+});

--- a/src/ax/util/apicall.redact.test.ts
+++ b/src/ax/util/apicall.redact.test.ts
@@ -59,6 +59,28 @@ describe('apiCall verbose header redaction', () => {
     expect(logged).toContain('***');
   });
 
+  it('fully redacts cookie values containing spaces', async () => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const mockFetch = okFetch();
+
+    await apiCall(
+      {
+        url: 'https://api.example.com/test',
+        fetch: mockFetch,
+        verbose: true,
+        headers: { Cookie: 'session=COOKIE_SECRET; theme=dark' },
+      },
+      { test: 'data' }
+    );
+
+    const logged = logSpy.mock.calls
+      .map((call) => call.map((arg) => String(arg)).join(' '))
+      .join('\n');
+
+    expect(logged).not.toContain('COOKIE_SECRET');
+    expect(logged).toContain('"Cookie": "***"');
+  });
+
   it('still sends the real, unredacted credential to fetch', async () => {
     vi.spyOn(console, 'log').mockImplementation(() => {});
     const mockFetch = okFetch();

--- a/src/ax/util/apicall.redact.test.ts
+++ b/src/ax/util/apicall.redact.test.ts
@@ -46,7 +46,7 @@ describe('apiCall verbose header redaction', () => {
         url: 'https://api.example.com/test',
         fetch: mockFetch,
         verbose: true,
-        headers: { 'x-api-key': 'topsecretapikey' },
+        headers: { 'x-api-key': 'top-secret-api-key' },
       },
       { test: 'data' }
     );
@@ -55,7 +55,7 @@ describe('apiCall verbose header redaction', () => {
       .map((call) => call.map((arg) => String(arg)).join(' '))
       .join('\n');
 
-    expect(logged).not.toContain('topsecretapikey');
+    expect(logged).not.toContain('top-secret-api-key');
     expect(logged).toContain('***');
   });
 
@@ -81,7 +81,7 @@ describe('apiCall verbose header redaction', () => {
     expect(logged).toContain('"Cookie": "***"');
   });
 
-  it('still sends the real, unredacted credential to fetch', async () => {
+  it('still sends the original credential to fetch', async () => {
     vi.spyOn(console, 'log').mockImplementation(() => {});
     const mockFetch = okFetch();
 

--- a/src/ax/util/apicall.ts
+++ b/src/ax/util/apicall.ts
@@ -511,6 +511,43 @@ export class AxContentProcessingError extends Error {
 }
 
 // Utility Functions
+// Header names whose values carry credentials and must never be logged.
+const SENSITIVE_HEADER_NAMES = new Set([
+  'authorization',
+  'proxy-authorization',
+  'x-api-key',
+  'api-key',
+  'apikey',
+  'x-goog-api-key',
+  'x-amz-security-token',
+  'cookie',
+  'set-cookie',
+]);
+
+/**
+ * Return a shallow copy of `headers` with the values of sensitive keys masked,
+ * for safe logging. Header-name matching is case-insensitive. The original
+ * headers object is never mutated, so the real credentials are still sent.
+ *
+ * `Authorization` values keep their scheme (e.g. `Bearer ***`) so the log stays
+ * useful for debugging while the secret itself is redacted.
+ */
+function redactHeaders(
+  headers: Record<string, string>
+): Record<string, string> {
+  const redacted: Record<string, string> = {};
+  for (const [key, value] of Object.entries(headers)) {
+    if (SENSITIVE_HEADER_NAMES.has(key.toLowerCase())) {
+      const spaceIndex = typeof value === 'string' ? value.indexOf(' ') : -1;
+      redacted[key] =
+        spaceIndex > 0 ? `${value.slice(0, spaceIndex)} ***` : '***';
+    } else {
+      redacted[key] = value;
+    }
+  }
+  return redacted;
+}
+
 async function safeReadResponseBody(response: Response) {
   try {
     if (response.headers.get('content-type')?.includes('application/json')) {
@@ -707,12 +744,12 @@ export const apiCall = async <TRequest = unknown, TResponse = unknown>(
           `Method: ${method}\n`,
           `Headers:`,
           JSON.stringify(
-            {
+            redactHeaders({
               'Content-Type': 'application/json',
               'X-Request-ID': requestId,
               'X-Retry-Count': attempt.toString(),
               ...requestHeaders,
-            },
+            }),
             null,
             2
           ),

--- a/src/ax/util/apicall.ts
+++ b/src/ax/util/apicall.ts
@@ -529,8 +529,8 @@ const SENSITIVE_HEADER_NAMES = new Set([
  * for safe logging. Header-name matching is case-insensitive. The original
  * headers object is never mutated, so the real credentials are still sent.
  *
- * `Authorization` values keep their scheme (e.g. `Bearer ***`) so the log stays
- * useful for debugging while the secret itself is redacted.
+ * Sensitive values are masked in full. Preserving a prefix is unsafe for
+ * headers such as Cookie, whose first value commonly appears before a space.
  */
 function redactHeaders(
   headers: Record<string, string>
@@ -538,9 +538,7 @@ function redactHeaders(
   const redacted: Record<string, string> = {};
   for (const [key, value] of Object.entries(headers)) {
     if (SENSITIVE_HEADER_NAMES.has(key.toLowerCase())) {
-      const spaceIndex = typeof value === 'string' ? value.indexOf(' ') : -1;
-      redacted[key] =
-        spaceIndex > 0 ? `${value.slice(0, spaceIndex)} ***` : '***';
+      redacted[key] = '***';
     } else {
       redacted[key] = value;
     }


### PR DESCRIPTION
## Summary

The `verbose` request-log block in `src/ax/util/apicall.ts` spread the outgoing request headers verbatim into `console.log`. Providers inject credentials as headers (`Authorization`, `x-api-key`, cookies, and similar), so with `verbose: true` raw secrets could be printed to stdout.

Fix: redact the values of sensitive header names (`authorization`, `proxy-authorization`, `x-api-key`, `api-key`, `cookie`, and others) in full to `***` before logging. Full masking avoids leaking prefix-bearing values such as `Cookie: session=SECRET; theme=dark`. The real headers object is never mutated, so the actual credential still reaches `fetch`.

`verbose` is opt-in (default `false`), so this is debug-log hygiene rather than a default-path leak; headers were the one place a credential could reach stdout (request bodies are already gated by `includeRequestBodyInErrors`).

## Tests

`apicall.redact.test.ts` (4 tests) covers `Authorization`, `x-api-key`, a spaced multi-cookie value, and confirms the unredacted credential still reaches `fetch`. The cookie regression is red on the original head and green after full-value masking.

Local verification on the merge result against current `main`: focused API-call tests 47/47, utility suite 156/156, full `@ax-llm/ax` suite 3,030 passed with one intentional skip, plus type tests, Biome, contribution policy, and production build. Handwritten TypeScript, non-vetoed path.
