### PR TITLE
fix(event): remove the abort-signal listener when a clock sleep settles

### DIFF
--- a/src/ax/event/types.test.ts
+++ b/src/ax/event/types.test.ts
@@ -1,0 +1,61 @@
+import { getEventListeners } from 'node:events';
+
+import { describe, expect, it } from 'vitest';
+
+import { AxManualEventClock, AxSystemEventClock } from './types.js';
+
+describe('AxSystemEventClock.sleep', () => {
+  it('removes the abort listener after each timer-resolved sleep', async () => {
+    const clock = new AxSystemEventClock();
+    const controller = new AbortController();
+    const { signal } = controller;
+
+    for (let i = 0; i < 25; i++) {
+      await clock.sleep(0, signal);
+    }
+
+    expect(getEventListeners(signal, 'abort').length).toBe(0);
+  });
+
+  it('still rejects and cleans up when the signal aborts', async () => {
+    const clock = new AxSystemEventClock();
+    const controller = new AbortController();
+    const { signal } = controller;
+    const reason = new Error('aborted');
+
+    const pending = clock.sleep(1000, signal);
+    controller.abort(reason);
+
+    await expect(pending).rejects.toBe(reason);
+    expect(getEventListeners(signal, 'abort').length).toBe(0);
+  });
+});
+
+describe('AxManualEventClock.sleep', () => {
+  it('removes the abort listener after each advance-resolved sleep', async () => {
+    const clock = new AxManualEventClock();
+    const controller = new AbortController();
+    const { signal } = controller;
+
+    for (let i = 0; i < 25; i++) {
+      const pending = clock.sleep(5, signal);
+      clock.advanceBy(5);
+      await pending;
+    }
+
+    expect(getEventListeners(signal, 'abort').length).toBe(0);
+  });
+
+  it('still rejects and cleans up when the signal aborts', async () => {
+    const clock = new AxManualEventClock();
+    const controller = new AbortController();
+    const { signal } = controller;
+    const reason = new Error('aborted');
+
+    const pending = clock.sleep(5, signal);
+    controller.abort(reason);
+
+    await expect(pending).rejects.toBe(reason);
+    expect(getEventListeners(signal, 'abort').length).toBe(0);
+  });
+});

--- a/src/ax/event/types.ts
+++ b/src/ax/event/types.ts
@@ -68,15 +68,21 @@ export class AxSystemEventClock implements AxEventClock {
   sleep(ms: number, signal?: AbortSignal): Promise<void> {
     if (signal?.aborted) return Promise.reject(signal.reason);
     return new Promise((resolve, reject) => {
-      const timeout = setTimeout(resolve, Math.max(0, ms));
-      signal?.addEventListener(
-        'abort',
+      // The timer firing never triggers the abort listener, so both the timer
+      // and the listener must be cleaned up on every path to avoid leaking a
+      // listener on a long-lived signal reused across many sleep() calls.
+      const onAbort = () => {
+        clearTimeout(timeout);
+        reject(signal?.reason);
+      };
+      const timeout = setTimeout(
         () => {
-          clearTimeout(timeout);
-          reject(signal.reason);
+          if (signal) signal.removeEventListener('abort', onAbort);
+          resolve();
         },
-        { once: true }
+        Math.max(0, ms)
       );
+      signal?.addEventListener('abort', onAbort, { once: true });
     });
   }
 }
@@ -99,16 +105,23 @@ export class AxManualEventClock implements AxEventClock {
     if (signal?.aborted) return Promise.reject(signal.reason);
     if (ms <= 0) return Promise.resolve();
     return new Promise((resolve, reject) => {
-      const sleeper = { at: this.value + ms, resolve, reject };
-      this.sleepers.push(sleeper);
-      signal?.addEventListener(
-        'abort',
-        () => {
-          this.sleepers = this.sleepers.filter((value) => value !== sleeper);
-          reject(signal.reason);
+      // advanceBy() resolves sleepers directly and never fires the abort
+      // listener, so the settling path removes the listener to avoid leaking
+      // one on a long-lived signal reused across many sleep() calls.
+      const onAbort = () => {
+        this.sleepers = this.sleepers.filter((value) => value !== sleeper);
+        reject(signal?.reason);
+      };
+      const sleeper = {
+        at: this.value + ms,
+        resolve: () => {
+          if (signal) signal.removeEventListener('abort', onAbort);
+          resolve();
         },
-        { once: true }
-      );
+        reject,
+      };
+      this.sleepers.push(sleeper);
+      signal?.addEventListener('abort', onAbort, { once: true });
     });
   }
 


### PR DESCRIPTION
## Summary

`AxSystemEventClock.sleep` and `AxManualEventClock.sleep` (`src/ax/event/types.ts`) register a `{ once: true }` abort listener on the caller's signal but only clean it up when abort actually fires. On the normal settling path (system timer fires / `advanceBy` resolves the sleeper) the listener is never removed — and for the system clock the timer isn't cleared. `AxEventClock` is public API, and `AxInMemoryEventStore.waitForCapacity` calls `clock.sleep(ms, signal)` in a `Promise.race` inside the `enqueue` backpressure loop, **reusing the same signal** each iteration — so every satisfied wait leaks a dead listener (and a dangling timer) on a long-lived signal → `MaxListenersExceededWarning` + memory growth.

Fix: name the abort handler and `removeEventListener` on the normal settle path (system clock clears the timer too); the abort path is unchanged (`{ once: true }` auto-removes; `removeEventListener` is idempotent). Mirrors the `waitForWork` cleanup idiom in `memoryStore.ts`, and is the same family as #632.

## Tests

`src/ax/event/types.test.ts` (using the repo's `getEventListeners(signal,'abort').length` idiom): a 25-iteration leak test + an abort-path test for each clock. RED before (25 leaked), GREEN after (0). Full `src/ax/event/` suite 50/50; `tsc`/biome clean. Handwritten TS, non-vetoed, non-backlog path.
