### PR TITLE
chore: release v24.0.18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,30 @@
 # Changelog
 
+## [24.0.18](https://github.com/ax-llm/ax/compare/24.0.16...24.0.17) (2026-09-09)
+
+### Features
+
+* add Astra sessions and begin AxIR parity ([#651](https://github.com/ax-llm/ax/issues/651)) ([48eec33](https://github.com/ax-llm/ax/commit/48eec33e09d19704209f4de2c0aa387033e37c0a))
+* **ai:** add Gemini 3.8 Flash and preserve tool-call IDs ([#650](https://github.com/ax-llm/ax/issues/650)) ([5f0e470](https://github.com/ax-llm/ax/commit/5f0e470b6cab98304e445c7568a8891ebb97e8ac))
+* **ai:** add Meta Muse support through existing Ax APIs ([#649](https://github.com/ax-llm/ax/issues/649)) ([3e5fd36](https://github.com/ax-llm/ax/commit/3e5fd36537e9049c18c0920845ba96db4c74bba1))
+* extend AxIR Astra sessions and concurrent flows ([#653](https://github.com/ax-llm/ax/issues/653)) ([0a943e2](https://github.com/ax-llm/ax/commit/0a943e28cb7aa43b7cf7f0c3c8109ad290357d2f))
+* preserve native files through AxIR provider routing ([#652](https://github.com/ax-llm/ax/issues/652)) ([4590b14](https://github.com/ax-llm/ax/commit/4590b147b84a6c43ae3e01371cbb65648630edec))
+
+### Bug Fixes
+
+* **apicall:** remove user abort listener on all non-abort exit paths ([#645](https://github.com/ax-llm/ax/issues/645)) ([2034b04](https://github.com/ax-llm/ax/commit/2034b04f688bcfe64ffd8f728a4efccaa8045aff)), closes [#632](https://github.com/ax-llm/ax/issues/632)
+* complete Astra session parity across generated languages ([#657](https://github.com/ax-llm/ax/issues/657)) ([5ef03af](https://github.com/ax-llm/ax/commit/5ef03af8658c5aafc9122208412e4e93bbe7cac0))
+* **event:** clear timer and remove abort listener on normal sleep path ([#647](https://github.com/ax-llm/ax/issues/647)) ([039f1d7](https://github.com/ax-llm/ax/commit/039f1d7e36fc0dd05817d340350264376dd98e75))
+* preserve MCP contexts through child agents across languages ([#655](https://github.com/ax-llm/ax/issues/655)) ([27b8e31](https://github.com/ax-llm/ax/commit/27b8e3149c41edee0ff14a4f563cba7a28d409d5))
+* propagate MCP invocation cancellation across generated runtimes ([#656](https://github.com/ax-llm/ax/issues/656)) ([db7ce0c](https://github.com/ax-llm/ax/commit/db7ce0cbab8e29fbcc4872da0fc06dcf4c48bf7c))
+* **security:** redact sensitive headers in verbose API request logs ([#646](https://github.com/ax-llm/ax/issues/646)) ([b2d974b](https://github.com/ax-llm/ax/commit/b2d974b86fc4282f0da0165ec0421e1db469e7e4))
+
+## [24.0.17](https://github.com/ax-llm/ax/compare/24.0.16...24.0.17) (2026-09-01)
+
+### Features
+
+* **bedrock:** add native Converse capabilities ([#642](https://github.com/ax-llm/ax/issues/642)) ([d480062](https://github.com/ax-llm/ax/commit/d480062291e677056615b2938f36bd20f9557784))
+
 ## [24.0.17](https://github.com/ax-llm/ax/compare/24.0.16...24.0.17) (2026-09-01)
 
 ### Features

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -31,8 +31,10 @@ development fallback.
 
 `npm run release` is the normal release preparation path. It verifies that
 local `main` is clean and synchronized with `origin/main`, creates a
-`codex/release-<version>` branch, runs the workspace version bumps, regenerates
-the generated packages, creates the release commit, validates it, pushes the
+`codex/release-<version>` branch, runs the workspace version bumps (including
+internal example dependencies), refreshes the root lockfile, and checks that
+`npm ci` can resolve it. It then regenerates the generated packages, creates the
+release commit, validates it, pushes the
 branch, and opens a pull request. It intentionally does not tag, push directly
 to `main`, or create a GitHub Release.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ax-llm/ax-monorepo",
-  "version": "24.0.17",
+  "version": "24.0.18",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@ax-llm/ax-monorepo",
-      "version": "24.0.17",
+      "version": "24.0.18",
       "license": "Apache-2.0",
       "workspaces": [
         "src/*",
@@ -12863,12 +12863,12 @@
     },
     "src/aisdk": {
       "name": "@ax-llm/ax-ai-sdk-provider",
-      "version": "24.0.17",
+      "version": "24.0.18",
       "license": "Apache-2.0",
       "dependencies": {
         "@ai-sdk/provider": "^4.0.0",
         "@ai-sdk/provider-utils": "^5.0.0",
-        "@ax-llm/ax": "24.0.17",
+        "@ax-llm/ax": "24.0.18",
         "ai": "^7.0.2",
         "zod": "^3.25.76"
       },
@@ -12881,11 +12881,11 @@
     },
     "src/aws-bedrock": {
       "name": "@ax-llm/ax-ai-aws-bedrock",
-      "version": "24.0.17",
+      "version": "24.0.18",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/client-bedrock-runtime": "^3.1122.0",
-        "@ax-llm/ax": "24.0.17"
+        "@ax-llm/ax": "24.0.18"
       },
       "engines": {
         "node": ">=20"
@@ -12893,7 +12893,7 @@
     },
     "src/ax": {
       "name": "@ax-llm/ax",
-      "version": "24.0.17",
+      "version": "24.0.18",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/api": "^1.9.0"
@@ -12913,9 +12913,9 @@
       "version": "11.0.61",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ax-llm/ax": "24.0.17",
-        "@ax-llm/ax-ai-aws-bedrock": "24.0.17",
-        "@ax-llm/ax-tools": "24.0.17",
+        "@ax-llm/ax": "24.0.18",
+        "@ax-llm/ax-ai-aws-bedrock": "24.0.18",
+        "@ax-llm/ax-tools": "24.0.18",
         "@opentelemetry/exporter-metrics-otlp-http": "^0.208.0",
         "@opentelemetry/exporter-prometheus": "^0.218.0",
         "@opentelemetry/exporter-trace-otlp-http": "^0.203.0",
@@ -12934,10 +12934,10 @@
     },
     "src/tools": {
       "name": "@ax-llm/ax-tools",
-      "version": "24.0.17",
+      "version": "24.0.18",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ax-llm/ax": "24.0.17",
+        "@ax-llm/ax": "24.0.18",
         "better-sqlite3": "^12.11.1"
       },
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -122,5 +122,5 @@
   },
   "author": "Vikram <https://twitter.com/dosco>",
   "private": "true",
-  "version": "24.0.17"
+  "version": "24.0.18"
 }

--- a/packages/cpp/CMakeLists.txt
+++ b/packages/cpp/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.16)
-project(axllm VERSION 24.0.17 LANGUAGES CXX)
+project(axllm VERSION 24.0.18 LANGUAGES CXX)
 
 option(AX_BUILD_EXAMPLES "Build generated Ax examples" ON)
 option(AX_BUILD_CONFORMANCE "Build generated Ax conformance runner" ON)

--- a/packages/cpp/skills/ax-cpp-agent-context/SKILL.md
+++ b/packages/cpp/skills/ax-cpp-agent-context/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-cpp-agent-context"
 description: "Use when writing C++ code with `axllm` for deciding between context maps, trajectory context policy, offline optimization (ACE/GEPA), and memory recall for long-context agents."
-version: "24.0.17"
+version: "24.0.18"
 ---
 # AxAgent Context Selection For C++
 

--- a/packages/cpp/skills/ax-cpp-agent-memory-skills/SKILL.md
+++ b/packages/cpp/skills/ax-cpp-agent-memory-skills/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-cpp-agent-memory-skills"
 description: "Use when writing C++ code with `axllm` for agent memory, recall callbacks, dynamic skill discovery, loaded-skill state, and used-skill tracking."
-version: "24.0.17"
+version: "24.0.18"
 ---
 # AxAgent Memory And Skills For C++
 

--- a/packages/cpp/skills/ax-cpp-agent-observability/SKILL.md
+++ b/packages/cpp/skills/ax-cpp-agent-observability/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-cpp-agent-observability"
 description: "Use when writing C++ code with `axllm` for agent tracing, centralized and multi-tenant usage accounting, action logs, runtime diagnostics, replay, and production debugging."
-version: "24.0.17"
+version: "24.0.18"
 ---
 # AxAgent Observability For C++
 

--- a/packages/cpp/skills/ax-cpp-agent-optimize/SKILL.md
+++ b/packages/cpp/skills/ax-cpp-agent-optimize/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-cpp-agent-optimize"
 description: "Use when writing C++ code with `axllm` for agent optimization, verified agent-playbook evolution, evaluators, judges, optimizer artifacts, BootstrapFewShot, and GEPA."
-version: "24.0.17"
+version: "24.0.18"
 ---
 # AxAgent Optimize For C++
 

--- a/packages/cpp/skills/ax-cpp-agent-rlm/SKILL.md
+++ b/packages/cpp/skills/ax-cpp-agent-rlm/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-cpp-agent-rlm"
 description: "Use when writing C++ code with `axllm` for RLM executor loops, AxCodeRuntime sessions, runtime envelopes, process runtimes, and optional runtime profiles."
-version: "24.0.17"
+version: "24.0.18"
 ---
 # AxAgent RLM Runtime For C++
 

--- a/packages/cpp/skills/ax-cpp-agent/SKILL.md
+++ b/packages/cpp/skills/ax-cpp-agent/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-cpp-agent"
 description: "Use when writing C++ code with `axllm` for agents, child delegation, tools, MCP, citations, persistent playbook learning, stage instructions, runtime state, final typed responses, and direct-respond executor skipping."
-version: "24.0.17"
+version: "24.0.18"
 ---
 # AxAgent For C++
 

--- a/packages/cpp/skills/ax-cpp-ai/SKILL.md
+++ b/packages/cpp/skills/ax-cpp-ai/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-cpp-ai"
 description: "Use when writing C++ code with `axllm` for named deployment profiles, generic provider clients, model selection, OpenAI-compatible calls, Responses, Gemini, Anthropic, routers, and balancers."
-version: "24.0.17"
+version: "24.0.18"
 ---
 # AxAI Providers For C++
 

--- a/packages/cpp/skills/ax-cpp-audio/SKILL.md
+++ b/packages/cpp/skills/ax-cpp-audio/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-cpp-audio"
 description: "Use when writing C++ code with `axllm` for audio input/output, OpenAI Responses audio mapping, realtime event folding, and generated package audio examples."
-version: "24.0.17"
+version: "24.0.18"
 ---
 # Ax Audio And Realtime For C++
 

--- a/packages/cpp/skills/ax-cpp-flow/SKILL.md
+++ b/packages/cpp/skills/ax-cpp-flow/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-cpp-flow"
 description: "Use when writing C++ code with `axllm` for flows, nodes, program graphs, nested programs, dynamic options, caching, and optimizer components."
-version: "24.0.17"
+version: "24.0.18"
 ---
 # AxFlow For C++
 

--- a/packages/cpp/skills/ax-cpp-gen/SKILL.md
+++ b/packages/cpp/skills/ax-cpp-gen/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-cpp-gen"
 description: "Use when writing C++ code with `axllm` for AxGen programs, forward calls, indexed multi-sampling, result pickers, streaming, tools, assertions, traces, usage, and output parsing."
-version: "24.0.17"
+version: "24.0.18"
 ---
 # AxGen Structured Generation For C++
 

--- a/packages/cpp/skills/ax-cpp-gepa/SKILL.md
+++ b/packages/cpp/skills/ax-cpp-gepa/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-cpp-gepa"
 description: "Use when writing C++ code with `axllm` for GEPA, Pareto tradeoffs, reflection clients, metric budgets, optimizer state, and artifacts."
-version: "24.0.17"
+version: "24.0.18"
 ---
 # Ax GEPA For C++
 

--- a/packages/cpp/skills/ax-cpp-llm/SKILL.md
+++ b/packages/cpp/skills/ax-cpp-llm/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-cpp-llm"
 description: "Use when writing C++ code with `axllm` for using the generated Ax package, factory functions, package docs, examples, and API reference."
-version: "24.0.17"
+version: "24.0.18"
 ---
 # Ax LLM Quick Reference For C++
 

--- a/packages/cpp/skills/ax-cpp-playbook/SKILL.md
+++ b/packages/cpp/skills/ax-cpp-playbook/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-cpp-playbook"
 description: "Use when writing C++ code with `axllm` for the playbook() context-engineering surface, agent-bound verified evolution, run-end learning, online updates, and rendering a playbook into a program."
-version: "24.0.17"
+version: "24.0.18"
 ---
 # Ax Playbook For C++
 

--- a/packages/cpp/skills/ax-cpp-refine/SKILL.md
+++ b/packages/cpp/skills/ax-cpp-refine/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-cpp-refine"
 description: "Use when writing C++ code with `axllm` for reward-scored generation, iterative candidate improvement, evaluator feedback, and optimizer-backed refinement patterns."
-version: "24.0.17"
+version: "24.0.18"
 ---
 # Ax Refinement Patterns For C++
 

--- a/packages/cpp/skills/ax-cpp-signature/SKILL.md
+++ b/packages/cpp/skills/ax-cpp-signature/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-cpp-signature"
 description: "Use when writing C++ code with `axllm` for string signatures, field descriptors, JSON schema output, validation, and typed tool argument shapes."
-version: "24.0.17"
+version: "24.0.18"
 ---
 # Ax Signatures For C++
 

--- a/packages/go/axllm.go
+++ b/packages/go/axllm.go
@@ -80359,4 +80359,4 @@ func extractQuotedSuffix(s string) (Value, error) {
 
 func _core_type_is_json(value Value) Value { return true }
 
-func Version() string { return "24.0.17" }
+func Version() string { return "24.0.18" }

--- a/packages/go/skills/ax-go-agent-context/SKILL.md
+++ b/packages/go/skills/ax-go-agent-context/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-go-agent-context"
 description: "Use when writing Go code with `github.com/ax-llm/ax/packages/go` for deciding between context maps, trajectory context policy, offline optimization (ACE/GEPA), and memory recall for long-context agents."
-version: "24.0.17"
+version: "24.0.18"
 ---
 # AxAgent Context Selection For Go
 

--- a/packages/go/skills/ax-go-agent-memory-skills/SKILL.md
+++ b/packages/go/skills/ax-go-agent-memory-skills/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-go-agent-memory-skills"
 description: "Use when writing Go code with `github.com/ax-llm/ax/packages/go` for agent memory, recall callbacks, dynamic skill discovery, loaded-skill state, and used-skill tracking."
-version: "24.0.17"
+version: "24.0.18"
 ---
 # AxAgent Memory And Skills For Go
 

--- a/packages/go/skills/ax-go-agent-observability/SKILL.md
+++ b/packages/go/skills/ax-go-agent-observability/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-go-agent-observability"
 description: "Use when writing Go code with `github.com/ax-llm/ax/packages/go` for agent tracing, centralized and multi-tenant usage accounting, action logs, runtime diagnostics, replay, and production debugging."
-version: "24.0.17"
+version: "24.0.18"
 ---
 # AxAgent Observability For Go
 

--- a/packages/go/skills/ax-go-agent-optimize/SKILL.md
+++ b/packages/go/skills/ax-go-agent-optimize/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-go-agent-optimize"
 description: "Use when writing Go code with `github.com/ax-llm/ax/packages/go` for agent optimization, verified agent-playbook evolution, evaluators, judges, optimizer artifacts, BootstrapFewShot, and GEPA."
-version: "24.0.17"
+version: "24.0.18"
 ---
 # AxAgent Optimize For Go
 

--- a/packages/go/skills/ax-go-agent-rlm/SKILL.md
+++ b/packages/go/skills/ax-go-agent-rlm/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-go-agent-rlm"
 description: "Use when writing Go code with `github.com/ax-llm/ax/packages/go` for RLM executor loops, AxCodeRuntime sessions, runtime envelopes, process runtimes, and optional runtime profiles."
-version: "24.0.17"
+version: "24.0.18"
 ---
 # AxAgent RLM Runtime For Go
 

--- a/packages/go/skills/ax-go-agent/SKILL.md
+++ b/packages/go/skills/ax-go-agent/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-go-agent"
 description: "Use when writing Go code with `github.com/ax-llm/ax/packages/go` for agents, child delegation, tools, MCP, citations, persistent playbook learning, stage instructions, runtime state, final typed responses, and direct-respond executor skipping."
-version: "24.0.17"
+version: "24.0.18"
 ---
 # AxAgent For Go
 

--- a/packages/go/skills/ax-go-ai/SKILL.md
+++ b/packages/go/skills/ax-go-ai/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-go-ai"
 description: "Use when writing Go code with `github.com/ax-llm/ax/packages/go` for named deployment profiles, generic provider clients, model selection, OpenAI-compatible calls, Responses, Gemini, Anthropic, routers, and balancers."
-version: "24.0.17"
+version: "24.0.18"
 ---
 # AxAI Providers For Go
 

--- a/packages/go/skills/ax-go-audio/SKILL.md
+++ b/packages/go/skills/ax-go-audio/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-go-audio"
 description: "Use when writing Go code with `github.com/ax-llm/ax/packages/go` for audio input/output, OpenAI Responses audio mapping, realtime event folding, and generated package audio examples."
-version: "24.0.17"
+version: "24.0.18"
 ---
 # Ax Audio And Realtime For Go
 

--- a/packages/go/skills/ax-go-flow/SKILL.md
+++ b/packages/go/skills/ax-go-flow/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-go-flow"
 description: "Use when writing Go code with `github.com/ax-llm/ax/packages/go` for flows, nodes, program graphs, nested programs, dynamic options, caching, and optimizer components."
-version: "24.0.17"
+version: "24.0.18"
 ---
 # AxFlow For Go
 

--- a/packages/go/skills/ax-go-gen/SKILL.md
+++ b/packages/go/skills/ax-go-gen/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-go-gen"
 description: "Use when writing Go code with `github.com/ax-llm/ax/packages/go` for AxGen programs, forward calls, indexed multi-sampling, result pickers, streaming, tools, assertions, traces, usage, and output parsing."
-version: "24.0.17"
+version: "24.0.18"
 ---
 # AxGen Structured Generation For Go
 

--- a/packages/go/skills/ax-go-gepa/SKILL.md
+++ b/packages/go/skills/ax-go-gepa/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-go-gepa"
 description: "Use when writing Go code with `github.com/ax-llm/ax/packages/go` for GEPA, Pareto tradeoffs, reflection clients, metric budgets, optimizer state, and artifacts."
-version: "24.0.17"
+version: "24.0.18"
 ---
 # Ax GEPA For Go
 

--- a/packages/go/skills/ax-go-llm/SKILL.md
+++ b/packages/go/skills/ax-go-llm/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-go-llm"
 description: "Use when writing Go code with `github.com/ax-llm/ax/packages/go` for using the generated Ax package, factory functions, package docs, examples, and API reference."
-version: "24.0.17"
+version: "24.0.18"
 ---
 # Ax LLM Quick Reference For Go
 

--- a/packages/go/skills/ax-go-playbook/SKILL.md
+++ b/packages/go/skills/ax-go-playbook/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-go-playbook"
 description: "Use when writing Go code with `github.com/ax-llm/ax/packages/go` for the playbook() context-engineering surface, agent-bound verified evolution, run-end learning, online updates, and rendering a playbook into a program."
-version: "24.0.17"
+version: "24.0.18"
 ---
 # Ax Playbook For Go
 

--- a/packages/go/skills/ax-go-refine/SKILL.md
+++ b/packages/go/skills/ax-go-refine/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-go-refine"
 description: "Use when writing Go code with `github.com/ax-llm/ax/packages/go` for reward-scored generation, iterative candidate improvement, evaluator feedback, and optimizer-backed refinement patterns."
-version: "24.0.17"
+version: "24.0.18"
 ---
 # Ax Refinement Patterns For Go
 

--- a/packages/go/skills/ax-go-signature/SKILL.md
+++ b/packages/go/skills/ax-go-signature/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-go-signature"
 description: "Use when writing Go code with `github.com/ax-llm/ax/packages/go` for string signatures, field descriptors, JSON schema output, validation, and typed tool argument shapes."
-version: "24.0.17"
+version: "24.0.18"
 ---
 # Ax Signatures For Go
 

--- a/packages/java/README.md
+++ b/packages/java/README.md
@@ -10,14 +10,14 @@ Add the dependency from Maven Central:
 <dependency>
   <groupId>dev.axllm</groupId>
   <artifactId>ax</artifactId>
-  <version>24.0.17</version>
+  <version>24.0.18</version>
 </dependency>
 ```
 
 Or with Gradle:
 
 ```groovy
-implementation 'dev.axllm:ax:24.0.17'
+implementation 'dev.axllm:ax:24.0.18'
 ```
 
 Realtime audio over WebSocket uses the JDK's built-in `java.net.http` WebSocket — no extra dependency.

--- a/packages/java/build.gradle
+++ b/packages/java/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 group = 'dev.axllm'
-version = '24.0.17'
+version = '24.0.18'
 
 java {
   toolchain {

--- a/packages/java/pom.xml
+++ b/packages/java/pom.xml
@@ -4,7 +4,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>dev.axllm</groupId>
   <artifactId>ax</artifactId>
-  <version>24.0.17</version>
+  <version>24.0.18</version>
   <name>Ax</name>
   <url>https://axllm.dev</url>
   <licenses>

--- a/packages/java/skills/ax-java-agent-context/SKILL.md
+++ b/packages/java/skills/ax-java-agent-context/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-java-agent-context"
 description: "Use when writing Java code with `dev.axllm:ax` for deciding between context maps, trajectory context policy, offline optimization (ACE/GEPA), and memory recall for long-context agents."
-version: "24.0.17"
+version: "24.0.18"
 ---
 # AxAgent Context Selection For Java
 

--- a/packages/java/skills/ax-java-agent-memory-skills/SKILL.md
+++ b/packages/java/skills/ax-java-agent-memory-skills/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-java-agent-memory-skills"
 description: "Use when writing Java code with `dev.axllm:ax` for agent memory, recall callbacks, dynamic skill discovery, loaded-skill state, and used-skill tracking."
-version: "24.0.17"
+version: "24.0.18"
 ---
 # AxAgent Memory And Skills For Java
 

--- a/packages/java/skills/ax-java-agent-observability/SKILL.md
+++ b/packages/java/skills/ax-java-agent-observability/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-java-agent-observability"
 description: "Use when writing Java code with `dev.axllm:ax` for agent tracing, centralized and multi-tenant usage accounting, action logs, runtime diagnostics, replay, and production debugging."
-version: "24.0.17"
+version: "24.0.18"
 ---
 # AxAgent Observability For Java
 

--- a/packages/java/skills/ax-java-agent-optimize/SKILL.md
+++ b/packages/java/skills/ax-java-agent-optimize/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-java-agent-optimize"
 description: "Use when writing Java code with `dev.axllm:ax` for agent optimization, verified agent-playbook evolution, evaluators, judges, optimizer artifacts, BootstrapFewShot, and GEPA."
-version: "24.0.17"
+version: "24.0.18"
 ---
 # AxAgent Optimize For Java
 

--- a/packages/java/skills/ax-java-agent-rlm/SKILL.md
+++ b/packages/java/skills/ax-java-agent-rlm/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-java-agent-rlm"
 description: "Use when writing Java code with `dev.axllm:ax` for RLM executor loops, AxCodeRuntime sessions, runtime envelopes, process runtimes, and optional runtime profiles."
-version: "24.0.17"
+version: "24.0.18"
 ---
 # AxAgent RLM Runtime For Java
 

--- a/packages/java/skills/ax-java-agent/SKILL.md
+++ b/packages/java/skills/ax-java-agent/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-java-agent"
 description: "Use when writing Java code with `dev.axllm:ax` for agents, child delegation, tools, MCP, citations, persistent playbook learning, stage instructions, runtime state, final typed responses, and direct-respond executor skipping."
-version: "24.0.17"
+version: "24.0.18"
 ---
 # AxAgent For Java
 

--- a/packages/java/skills/ax-java-ai/SKILL.md
+++ b/packages/java/skills/ax-java-ai/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-java-ai"
 description: "Use when writing Java code with `dev.axllm:ax` for named deployment profiles, generic provider clients, model selection, OpenAI-compatible calls, Responses, Gemini, Anthropic, routers, and balancers."
-version: "24.0.17"
+version: "24.0.18"
 ---
 # AxAI Providers For Java
 

--- a/packages/java/skills/ax-java-audio/SKILL.md
+++ b/packages/java/skills/ax-java-audio/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-java-audio"
 description: "Use when writing Java code with `dev.axllm:ax` for audio input/output, OpenAI Responses audio mapping, realtime event folding, and generated package audio examples."
-version: "24.0.17"
+version: "24.0.18"
 ---
 # Ax Audio And Realtime For Java
 

--- a/packages/java/skills/ax-java-flow/SKILL.md
+++ b/packages/java/skills/ax-java-flow/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-java-flow"
 description: "Use when writing Java code with `dev.axllm:ax` for flows, nodes, program graphs, nested programs, dynamic options, caching, and optimizer components."
-version: "24.0.17"
+version: "24.0.18"
 ---
 # AxFlow For Java
 

--- a/packages/java/skills/ax-java-gen/SKILL.md
+++ b/packages/java/skills/ax-java-gen/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-java-gen"
 description: "Use when writing Java code with `dev.axllm:ax` for AxGen programs, forward calls, indexed multi-sampling, result pickers, streaming, tools, assertions, traces, usage, and output parsing."
-version: "24.0.17"
+version: "24.0.18"
 ---
 # AxGen Structured Generation For Java
 

--- a/packages/java/skills/ax-java-gepa/SKILL.md
+++ b/packages/java/skills/ax-java-gepa/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-java-gepa"
 description: "Use when writing Java code with `dev.axllm:ax` for GEPA, Pareto tradeoffs, reflection clients, metric budgets, optimizer state, and artifacts."
-version: "24.0.17"
+version: "24.0.18"
 ---
 # Ax GEPA For Java
 

--- a/packages/java/skills/ax-java-llm/SKILL.md
+++ b/packages/java/skills/ax-java-llm/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-java-llm"
 description: "Use when writing Java code with `dev.axllm:ax` for using the generated Ax package, factory functions, package docs, examples, and API reference."
-version: "24.0.17"
+version: "24.0.18"
 ---
 # Ax LLM Quick Reference For Java
 

--- a/packages/java/skills/ax-java-playbook/SKILL.md
+++ b/packages/java/skills/ax-java-playbook/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-java-playbook"
 description: "Use when writing Java code with `dev.axllm:ax` for the playbook() context-engineering surface, agent-bound verified evolution, run-end learning, online updates, and rendering a playbook into a program."
-version: "24.0.17"
+version: "24.0.18"
 ---
 # Ax Playbook For Java
 

--- a/packages/java/skills/ax-java-refine/SKILL.md
+++ b/packages/java/skills/ax-java-refine/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-java-refine"
 description: "Use when writing Java code with `dev.axllm:ax` for reward-scored generation, iterative candidate improvement, evaluator feedback, and optimizer-backed refinement patterns."
-version: "24.0.17"
+version: "24.0.18"
 ---
 # Ax Refinement Patterns For Java
 

--- a/packages/java/skills/ax-java-signature/SKILL.md
+++ b/packages/java/skills/ax-java-signature/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-java-signature"
 description: "Use when writing Java code with `dev.axllm:ax` for string signatures, field descriptors, JSON schema output, validation, and typed tool argument shapes."
-version: "24.0.17"
+version: "24.0.18"
 ---
 # Ax Signatures For Java
 

--- a/packages/python/pyproject.toml
+++ b/packages/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "axllm"
-version = "24.0.17"
+version = "24.0.18"
 description = "Generated Ax runtime library"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/packages/python/skills/ax-python-agent-context/SKILL.md
+++ b/packages/python/skills/ax-python-agent-context/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-python-agent-context"
 description: "Use when writing Python code with `axllm` for deciding between context maps, trajectory context policy, offline optimization (ACE/GEPA), and memory recall for long-context agents."
-version: "24.0.17"
+version: "24.0.18"
 ---
 # AxAgent Context Selection For Python
 

--- a/packages/python/skills/ax-python-agent-memory-skills/SKILL.md
+++ b/packages/python/skills/ax-python-agent-memory-skills/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-python-agent-memory-skills"
 description: "Use when writing Python code with `axllm` for agent memory, recall callbacks, dynamic skill discovery, loaded-skill state, and used-skill tracking."
-version: "24.0.17"
+version: "24.0.18"
 ---
 # AxAgent Memory And Skills For Python
 

--- a/packages/python/skills/ax-python-agent-observability/SKILL.md
+++ b/packages/python/skills/ax-python-agent-observability/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-python-agent-observability"
 description: "Use when writing Python code with `axllm` for agent tracing, centralized and multi-tenant usage accounting, action logs, runtime diagnostics, replay, and production debugging."
-version: "24.0.17"
+version: "24.0.18"
 ---
 # AxAgent Observability For Python
 

--- a/packages/python/skills/ax-python-agent-optimize/SKILL.md
+++ b/packages/python/skills/ax-python-agent-optimize/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-python-agent-optimize"
 description: "Use when writing Python code with `axllm` for agent optimization, verified agent-playbook evolution, evaluators, judges, optimizer artifacts, BootstrapFewShot, and GEPA."
-version: "24.0.17"
+version: "24.0.18"
 ---
 # AxAgent Optimize For Python
 

--- a/packages/python/skills/ax-python-agent-rlm/SKILL.md
+++ b/packages/python/skills/ax-python-agent-rlm/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-python-agent-rlm"
 description: "Use when writing Python code with `axllm` for RLM executor loops, AxCodeRuntime sessions, runtime envelopes, process runtimes, and optional runtime profiles."
-version: "24.0.17"
+version: "24.0.18"
 ---
 # AxAgent RLM Runtime For Python
 

--- a/packages/python/skills/ax-python-agent/SKILL.md
+++ b/packages/python/skills/ax-python-agent/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-python-agent"
 description: "Use when writing Python code with `axllm` for agents, child delegation, tools, MCP, citations, persistent playbook learning, stage instructions, runtime state, final typed responses, and direct-respond executor skipping."
-version: "24.0.17"
+version: "24.0.18"
 ---
 # AxAgent For Python
 

--- a/packages/python/skills/ax-python-ai/SKILL.md
+++ b/packages/python/skills/ax-python-ai/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-python-ai"
 description: "Use when writing Python code with `axllm` for named deployment profiles, generic provider clients, model selection, OpenAI-compatible calls, Responses, Gemini, Anthropic, routers, and balancers."
-version: "24.0.17"
+version: "24.0.18"
 ---
 # AxAI Providers For Python
 

--- a/packages/python/skills/ax-python-audio/SKILL.md
+++ b/packages/python/skills/ax-python-audio/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-python-audio"
 description: "Use when writing Python code with `axllm` for audio input/output, OpenAI Responses audio mapping, realtime event folding, and generated package audio examples."
-version: "24.0.17"
+version: "24.0.18"
 ---
 # Ax Audio And Realtime For Python
 

--- a/packages/python/skills/ax-python-flow/SKILL.md
+++ b/packages/python/skills/ax-python-flow/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-python-flow"
 description: "Use when writing Python code with `axllm` for flows, nodes, program graphs, nested programs, dynamic options, caching, and optimizer components."
-version: "24.0.17"
+version: "24.0.18"
 ---
 # AxFlow For Python
 

--- a/packages/python/skills/ax-python-gen/SKILL.md
+++ b/packages/python/skills/ax-python-gen/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-python-gen"
 description: "Use when writing Python code with `axllm` for AxGen programs, forward calls, indexed multi-sampling, result pickers, streaming, tools, assertions, traces, usage, and output parsing."
-version: "24.0.17"
+version: "24.0.18"
 ---
 # AxGen Structured Generation For Python
 

--- a/packages/python/skills/ax-python-gepa/SKILL.md
+++ b/packages/python/skills/ax-python-gepa/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-python-gepa"
 description: "Use when writing Python code with `axllm` for GEPA, Pareto tradeoffs, reflection clients, metric budgets, optimizer state, and artifacts."
-version: "24.0.17"
+version: "24.0.18"
 ---
 # Ax GEPA For Python
 

--- a/packages/python/skills/ax-python-llm/SKILL.md
+++ b/packages/python/skills/ax-python-llm/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-python-llm"
 description: "Use when writing Python code with `axllm` for using the generated Ax package, factory functions, package docs, examples, and API reference."
-version: "24.0.17"
+version: "24.0.18"
 ---
 # Ax LLM Quick Reference For Python
 

--- a/packages/python/skills/ax-python-playbook/SKILL.md
+++ b/packages/python/skills/ax-python-playbook/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-python-playbook"
 description: "Use when writing Python code with `axllm` for the playbook() context-engineering surface, agent-bound verified evolution, run-end learning, online updates, and rendering a playbook into a program."
-version: "24.0.17"
+version: "24.0.18"
 ---
 # Ax Playbook For Python
 

--- a/packages/python/skills/ax-python-refine/SKILL.md
+++ b/packages/python/skills/ax-python-refine/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-python-refine"
 description: "Use when writing Python code with `axllm` for reward-scored generation, iterative candidate improvement, evaluator feedback, and optimizer-backed refinement patterns."
-version: "24.0.17"
+version: "24.0.18"
 ---
 # Ax Refinement Patterns For Python
 

--- a/packages/python/skills/ax-python-signature/SKILL.md
+++ b/packages/python/skills/ax-python-signature/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-python-signature"
 description: "Use when writing Python code with `axllm` for string signatures, field descriptors, JSON schema output, validation, and typed tool argument shapes."
-version: "24.0.17"
+version: "24.0.18"
 ---
 # Ax Signatures For Python
 

--- a/packages/rust/Cargo.toml
+++ b/packages/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "axllm"
-version = "24.0.17"
+version = "24.0.18"
 edition = "2021"
 rust-version = "1.74"
 description = "Generated Ax runtime library"

--- a/packages/rust/README.md
+++ b/packages/rust/README.md
@@ -11,7 +11,7 @@ cargo add axllm
 Or add to your `Cargo.toml`:
 
 ```toml
-axllm = "24.0.17"
+axllm = "24.0.18"
 ```
 
 Enable realtime audio over WebSocket with the `realtime` feature (pulls `tungstenite`):

--- a/packages/rust/skills/ax-rust-agent-context/SKILL.md
+++ b/packages/rust/skills/ax-rust-agent-context/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-rust-agent-context"
 description: "Use when writing Rust code with `axllm` for deciding between context maps, trajectory context policy, offline optimization (ACE/GEPA), and memory recall for long-context agents."
-version: "24.0.17"
+version: "24.0.18"
 ---
 # AxAgent Context Selection For Rust
 

--- a/packages/rust/skills/ax-rust-agent-memory-skills/SKILL.md
+++ b/packages/rust/skills/ax-rust-agent-memory-skills/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-rust-agent-memory-skills"
 description: "Use when writing Rust code with `axllm` for agent memory, recall callbacks, dynamic skill discovery, loaded-skill state, and used-skill tracking."
-version: "24.0.17"
+version: "24.0.18"
 ---
 # AxAgent Memory And Skills For Rust
 

--- a/packages/rust/skills/ax-rust-agent-observability/SKILL.md
+++ b/packages/rust/skills/ax-rust-agent-observability/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-rust-agent-observability"
 description: "Use when writing Rust code with `axllm` for agent tracing, centralized and multi-tenant usage accounting, action logs, runtime diagnostics, replay, and production debugging."
-version: "24.0.17"
+version: "24.0.18"
 ---
 # AxAgent Observability For Rust
 

--- a/packages/rust/skills/ax-rust-agent-optimize/SKILL.md
+++ b/packages/rust/skills/ax-rust-agent-optimize/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-rust-agent-optimize"
 description: "Use when writing Rust code with `axllm` for agent optimization, verified agent-playbook evolution, evaluators, judges, optimizer artifacts, BootstrapFewShot, and GEPA."
-version: "24.0.17"
+version: "24.0.18"
 ---
 # AxAgent Optimize For Rust
 

--- a/packages/rust/skills/ax-rust-agent-rlm/SKILL.md
+++ b/packages/rust/skills/ax-rust-agent-rlm/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-rust-agent-rlm"
 description: "Use when writing Rust code with `axllm` for RLM executor loops, AxCodeRuntime sessions, runtime envelopes, process runtimes, and optional runtime profiles."
-version: "24.0.17"
+version: "24.0.18"
 ---
 # AxAgent RLM Runtime For Rust
 

--- a/packages/rust/skills/ax-rust-agent/SKILL.md
+++ b/packages/rust/skills/ax-rust-agent/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-rust-agent"
 description: "Use when writing Rust code with `axllm` for agents, child delegation, tools, MCP, citations, persistent playbook learning, stage instructions, runtime state, final typed responses, and direct-respond executor skipping."
-version: "24.0.17"
+version: "24.0.18"
 ---
 # AxAgent For Rust
 

--- a/packages/rust/skills/ax-rust-ai/SKILL.md
+++ b/packages/rust/skills/ax-rust-ai/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-rust-ai"
 description: "Use when writing Rust code with `axllm` for named deployment profiles, generic provider clients, model selection, OpenAI-compatible calls, Responses, Gemini, Anthropic, routers, and balancers."
-version: "24.0.17"
+version: "24.0.18"
 ---
 # AxAI Providers For Rust
 

--- a/packages/rust/skills/ax-rust-audio/SKILL.md
+++ b/packages/rust/skills/ax-rust-audio/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-rust-audio"
 description: "Use when writing Rust code with `axllm` for audio input/output, OpenAI Responses audio mapping, realtime event folding, and generated package audio examples."
-version: "24.0.17"
+version: "24.0.18"
 ---
 # Ax Audio And Realtime For Rust
 

--- a/packages/rust/skills/ax-rust-flow/SKILL.md
+++ b/packages/rust/skills/ax-rust-flow/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-rust-flow"
 description: "Use when writing Rust code with `axllm` for flows, nodes, program graphs, nested programs, dynamic options, caching, and optimizer components."
-version: "24.0.17"
+version: "24.0.18"
 ---
 # AxFlow For Rust
 

--- a/packages/rust/skills/ax-rust-gen/SKILL.md
+++ b/packages/rust/skills/ax-rust-gen/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-rust-gen"
 description: "Use when writing Rust code with `axllm` for AxGen programs, forward calls, indexed multi-sampling, result pickers, streaming, tools, assertions, traces, usage, and output parsing."
-version: "24.0.17"
+version: "24.0.18"
 ---
 # AxGen Structured Generation For Rust
 

--- a/packages/rust/skills/ax-rust-gepa/SKILL.md
+++ b/packages/rust/skills/ax-rust-gepa/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-rust-gepa"
 description: "Use when writing Rust code with `axllm` for GEPA, Pareto tradeoffs, reflection clients, metric budgets, optimizer state, and artifacts."
-version: "24.0.17"
+version: "24.0.18"
 ---
 # Ax GEPA For Rust
 

--- a/packages/rust/skills/ax-rust-llm/SKILL.md
+++ b/packages/rust/skills/ax-rust-llm/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-rust-llm"
 description: "Use when writing Rust code with `axllm` for using the generated Ax package, factory functions, package docs, examples, and API reference."
-version: "24.0.17"
+version: "24.0.18"
 ---
 # Ax LLM Quick Reference For Rust
 

--- a/packages/rust/skills/ax-rust-playbook/SKILL.md
+++ b/packages/rust/skills/ax-rust-playbook/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-rust-playbook"
 description: "Use when writing Rust code with `axllm` for the playbook() context-engineering surface, agent-bound verified evolution, run-end learning, online updates, and rendering a playbook into a program."
-version: "24.0.17"
+version: "24.0.18"
 ---
 # Ax Playbook For Rust
 

--- a/packages/rust/skills/ax-rust-refine/SKILL.md
+++ b/packages/rust/skills/ax-rust-refine/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-rust-refine"
 description: "Use when writing Rust code with `axllm` for reward-scored generation, iterative candidate improvement, evaluator feedback, and optimizer-backed refinement patterns."
-version: "24.0.17"
+version: "24.0.18"
 ---
 # Ax Refinement Patterns For Rust
 

--- a/packages/rust/skills/ax-rust-signature/SKILL.md
+++ b/packages/rust/skills/ax-rust-signature/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: "ax-rust-signature"
 description: "Use when writing Rust code with `axllm` for string signatures, field descriptors, JSON schema output, validation, and typed tool argument shapes."
-version: "24.0.17"
+version: "24.0.18"
 ---
 # Ax Signatures For Rust
 

--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -325,6 +325,20 @@ function prepare(increment = 'patch') {
     version,
     '--ci',
   ]);
+  run('npm', [
+    'install',
+    '--package-lock-only',
+    '--ignore-scripts',
+    '--no-audit',
+    '--no-fund',
+  ]);
+  run('npm', [
+    'ci',
+    '--dry-run',
+    '--ignore-scripts',
+    '--no-audit',
+    '--no-fund',
+  ]);
   run('npm', ['run', 'axir:generate-packages']);
   run('npm', ['exec', '--', 'release-it', '--no-increment', '--ci']);
   verifyPreparedRelease(version, branch);

--- a/scripts/release.test.js
+++ b/scripts/release.test.js
@@ -21,6 +21,43 @@ const repoRoot = path.resolve(
 );
 
 describe('protected-main release workflow', () => {
+  it('keeps release workspace manifests and lockfile metadata aligned', () => {
+    const lock = JSON.parse(
+      readFileSync(path.join(repoRoot, 'package-lock.json'), 'utf8')
+    );
+    for (const directory of [
+      '',
+      'src/ax',
+      'src/aisdk',
+      'src/aws-bedrock',
+      'src/tools',
+      'src/examples',
+    ]) {
+      const manifest = JSON.parse(
+        readFileSync(path.join(repoRoot, directory, 'package.json'), 'utf8')
+      );
+      expect(lock.packages[directory].version, directory).toBe(
+        manifest.version
+      );
+      expect(lock.packages[directory].dependencies, directory).toEqual(
+        manifest.dependencies
+      );
+    }
+  });
+
+  it('bumps the examples Bedrock dependency with its provider package', () => {
+    const config = JSON.parse(
+      readFileSync(
+        path.join(repoRoot, 'src/aws-bedrock/.release-it.json'),
+        'utf8'
+      )
+    );
+    expect(config.plugins['@release-it/bumper'].out).toContainEqual({
+      file: '../examples/package.json',
+      path: ['dependencies.@ax-llm/ax-ai-aws-bedrock'],
+    });
+  });
+
   it.each([
     ['24.0.5', 'patch', '24.0.6'],
     ['24.0.5', 'minor', '24.1.0'],

--- a/src/aisdk/package.json
+++ b/src/aisdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ax-llm/ax-ai-sdk-provider",
-  "version": "24.0.17",
+  "version": "24.0.18",
   "type": "module",
   "description": "Ax AI SDK Provider for the Vercel AI SDK",
   "repository": {
@@ -36,7 +36,7 @@
   "dependencies": {
     "@ai-sdk/provider": "^4.0.0",
     "@ai-sdk/provider-utils": "^5.0.0",
-    "@ax-llm/ax": "24.0.17",
+    "@ax-llm/ax": "24.0.18",
     "ai": "^7.0.2",
     "zod": "^3.25.76"
   },

--- a/src/aws-bedrock/.release-it.json
+++ b/src/aws-bedrock/.release-it.json
@@ -9,6 +9,10 @@
         {
           "file": "../../package.json",
           "path": ["version"]
+        },
+        {
+          "file": "../examples/package.json",
+          "path": ["dependencies.@ax-llm/ax-ai-aws-bedrock"]
         }
       ]
     }

--- a/src/aws-bedrock/package.json
+++ b/src/aws-bedrock/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ax-llm/ax-ai-aws-bedrock",
-  "version": "24.0.17",
+  "version": "24.0.18",
   "type": "module",
   "description": "AWS Bedrock Provider for AX - supports Claude, GPT OSS, and Titan Embed models",
   "repository": {
@@ -42,7 +42,7 @@
   },
   "dependencies": {
     "@aws-sdk/client-bedrock-runtime": "^3.1122.0",
-    "@ax-llm/ax": "24.0.17"
+    "@ax-llm/ax": "24.0.18"
   },
   "bugs": {
     "url": "https://github.com/@ax-llm/ax/issues"

--- a/src/ax/package.json
+++ b/src/ax/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ax-llm/ax",
-  "version": "24.0.17",
+  "version": "24.0.18",
   "type": "module",
   "description": "The best library to work with LLMs",
   "repository": {

--- a/src/examples/package.json
+++ b/src/examples/package.json
@@ -27,7 +27,7 @@
   },
   "dependencies": {
     "@ax-llm/ax": "24.0.18",
-    "@ax-llm/ax-ai-aws-bedrock": "24.0.17",
+    "@ax-llm/ax-ai-aws-bedrock": "24.0.18",
     "@ax-llm/ax-tools": "24.0.18",
     "@opentelemetry/exporter-metrics-otlp-http": "^0.208.0",
     "@opentelemetry/exporter-prometheus": "^0.218.0",

--- a/src/examples/package.json
+++ b/src/examples/package.json
@@ -26,9 +26,9 @@
     "example:go": "node ../../scripts/run-example.mjs go"
   },
   "dependencies": {
-    "@ax-llm/ax": "24.0.17",
+    "@ax-llm/ax": "24.0.18",
     "@ax-llm/ax-ai-aws-bedrock": "24.0.17",
-    "@ax-llm/ax-tools": "24.0.17",
+    "@ax-llm/ax-tools": "24.0.18",
     "@opentelemetry/exporter-metrics-otlp-http": "^0.208.0",
     "@opentelemetry/exporter-prometheus": "^0.218.0",
     "@opentelemetry/exporter-trace-otlp-http": "^0.203.0",

--- a/src/tools/package.json
+++ b/src/tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ax-llm/ax-tools",
-  "version": "24.0.17",
+  "version": "24.0.18",
   "type": "module",
   "description": "Ax tools package",
   "repository": {
@@ -31,7 +31,7 @@
     "postbuild": "node ../../scripts/postbuild.js"
   },
   "dependencies": {
-    "@ax-llm/ax": "24.0.17",
+    "@ax-llm/ax": "24.0.18",
     "better-sqlite3": "^12.11.1"
   },
   "files": [


### PR DESCRIPTION
## Release 24.0.18

This PR was prepared by the protected-main release workflow.

- aligns all publishable package versions
- regenerates the checked-in AxIR packages
- updates the changelog
- creates no tag or GitHub Release before merge

After merge, successful main-branch CI publishes this release automatically.
If that automation needs recovery, publish with:

```sh
npm run release:publish -- 24.0.18
```

### Release preparation fix

CI initially failed during dependency installation: the root lockfile retained 24.0.17 and the examples still pinned the previous Bedrock provider. The lockfile and example dependency now match 24.0.18. Future preparation bumps that dependency, refreshes the lockfile, and validates clean installation before creating the release commit.

Validation: the new lockfile regression failed on the original release state and passed after repair; all 24 release workflow tests, clean-install resolution, formatting, and lint passed locally. Final-head CI verifies the complete release.
