### PR TITLE
docs(website): explain Ax benefits and core strengths

### DIFF
--- a/scripts/check-website-links.mjs
+++ b/scripts/check-website-links.mjs
@@ -358,7 +358,24 @@ try {
     const html = await readFile(file, 'utf8');
     const rel = path.relative(destination, file).replaceAll(path.sep, '/');
     if (isAcademyPage(rel)) academyHtmlFiles.push(rel);
-    for (const ref of localRefs(html)) {
+    const refs = localRefs(html);
+    if (rel === 'index.html') {
+      for (const [tag] of html.matchAll(/<a\b[^>]*>/gi)) {
+        const route = attrValue(tag, 'data-home-lang-href');
+        if (!route) continue;
+        for (const language of [
+          'typescript',
+          'python',
+          'java',
+          'cpp',
+          'go',
+          'rust',
+        ]) {
+          refs.push(`/${language}/${route}`);
+        }
+      }
+    }
+    for (const ref of new Set(refs)) {
       const target = resolveRef(file, ref);
       if (!target) continue;
       if (!(await exists(target))) {
@@ -727,35 +744,30 @@ function collectQualityFailures(rel, html, failures) {
       failures.push(`${rel}: homepage section headings must stay left-aligned`);
     }
     if (
-      !/<h1[^>]*>[\s\S]*?Stop prompting\.[\s\S]*?Start programming\.[\s\S]*?<\/h1>/.test(
+      !/<h1[^>]*>[\s\S]*?Build AI features[\s\S]*?and agents[\s\S]*?in your app\.[\s\S]*?<\/h1>/.test(
         html
       )
     ) {
-      failures.push(
-        `${rel}: homepage h1 missing programming-not-prompting hero hook`
-      );
+      failures.push(`${rel}: homepage h1 must explain what visitors can build`);
     }
-    if (
-      !/<span[^>]*\bhome-h1-line\b[^>]*>Stop prompting\.<\/span>/.test(html)
-    ) {
-      failures.push(
-        `${rel}: homepage h1 sentences must sit on their own lines (home-h1-line)`
-      );
+    if (!hasClass(firstFold, 'span', 'home-h1-line')) {
+      failures.push(`${rel}: homepage h1 missing controlled phrase breaks`);
     }
     if (html.includes('The universal way to build with LLMs')) {
       failures.push(`${rel}: homepage still has abstract universal hero`);
     }
-    if (!html.includes('hands back typed data')) {
+    if (!hasClass(firstFold, 'p', 'home-lede')) {
       failures.push(`${rel}: homepage missing newcomer lede`);
     }
     if (!hasClass(html, 'div', 'home-proof-row')) {
       failures.push(`${rel}: homepage missing proof points`);
     }
     for (const proof of [
-      'Typed, validated outputs',
-      'Agents on any model',
-      'RLM research inside',
-      'Native in your language',
+      'DSPy-style programming',
+      'RLM-powered agents',
+      'One compiled framework',
+      'Open-source AI library',
+      'Native in six languages',
     ]) {
       if (!firstFold.includes(proof)) {
         failures.push(`${rel}: homepage first fold missing ${proof}`);
@@ -765,7 +777,7 @@ function collectQualityFailures(rel, html, failures) {
       failures.push(`${rel}: homepage missing sticky language bar`);
     }
     if (!hasClass(html, 'div', 'home-proof-strip')) {
-      failures.push(`${rel}: homepage missing six-wide proof strip`);
+      failures.push(`${rel}: homepage missing shared-framework explanation`);
     }
     if (!hasClass(html, 'div', 'home-example-tabs')) {
       failures.push(`${rel}: homepage missing hero example tabs`);
@@ -818,37 +830,30 @@ function collectQualityFailures(rel, html, failures) {
     if (!hasClass(html, 'div', 'home-hero-panel')) {
       failures.push(`${rel}: homepage missing polished hero panel`);
     }
-    const researchIndex = html.indexOf('home-research-section');
-    const capabilityIndex = html.indexOf('home-capability-grid');
-    if (
-      researchIndex < 0 ||
-      capabilityIndex < 0 ||
-      researchIndex > capabilityIndex
-    ) {
-      failures.push(
-        `${rel}: homepage research section must appear before capabilities`
-      );
-    }
     if (!hasClass(html, 'div', 'home-capability-grid')) {
       failures.push(`${rel}: homepage missing capability grid`);
     }
-    if (countOccurrences(html, 'home-marketing-card') < 19) {
-      failures.push(`${rel}: homepage missing capability/production cards`);
+    for (const foundation of ['dspy', 'rlm', 'compiled']) {
+      if (
+        !hasAttributeValue(html, 'article', 'data-home-foundation', foundation)
+      ) {
+        failures.push(`${rel}: homepage missing ${foundation} explanation`);
+      }
     }
     for (const capability of [
-      'Structured generation',
-      'Signatures',
-      'Tools and MCP',
-      'Agents',
-      'Audio',
-      'Workflows',
-      'Optimization',
-      'Providers',
-      'Telemetry',
-      'Native packages',
+      'extraction',
+      'classification',
+      'answers',
+      'agents',
+      'voice',
+      'workflows',
     ]) {
-      if (!html.includes(capability)) {
-        failures.push(`${rel}: homepage missing capability ${capability}`);
+      if (
+        !hasAttributeValue(html, 'article', 'data-home-use-case', capability)
+      ) {
+        failures.push(
+          `${rel}: homepage missing practical use case ${capability}`
+        );
       }
     }
     if (!hasClass(html, 'section', 'home-audio-section')) {
@@ -989,10 +994,8 @@ function collectQualityFailures(rel, html, failures) {
     }
     for (const compilerTerm of [
       'AxIR compiler',
-      "We didn't port Ax six times. We compiled it.",
       'portable intermediate representation',
       'TypeScript is the reference runtime',
-      'native package surfaces',
       'axir verify',
     ]) {
       if (!html.includes(compilerTerm)) {
@@ -1032,10 +1035,8 @@ function collectQualityFailures(rel, html, failures) {
       'RLM',
       'PEEK',
       'context management',
-      'built-in memory',
       'skills',
-      'typed signatures',
-      'computes on your data instead of reading it',
+      'runtime session',
       'grounded-audit example',
       'Long-horizon',
       'agent.optimize',
@@ -1047,7 +1048,7 @@ function collectQualityFailures(rel, html, failures) {
     for (const feature of [
       'Discovery',
       'Context maps',
-      'Memory + skills',
+      'memory',
       'Optimization',
     ]) {
       if (!html.includes(feature)) {
@@ -1082,7 +1083,6 @@ function collectQualityFailures(rel, html, failures) {
       );
     }
     for (const providerTerm of [
-      'Use any model.',
       'OpenAI-compatible',
       'Need routing, embeddings, audio, or context caching?',
     ]) {
@@ -1095,38 +1095,55 @@ function collectQualityFailures(rel, html, failures) {
     if (!hasClass(html, 'section', 'home-graphjin')) {
       failures.push(`${rel}: homepage missing GraphJin cross-promo`);
     }
-    const codeStoryIndex = html.indexOf('home-code-story');
-    const compilerIndex = html.indexOf('home-compiler-section');
-    const agentIndex = html.indexOf('home-agent-section');
-    const graphjinIndex = html.indexOf('home-graphjin');
-    const audioIndex = html.indexOf('home-audio-section');
-    const finalCtaIndex = html.indexOf('home-final-cta');
-    if (
-      codeStoryIndex < 0 ||
-      compilerIndex < 0 ||
-      agentIndex < 0 ||
-      codeStoryIndex > compilerIndex ||
-      compilerIndex > researchIndex ||
-      researchIndex > agentIndex
-    ) {
-      failures.push(
-        `${rel}: homepage must order signatures, compiler, research, then agents`
+    const sections = [
+      ...html.matchAll(/<section\b[^>]*>[\s\S]*?<\/section>/gi),
+    ];
+    let previousSectionIndex = -1;
+    for (const sectionClass of [
+      'home-foundations',
+      'home-use-cases',
+      'home-graphjin',
+      'home-quick-install',
+      'home-code-story',
+      'home-agent-section',
+      'home-audio-section',
+      'home-optimization-section',
+      'home-model-section',
+      'home-production-section',
+      'home-compiler-section',
+      'home-research-section',
+      'home-academy-cta',
+      'home-final-cta',
+    ]) {
+      const sectionIndex = sections.findIndex((section) =>
+        hasClass(section[0], 'section', sectionClass)
       );
+      if (sectionIndex < 0 || sectionIndex <= previousSectionIndex) {
+        failures.push(
+          `${rel}: homepage section missing or out of order: ${sectionClass}`
+        );
+      }
+      previousSectionIndex = sectionIndex;
     }
-    if (
-      graphjinIndex < 0 ||
-      graphjinIndex < agentIndex ||
-      audioIndex < 0 ||
-      graphjinIndex > audioIndex ||
-      finalCtaIndex < 0 ||
-      graphjinIndex > finalCtaIndex
-    ) {
-      failures.push(
-        `${rel}: homepage must place GraphJin after agents and before audio`
-      );
+    // Explicit package badges keep their own language. Other homepage links
+    // must follow the language selected for examples and installation.
+    for (const [section] of sections) {
+      if (hasClass(section, 'section', 'home-compiler-section')) continue;
+      for (const [tag] of section.matchAll(/<a\b[^>]*>/gi)) {
+        const href = attrValue(tag, 'href');
+        if (
+          href.startsWith('/typescript/') &&
+          attrValue(tag, 'data-home-lang-href') !==
+            href.slice('/typescript/'.length)
+        ) {
+          failures.push(
+            `${rel}: homepage link does not follow selected language: ${href}`
+          );
+        }
+      }
     }
-    if (!html.includes('GraphJin runs on Ax')) {
-      failures.push(`${rel}: homepage missing GraphJin case-study heading`);
+    if (!html.includes('Connect your databases to AI with GraphJin')) {
+      failures.push(`${rel}: homepage missing database benefit heading`);
     }
     if (html.includes('Also checkout')) {
       failures.push(`${rel}: homepage still uses the old GraphJin cross-promo`);

--- a/website/content/_index.md
+++ b/website/content/_index.md
@@ -1,6 +1,6 @@
 ---
 title: "Ax"
-description: "Stop prompting. Start programming. Typed signatures become reliable LLM calls and RLM-grade agents — validated, streamed, optimized — native in TypeScript, Python, Java, C++, Go, and Rust."
+description: "Build AI features and agents with DSPy-style programming, RLM agents, and one compiled framework. Native libraries for TypeScript, Python, Java, C++, Go, and Rust."
 ---
 
 <!-- Shortcode calls must start at column 0: Hugo re-indents shortcode output
@@ -8,34 +8,36 @@ description: "Stop prompting. Start programming. Typed signatures become reliabl
      scripts/check-website-links.mjs enforces this on the built HTML. -->
 
 <div data-home-language-root data-active-language="typescript">
+
 <section class="home-hero">
 <div class="home-hero-copy">
-  <p class="home-kicker">Ax</p>
-  <h1><span class="home-h1-line">Stop prompting.</span> <span class="home-h1-line">Start programming.</span></h1>
-  <p class="home-lede">A one-line signature declares what goes in and what comes out — Ax turns it into the prompt, the parser, the validators, and the retry loop, and hands back typed data your code can trust. The same contract scales from one typed call to RLM-grade agents on any model — native in <strong class="home-lede-lang"><span data-home-lang-text="typescript" data-home-active="true">TypeScript</span><span data-home-lang-text="python" data-home-active="false" aria-hidden="true">Python</span><span data-home-lang-text="java" data-home-active="false" aria-hidden="true">Java</span><span data-home-lang-text="cpp" data-home-active="false" aria-hidden="true">C++</span><span data-home-lang-text="go" data-home-active="false" aria-hidden="true">Go</span><span data-home-lang-text="rust" data-home-active="false" aria-hidden="true">Rust</span></strong>, and five more languages.</p>
+  <p class="home-kicker">DSPy-style programming. RLM-powered agents. One compiled framework.</p>
+  <h1><span class="home-h1-line">Build AI features</span> <span class="home-h1-line">and agents</span> <span class="home-h1-line">in your app.</span></h1>
+  <p class="home-lede">Define the inputs and outputs. Improve results using examples and evaluations. Build agents that work through data and tools using code. One shared framework brings it all to <strong>TypeScript, Python, Java, C++, Go, and Rust.</strong></p>
   <div class="home-proof-row" aria-label="Ax highlights">
-    <span><i class="home-proof-dot proof-blue" aria-hidden="true"></i>Typed, validated outputs</span>
-    <span><i class="home-proof-dot proof-violet" aria-hidden="true"></i>Agents on any model — even small local ones</span>
-    <span><i class="home-proof-dot proof-teal" aria-hidden="true"></i>DSPy · GEPA · ACE · RLM research inside</span>
-    <span><i class="home-proof-dot proof-green" aria-hidden="true"></i>Native in your language — six supported</span>
+    <span><i class="home-proof-dot proof-blue" aria-hidden="true"></i>Open-source AI library</span>
+    <span><i class="home-proof-dot proof-violet" aria-hidden="true"></i>Validated outputs</span>
+    <span><i class="home-proof-dot proof-teal" aria-hidden="true"></i>Cloud and local models</span>
+    <span><i class="home-proof-dot proof-green" aria-hidden="true"></i>Native in six languages</span>
   </div>
   <div class="home-actions">
-    <a href="/typescript/quick-start/" data-home-lang-href="quick-start/">Get started — 5 min</a>
+    <a href="/typescript/quick-start/" data-home-lang-href="quick-start/">Build your first AI feature</a>
     <a class="home-button-secondary" href="https://github.com/ax-llm/ax">GitHub</a>
     <div class="home-hero-stats" data-home-stats data-repo="ax-llm/ax" data-npm-package="@ax-llm/ax" aria-label="Project stats">
       <a href="https://github.com/ax-llm/ax" hidden><strong data-stat="stars"></strong><span>GitHub stars</span></a>
       <a href="https://www.npmjs.com/package/@ax-llm/ax" hidden><strong data-stat="downloads"></strong><span>npm downloads/week</span></a>
     </div>
   </div>
-  <p class="home-skills-note">Coding with AI? <a href="/typescript/skills/" data-home-lang-href="skills/">Install the Ax skills</a> — Claude Code, Cursor, and other agents write correct Ax in all six languages.</p>
+  <p class="home-skills-note">Coding with AI? <a href="/typescript/skills/" data-home-lang-href="skills/">Install the Ax skills</a> — give Claude Code, Cursor, and other coding assistants the Ax API guide for your language.</p>
 </div>
-<div class="home-hero-panel" aria-label="Ax signature runtime preview">
+<div class="home-hero-panel" aria-label="Example AI task and result">
   <div class="home-example-tabs" role="tablist" aria-label="Hero example">
-    <button type="button" role="tab" data-home-example-tab="classifier" aria-selected="true">Typed call</button>
-    <button type="button" role="tab" data-home-example-tab="agent" aria-selected="false">Agent</button>
+    <button type="button" role="tab" data-home-example-tab="classifier" aria-selected="true">Classify a review</button>
+    <button type="button" role="tab" data-home-example-tab="agent" aria-selected="false">Analyze a ledger</button>
   </div>
 {{< home-code topics="classifier,agent" group="hero" >}}
-{{< home-output topics="classifier,agent" title="Typed output" >}}
+{{< home-output topics="classifier,agent" title="Example result" >}}
+  <p class="home-inline-note">Abridged examples. <a href="/typescript/quick-start/" data-home-lang-href="quick-start/">Run your first complete program</a> or <a href="/typescript/agents/performance/" data-home-lang-href="agents/performance/">explore the ledger audit</a>.</p>
 </div>
 </section>
 
@@ -44,35 +46,113 @@ description: "Stop prompting. Start programming. Typed signatures become reliabl
 {{< home-language-controls variant="hero" >}}
 </div>
 
-<div class="home-proof-strip" aria-label="Ax ships six-wide">
-  <p><strong>One core ships everything six-wide:</strong> 220+ runnable examples · 60+ docs pages per language, kept in lockstep · 15 agent skills per language · 1,000+ tests · 15+ providers · Apache-2.0</p>
+<div class="home-proof-strip" aria-label="Ax libraries and examples">
+  <p><strong>One framework, native in six languages.</strong> Switch the language to see the same task in its native API. Runnable examples, documentation, and package checks are maintained together.</p>
 </div>
 
-<section class="home-section home-academy-cta" aria-labelledby="home-academy-title">
-<article class="home-editorial-callout">
+<section class="home-section home-foundations" aria-labelledby="why-ax">
+<div class="home-section-heading">
+  <p class="home-section-label">Why Ax?</p>
+  <h2 id="why-ax">Program it. Give it tools. Use it across your stack.</h2>
+  <p>Ax combines three ideas that help you grow from a first AI feature to agents working with real data.</p>
+</div>
+<div class="home-card-grid three-up">
+  <article class="home-marketing-card" data-home-foundation="dspy">
 {{< home-icon "list-checks" "icon-violet" >}}
-  <div class="home-editorial-callout-copy">
-    <p class="home-section-label">Ax Academy</p>
-    <h2 id="home-academy-title">Learn Ax through an adaptive knowledge path.</h2>
-    <p>A free course — about six hours end to end, entirely in your browser. Start with a diagnostic, build mastery through short scaffolded lessons, and strengthen due concepts with interleaved spaced review.</p>
+    <p class="home-card-eyebrow">DSPy-style programming</p>
+    <h3>Program and improve your AI.</h3>
+    <p>Define what a task receives and returns. Ax builds the prompt, validates the response, and lets you optimize instructions and examples against your evaluations — tests that score how well the task works.</p>
+    <a class="home-card-link" href="/typescript/concepts/dspy/" data-home-lang-href="concepts/dspy/">How DSPy-style programming works</a>
+  </article>
+  <article class="home-marketing-card" data-home-foundation="rlm">
+{{< home-icon "brain" "icon-teal" >}}
+    <p class="home-card-eyebrow">RLM agents</p>
+    <h3>Give agents data they can work with.</h3>
+    <p>Following the Recursive Language Model approach, agents run small code steps to inspect data, calculate results, and use tools. Large inputs stay in the runtime; selected evidence enters the model's context.</p>
+    <a class="home-card-link" href="/typescript/agents/" data-home-lang-href="agents/">See how RLM agents work</a>
+  </article>
+  <article class="home-marketing-card" data-home-foundation="compiled">
+{{< home-icon "languages" "icon-blue" >}}
+    <p class="home-card-eyebrow">One compiled framework</p>
+    <h3>Learn once. Use it across your stack.</h3>
+    <p>One shared core brings consistent concepts and checked behavior to TypeScript, Python, Java, C++, Go, and Rust. Native libraries fit each language, so teams can use Ax in the applications they already have.</p>
+    <a class="home-card-link" href="#compiler-ir">How one framework becomes six libraries</a>
+  </article>
+</div>
+</section>
+
+<section class="home-section home-use-cases" aria-labelledby="included">
+<div class="home-section-heading">
+  <p class="home-section-label">What can you build?</p>
+  <h2 id="included">Start with something useful.</h2>
+  <p>Add one AI feature to your app, then combine it with tools and other steps as your needs grow.</p>
+</div>
+<div class="home-capability-grid">
+  <article class="home-marketing-card" data-home-use-case="extraction">{{< home-icon "file-text" "icon-teal" >}}<h3>Turn documents into usable data</h3><p>Extract names, dates, and amounts from text into fields your application can use.</p><a class="home-card-link" href="/typescript/examples/generation/" data-home-lang-href="examples/generation/">Try structured extraction</a></article>
+  <article class="home-marketing-card" data-home-use-case="classification">{{< home-icon "tags" "icon-violet" >}}<h3>Sort messages automatically</h3><p>Categorize incoming requests, customer feedback, or reviews using the labels you choose.</p><a class="home-card-link" href="/typescript/quick-start/" data-home-lang-href="quick-start/">Build a classifier</a></article>
+  <article class="home-marketing-card" data-home-use-case="answers">{{< home-icon "message-circle" "icon-green" >}}<h3>Answer questions using your content</h3><p>Give the model relevant documents and a question to build an assistant for your own content.</p><a class="home-card-link" href="/typescript/examples/generation/" data-home-lang-href="examples/generation/">Explore question answering</a></article>
+  <article class="home-marketing-card" data-home-use-case="agents">{{< home-icon "bot" "icon-blue" >}}<h3>Build assistants that use your tools</h3><p>Let an agent look up information, calculate results, and work through several steps to answer a request.</p><a class="home-card-link" href="/typescript/agents/micro/" data-home-lang-href="agents/micro/">Build your first agent</a></article>
+  <article class="home-marketing-card home-audio-card" data-home-use-case="voice">{{< home-icon "activity" "icon-amber" >}}<h3>Add voice to your app</h3><p>Turn recordings into text, generate spoken responses, or add a voice conversation.</p><a class="home-card-link" href="/typescript/examples/#llm-media" data-home-lang-href="examples/#llm-media">Explore voice examples</a></article>
+  <article class="home-marketing-card" data-home-use-case="workflows">{{< home-icon "list-checks" "icon-teal" >}}<h3>Automate a sequence of tasks</h3><p>Extract information, analyze it, and produce a report. Use workflows to connect steps, branches, and parallel work.</p><a class="home-card-link" href="/typescript/subsystems/flow/" data-home-lang-href="subsystems/flow/">Build a workflow</a></article>
+</div>
+</section>
+
+<section id="graphjin" class="home-section home-graphjin" aria-labelledby="graphjin-title">
+<div class="home-graphjin-header">
+  <div class="home-graphjin-heading">
+    <p class="home-section-label">AI for your databases</p>
+    <h2 id="graphjin-title">Connect your databases to AI with GraphJin.</h2>
+    <p>Ask questions across your databases in plain English. GraphJin connects the data and enforces configured access rules; its built-in agent uses Ax to investigate questions and assemble answers.</p>
   </div>
-  <div class="home-actions home-editorial-callout-actions"><a href="/typescript/academy/" data-home-lang-href="academy/">Start Ax Academy</a></div>
-</article>
+  <div class="home-actions home-graphjin-actions">
+    <a href="https://graphjin.com/start/demos/">Try GraphJin with sample data</a>
+    <a class="home-button-secondary" href="https://graphjin.com/agentic/server-agent/">How GraphJin uses Ax</a>
+  </div>
+</div>
+<p class="home-inline-note">Already using Claude Code? These commands connect it to a GraphJin demo with sample data. Connecting your own databases requires a separate GraphJin configuration.</p>
+<div class="home-graphjin-demo">
+  <div class="home-graphjin-command-row" aria-label="GraphJin setup commands">
+    <div class="home-graphjin-command" aria-label="Install GraphJin"><span>$</span><code><span class="home-install-command">npm install -g graphjin</span></code></div>
+    <div class="home-graphjin-command" aria-label="Add GraphJin as an MCP server"><span>$</span><code><span class="home-install-command">claude mcp add graphjin -- graphjin mcp --demo</span></code></div>
+  </div>
+  <div class="home-graphjin-terminal" aria-label="GraphJin demo conversation">
+    <div class="home-panel-title">Example question and answer</div>
+<pre><code>Q: which customers churned last month,
+   and what did they have in common?&#10;
+A: 9 of 12 churned accounts were on the Starter plan.
+   7 opened a support ticket in their final 30 days.
+   Median tenure: 4 months.</code></pre>
+  </div>
+</div>
+<div class="home-graphjin-status">
+  <span aria-hidden="true"></span>
+  <p>Queries checked against the schema · configured access rules enforced</p>
+  <a href="https://github.com/dosco/graphjin">GraphJin source code</a>
+</div>
+<div class="home-graphjin-proof">
+  <div class="home-graphjin-proof-heading">
+    <p class="home-section-label">Proof, in public</p>
+    <h3>DeepORG benchmark</h3>
+    <a href="https://graphjin.com/benchmark/">Read the published results</a>
+  </div>
+  <p class="home-inline-note">GraphJin publishes task results, costs, and safety checks with the models and methodology used. Read the current report to see what was tested.</p>
+</div>
 </section>
 
 <section class="home-section home-quick-install" aria-labelledby="quick-install">
 <div class="home-section-heading">
   <p class="home-section-label">Get started</p>
   <h2 id="quick-install">Quick install</h2>
-  <p>Just want the package? One Ax programming model, six languages — pick yours and drop it in.</p>
+  <p>Pick your language and install its native library. The quick start walks you through setting a model API key and running your first program.</p>
 </div>
 <div class="home-quick-install-bar">
 {{< home-language-controls >}}
 </div>
 {{< home-install >}}
+<p class="home-inline-note"><a href="/typescript/quick-start/" data-home-lang-href="quick-start/">Set up your API key and run the first example</a>.</p>
 <div class="home-agent-strip">
-  <h3>Your coding agent already knows Ax</h3>
-  <p>Ax ships installable, versioned <strong>skills</strong> for every language: instruction files that teach Claude Code, Cursor, and other coding agents exactly how the Ax API works — so your agent writes correct Ax instead of guessing at it. One command points it at them.</p>
+  <h3>Help your coding agent write Ax</h3>
+  <p>Ax includes <strong>skills</strong>: instruction files that give Claude Code, Cursor, and other coding assistants the API guide and examples for your chosen language. Install them alongside Ax to help your assistant use the library.</p>
 {{< home-install field="skillsCommand" class="home-install-skills" label="Install Ax agent skills" >}}
   <a class="home-agent-strip-link" href="/typescript/skills/" data-home-lang-href="skills/">Browse agent skills</a>
 </div>
@@ -80,14 +160,14 @@ description: "Stop prompting. Start programming. Typed signatures become reliabl
 
 <section class="home-section home-code-story home-chapter-start" aria-labelledby="why-signatures">
 <div class="home-section-heading">
-  <p class="home-section-label">Why signatures?</p>
+  <p class="home-section-label">Your first AI call · DSPy</p>
   <h2 id="why-signatures">Describe the input and output. Ax handles the model call.</h2>
-  <p>The hero demo is the whole philosophy. A signature says what data the model receives and what typed data your app expects back. Ax uses that one contract to render prompts, call providers, parse output, validate constraints, retry with feedback, stream partial results, record traces, seed examples, and optimize behavior later.</p>
+  <p>A signature is a short description of the inputs you provide and the outputs you want. In the review example, text goes in and a sentiment label comes back. This is the DSPy-style starting point: define the task, then test and improve how it performs.</p>
 </div>
 <div class="home-resource-row home-resource-row-tight">
   <div>
-    <h3>The contract becomes the system boundary.</h3>
-    <p>Instead of spreading prompt text, JSON parsing, retry logic, tool schemas, tracing, and eval metadata across your app, Ax hangs them from the signature.</p>
+    <h3>Get results your app can use.</h3>
+    <p>Ax parses the response into fields, checks their types and constraints, and can retry with feedback when validation fails. These checks enforce the requested format; evaluate the answers too when correctness matters.</p>
     <div class="home-badge-row"><span>Validation</span><span>Streaming</span><span>Tools</span><span>Traces</span><span>Optimization</span></div>
   </div>
   <div>
@@ -97,11 +177,233 @@ description: "Stop prompting. Start programming. Typed signatures become reliabl
 <div class="home-resource-row home-resource-row-tight">
   <div>
     <p class="home-section-label">Signature pipeline</p>
-    <h3>One line becomes a running pipeline.</h3>
-    <p>The signature you write is lowered into prompt rendering, streaming parsers, validators, retry feedback, and trace metadata — the same pipeline that produced the typed output above.</p>
+    <h3>Ax handles the steps around the model call.</h3>
+    <p>Your signature supplies the prompt fields and output checks. Ax calls the model, reads its response, and returns the declared fields. You can also stream results and inspect the steps when something goes wrong.</p>
   </div>
   <div>
 {{< svg "signature-runtime" "Signature to runtime pipeline" >}}
+  </div>
+</div>
+<div class="home-signature-grid">
+  <article class="home-code-card">
+    <div class="home-card-icon icon-violet" aria-hidden="true">S</div>
+    <h3>Signature syntax</h3>
+{{< home-code topic="signatureString" group="signature-string" compact="true" label="Signature syntax" >}}
+    <p>Name the inputs and outputs in one line. Use arrays, dates, numbers, and other field types to describe the result you need.</p>
+  </article>
+  <article class="home-code-card">
+    <div class="home-card-icon icon-teal" aria-hidden="true">F</div>
+    <h3>Fields and constraints</h3>
+{{< home-code topic="signatureFluent" group="signature-fluent" compact="true" label="Fields and constraints" >}}
+    <p>Build a signature in code when you need rules such as a maximum summary length or a list of tags.</p>
+  </article>
+  <article class="home-code-card">
+    <div class="home-card-icon icon-blue" aria-hidden="true">Z</div>
+    <h3>Structured schema output</h3>
+{{< home-code topic="signatureSchema" group="signature-schema" compact="true" label="Structured schema output" >}}
+    <p>Use a supported schema builder to define the output shape and constraints, such as a score from one to ten.</p>
+  </article>
+</div>
+</section>
+
+<section class="home-section" aria-labelledby="declare-capabilities">
+<div class="home-section-heading">
+  <p class="home-section-label">Patterns</p>
+  <h2 id="declare-capabilities">Small tasks start with a few fields.</h2>
+  <p>These signature examples describe a task’s inputs and outputs. Run the program with a model and input values, as shown in the quick start. Choose your language to see the equivalent syntax.</p>
+</div>
+<div class="home-pattern-grid">
+  <article>{{< home-icon "tags" "icon-violet" >}}<h3>Classification</h3><p>Categorize text into predefined classes.</p>
+{{< home-code topic="patterns.classification" group="pattern-classification" compact="true" label="Classification" >}}
+  </article>
+  <article>{{< home-icon "file-text" "icon-teal" >}}<h3>Extraction</h3><p>Pull structured data from unstructured text.</p>
+{{< home-code topic="patterns.extraction" group="pattern-extraction" compact="true" label="Extraction" >}}
+  </article>
+  <article>{{< home-icon "message-circle" "icon-green" >}}<h3>Question answering</h3><p>Answer questions with provided context.</p>
+{{< home-code topic="patterns.qa" group="pattern-qa" compact="true" label="Question answering" >}}
+  </article>
+  <article>{{< home-icon "image" "icon-amber" >}}<h3>Ask about an image</h3><p>Provide a photo and a question about it.</p>
+{{< home-code topic="patterns.multimodal" group="pattern-multimodal" compact="true" label="Image questions" >}}
+  </article>
+  <article>{{< home-icon "shield" "icon-rust" >}}<h3>Make a decision</h3><p>Ask the model for a yes-or-no result based on the inputs.</p>
+{{< home-code topic="patterns.decision" group="pattern-decision" compact="true" label="Decision" >}}
+  </article>
+  <article>{{< home-icon "zap" "icon-blue" >}}<h3>Generate text</h3><p>Turn a topic into text. Use the streaming API to receive it incrementally.</p>
+{{< home-code topic="patterns.generation" group="pattern-generation" compact="true" label="Text generation" >}}
+  </article>
+  <article>{{< home-icon "languages" "icon-violet" >}}<h3>Translation</h3><p>Translate text into the language you request.</p>
+{{< home-code topic="patterns.translation" group="pattern-translation" compact="true" label="Translation" >}}
+  </article>
+  <article>{{< home-icon "list-checks" "icon-teal" >}}<h3>Summarize a document</h3><p>Return a summary and key points from one task.</p>
+{{< home-code topic="patterns.summarization" group="pattern-summarization" compact="true" label="Summarization" >}}
+  </article>
+</div>
+</section>
+
+<section class="home-section home-agent-section home-chapter-start" aria-labelledby="agents-that-work">
+<div class="home-section-heading home-agent-heading">
+  <p class="home-section-label">Agents · RLM</p>
+  <h2 id="agents-that-work">Build agents that work through data and tools.</h2>
+  <p>An agent works through a task over several steps. Ax uses the RLM approach: the agent writes and runs code against data and tools, then uses the results to decide what to do next. Large inputs can stay in its runtime session, with selected evidence passed to the model.</p>
+  <p>Try the <a href="https://github.com/ax-llm/ax/blob/main/src/examples/agent-grounded-audit.ts">grounded-audit example</a>: an agent audits a 250-row ledger and checks its totals and flagged transactions against an answer calculated in ordinary code. The published results describe this specific task and the models tested. <a href="/typescript/agents/performance/" data-home-lang-href="agents/performance/">See the measurements</a>.</p>
+</div>
+<div class="home-card-grid three-up home-agent-tier-grid">
+  <article class="home-marketing-card home-agent-tier-card">{{< home-icon "zap" "icon-blue" >}}<h3>Answer using a few tools <span>Micro agents</span></h3><p>Start with a small task, the functions it needs, and the fields you want in the reply.</p><p><a href="/typescript/agents/micro/" data-home-lang-href="agents/micro/">Micro agents</a></p></article>
+  <article class="home-marketing-card home-agent-tier-card">{{< home-icon "bot" "icon-teal" >}}<h3>Coordinate tools and specialists <span>Standard agents</span></h3><p>Let an agent find relevant tools, delegate work to specialist agents, and ask for clarification.</p><p><a href="/typescript/agents/standard/" data-home-lang-href="agents/standard/">Standard agents</a></p></article>
+  <article class="home-marketing-card home-agent-tier-card">{{< home-icon "brain" "icon-green" >}}<h3>Work through larger tasks <span>Long-horizon agents</span></h3><p>Keep useful state, memory, and instructions available as an agent works through a longer job.</p><p><a href="/typescript/agents/long-horizon/" data-home-lang-href="agents/long-horizon/">Long-horizon agents</a></p></article>
+</div>
+<div class="home-agent-code">
+{{< home-code topic="agent" group="agent" >}}
+</div>
+<div class="home-agent-layout">
+  <div class="home-chart-panel">
+{{< svg "rlm-loop" "RLM loop" >}}
+  </div>
+  <div class="home-agent-feature-grid">
+    <article><h3>Find the right tools</h3><p>Discovery lets the agent load the tools it needs as it works, even when many are available.</p></article>
+    <article><h3>Keep track of the task</h3><p>Context maps and summaries help the agent find relevant information without rereading the whole conversation.</p></article>
+    <article><h3>Reuse useful knowledge</h3><p>Add memory for information worth recalling and skills for instructions the agent can use again.</p></article>
+    <article><h3>Improve against your tests</h3><p>Use <code>agent.optimize(...)</code> with examples and scoring criteria to evaluate changes to agent behavior.</p></article>
+  </div>
+</div>
+<div class="home-resource-row home-resource-row-tight">
+  <div>
+    <p class="home-section-label">Function discovery</p>
+    <h3>Connect tools and specialist agents as the job grows.</h3>
+    <p>Group related tools and give specialist agents focused jobs. The main agent can discover those capabilities when it needs them.</p>
+  </div>
+  <div>
+{{< svg "agent-tree" "Agent function discovery tree" >}}
+  </div>
+</div>
+<div class="home-resource-row home-resource-row-tight">
+  <div>
+    <p class="home-section-label">Context policy</p>
+    <h3>Keep the work available between steps.</h3>
+    <p>Store intermediate results in the runtime and use summaries to track progress. Context policies control how much of the conversation the model sees on later turns.</p>
+  </div>
+  <div>
+{{< svg "context-growth" "Context growth chart" >}}
+  </div>
+</div>
+<div class="home-resource-row home-resource-row-tight">
+  <div>
+    <p class="home-section-label">MCP and tools</p>
+    <h3>Connect your AI to tools and services.</h3>
+    <p>Tools let your AI call functions in your application. MCP (Model Context Protocol) is a standard way to connect tools from other services. Ax can use both in a task or an agent.</p>
+    <p><a href="/typescript/concepts/mcp/" data-home-lang-href="concepts/mcp/">Read the MCP guide</a> or <a href="/typescript/concepts/tools/" data-home-lang-href="concepts/tools/">open the tools guide</a>.</p>
+  </div>
+  <div>
+{{< svg "mcp-bridge" "MCP bridge" >}}
+  </div>
+</div>
+<div class="home-actions home-section-actions">
+  <a href="/typescript/agents/" data-home-lang-href="agents/">Build an agent</a>
+  <a class="home-button-secondary" href="/typescript/agents/performance/" data-home-lang-href="agents/performance/">Performance &amp; measurements</a>
+  <a class="home-button-secondary" href="/typescript/concepts/optimization/" data-home-lang-href="concepts/optimization/">Optimization guide</a>
+</div>
+</section>
+
+<section class="home-section home-audio-section" aria-labelledby="audio">
+<div class="home-section-heading">
+  <p class="home-section-label">Audio</p>
+  <h2 id="audio">Build text, voice, and realtime AI apps.</h2>
+  <p>Turn recordings into transcripts, generate spoken responses, or build a voice conversation. Choose a model and audio API that support the experience you need.</p>
+</div>
+<div class="home-resource-row home-resource-row-tight">
+  <div>
+    <h3>Choose what your app needs to hear or say.</h3>
+    <ul class="home-method-list">
+      <li><code>ai.transcribe(...)</code> for batch speech-to-text.</li>
+      <li><code>ai.speak(...)</code> for batch text-to-speech.</li>
+      <li><code>speech:audio</code> for a program that returns generated speech alongside other fields.</li>
+      <li><code>.chat()</code> audio config for conversational or realtime audio turns.</li>
+      <li>Agents can transcribe audio inputs and work with the resulting text.</li>
+    </ul>
+    <p><a href="/typescript/concepts/llms/" data-home-lang-href="concepts/llms/">Read the LLM guide</a> or <a href="/typescript/examples/#llm-media" data-home-lang-href="examples/#llm-media">open media examples</a>.</p>
+  </div>
+  <div>
+{{< home-code topic="audio" group="audio" >}}
+  </div>
+</div>
+<div class="home-card-grid three-up">
+  <article class="home-marketing-card">{{< home-icon "activity" "icon-blue" >}}<h3>Transcribe and speak</h3><p>Turn a recording into text or generate an audio file from a written response.</p></article>
+  <article class="home-marketing-card">{{< home-icon "message-circle" "icon-teal" >}}<h3>Conversational audio</h3><p>Build a spoken conversation using a provider’s supported audio chat or realtime API.</p></article>
+  <article class="home-marketing-card">{{< home-icon "brain" "icon-green" >}}<h3>Agent audio</h3><p>Give an agent a recording to work from and return a spoken response.</p></article>
+</div>
+</section>
+
+<section class="home-section home-optimization-section" aria-labelledby="optimize-frontiers">
+<div class="home-section-heading">
+  <p class="home-section-label">Improve with evaluations · DSPy</p>
+  <h2 id="optimize-frontiers">Improve your AI against examples of good results.</h2>
+  <p>Give Ax example tasks and a way to score the results. Its optimizers test changes to instructions and examples so you can compare answer quality, speed, and cost. This is the next step in DSPy-style programming: improve the program against evaluations you control.</p>
+</div>
+<div class="home-resource-row home-resource-row-tight">
+  <div>
+    <h3>Choose the results that fit your app.</h3>
+    <p>GEPA searches for useful tradeoffs rather than one score alone. Compare the candidates, evaluate the one you choose on fresh tasks, and save its configuration for reuse. Optimization is an explicit training step; it does not happen automatically on every request.</p>
+    <p><a href="/typescript/concepts/optimization/" data-home-lang-href="concepts/optimization/">Read optimization docs</a> or <a href="/typescript/api/optimize/" data-home-lang-href="api/optimize/">open the optimize API</a>.</p>
+  </div>
+  <div>
+{{< svg "pareto-frontier" "GEPA Pareto frontier" >}}
+  </div>
+</div>
+</section>
+
+<section class="home-section home-model-section" aria-labelledby="use-any-model">
+<div class="home-section-heading">
+  <p class="home-section-label">LLM providers</p>
+  <h2 id="use-any-model">Choose the model that fits your app.</h2>
+  <p>Use OpenAI, Claude, Gemini, or a supported local model through <code>ai()</code>. Keep your task’s inputs and outputs while trying different models. Available features, such as voice, depend on the provider.</p>
+</div>
+<div class="home-provider-layout home-provider-layout-simple">
+  <div>
+    <div class="home-provider-strip" aria-label="Supported provider examples">
+      <span>OpenAI</span>
+      <span>Claude</span>
+      <span>Gemini</span>
+      <span>OpenAI-compatible</span>
+      <span>Local</span>
+    </div>
+{{< home-code topic="provider" group="provider" compact="true" label="Provider setup" >}}
+    <p class="home-inline-note">Need routing, embeddings, audio, or context caching? <a href="/typescript/concepts/llms/" data-home-lang-href="concepts/llms/">Read the LLM guide</a>.</p>
+  </div>
+  <div class="home-provider-visual">
+{{< svg "provider-router" "Provider router map" >}}
+  </div>
+</div>
+</section>
+
+<section class="home-section home-production-section" aria-labelledby="production-ready">
+<div class="home-section-heading">
+  <p class="home-section-label">Understand your app in production</p>
+  <h2 id="production-ready">See what happened and what it cost.</h2>
+  <p>Follow model calls and tool use, investigate errors, and track response times and estimated costs. Ax integrates with OpenTelemetry so you can inspect AI work alongside the rest of your application.</p>
+</div>
+<div class="home-stats" aria-label="Ax production highlights">
+  <div><strong>1000+</strong><span>tests</span></div>
+  <div><strong>40+</strong><span>OTel metrics</span></div>
+  <div><strong>15+</strong><span>LLM providers</span></div>
+  <div><strong>6</strong><span>languages</span></div>
+</div>
+<div class="home-card-grid production-grid">
+  <article class="home-marketing-card">{{< home-icon "activity" "icon-blue" >}}<h3>Follow a request</h3><p>OpenTelemetry traces connect model calls, tool calls, and agent steps.</p></article>
+  <article class="home-marketing-card">{{< home-icon "bar-chart" "icon-teal" >}}<h3>Spot slow or failing steps</h3><p>Track response times, token usage, and errors as your app runs.</p></article>
+  <article class="home-marketing-card">{{< home-icon "zap" "icon-violet" >}}<h3>Show results as they arrive</h3><p>Stream output fields and check their format and constraints with validation and retry feedback.</p></article>
+  <article class="home-marketing-card">{{< home-icon "dollar" "icon-green" >}}<h3>Track estimated costs</h3><p>See the estimated model cost of a request and compare it with answer quality.</p></article>
+  <article class="home-marketing-card">{{< home-icon "globe" "icon-amber" >}}<h3>Work across your stack</h3><p>Use the shared Ax programming model from each of the six native libraries.</p></article>
+  <article class="home-marketing-card">{{< home-icon "shield" "icon-rust" >}}<h3>Control how requests run</h3><p>Configure rate limits, provider routing, redaction, and error handling for your app.</p></article>
+</div>
+<div class="home-resource-row home-resource-row-tight">
+  <div>
+    <p class="home-section-label">Operate Ax systems</p>
+    <h3>Trace a result back to the steps that produced it.</h3>
+    <p>Use the telemetry guide to connect Ax’s traces and metrics to your monitoring tools.</p>
+    <p><a href="/typescript/concepts/telemetry/" data-home-lang-href="concepts/telemetry/">Read telemetry docs</a>.</p>
+  </div>
+  <div>
+{{< svg "production-loop" "Production telemetry loop" >}}
   </div>
 </div>
 </section>
@@ -109,34 +411,14 @@ description: "Stop prompting. Start programming. Typed signatures become reliabl
 <section class="home-section home-compiler-section" aria-labelledby="compiler-ir">
 <div class="home-section-heading">
   <p class="home-section-label">AxIR compiler</p>
-  <h2 id="compiler-ir">We didn't port Ax six times. We compiled it.</h2>
-  <p>Ax is built around a portable intermediate representation. TypeScript is the reference runtime; the AxIR compiler lowers signatures, schemas, providers, generators, agents, flows, MCP, and optimizers into one shared semantic core — then emits native package surfaces for Python, Java, C++, Go, and Rust. Native names, native errors, native builders. Same behavior.</p>
-</div>
-<div class="home-signature-grid">
-  <article class="home-code-card">
-    <div class="home-card-icon icon-violet" aria-hidden="true">S</div>
-    <h3>Signature syntax</h3>
-{{< home-code topic="signatureString" group="signature-string" compact="true" label="Signature syntax" >}}
-    <p>String signatures become AxIR contracts that the compiler can lower into prompts, schemas, validators, examples, traces, and typed outputs.</p>
-  </article>
-  <article class="home-code-card">
-    <div class="home-card-icon icon-teal" aria-hidden="true">F</div>
-    <h3>Field schema IR</h3>
-{{< home-code topic="signatureFluent" group="signature-fluent" compact="true" label="Field schema IR" >}}
-    <p>Fluent fields, media types, arrays, enums, constraints, and validators preserve field semantics across native packages.</p>
-  </article>
-  <article class="home-code-card">
-    <div class="home-card-icon icon-blue" aria-hidden="true">Z</div>
-    <h3>Structured schema output</h3>
-{{< home-code topic="signatureSchema" group="signature-schema" compact="true" label="Structured schema output" >}}
-    <p>Schema-backed output keeps generated code aligned with the same parse, retry, docs, telemetry, and optimization contract.</p>
-  </article>
+  <h2 id="compiler-ir">One framework, compiled into native libraries.</h2>
+  <p>TypeScript is the reference runtime. The AxIR compiler represents shared Ax behavior in a portable intermediate representation and emits native libraries for Python, Java, C++, Go, and Rust. Each library uses its language’s own names, errors, and builders, with shared checks for supported behavior.</p>
 </div>
 <div class="home-resource-row home-resource-row-tight">
   <div>
     <p class="home-section-label">Compiler pipeline</p>
-    <h3>TypeScript reference runtime -> AxIR -> native APIs.</h3>
-    <p>The package compiler emits language-shaped APIs instead of transpiling TypeScript. Each backend keeps native names, errors, builders, callbacks, transports, and runtime profiles while sharing the same Ax semantics.</p>
+    <h3>Shared behavior. APIs that fit your language.</h3>
+    <p>Use Ax in a Python service, a TypeScript app, or a Go backend while working with the same concepts. The compiler emits APIs shaped for each language from the shared core.</p>
   </div>
   <div>
 {{< svg "axir-compiler" "AxIR compiler pipeline" >}}
@@ -144,9 +426,9 @@ description: "Stop prompting. Start programming. Typed signatures become reliabl
 </div>
 <div class="home-resource-row home-resource-row-tight">
   <div>
-    <p class="home-section-label">Conformance gate</p>
-    <h3>Capability manifests keep every backend honest.</h3>
-    <p>Generated package examples, API metadata, capability manifests, and conformance fixtures are checked by <code>axir verify</code>. That is why the language switcher in the hero is a demo, not a promise — every backend earns its place in the matrix.</p>
+    <p class="home-section-label">Verified across languages</p>
+    <h3>Language support comes with checks you can inspect.</h3>
+    <p>The <code>axir verify</code> checks cover generated packages and their shared behavior. Runnable examples, documentation, and capability manifests show what each language supports, including differences in host runtimes and transports.</p>
   </div>
   <div>
 {{< svg "language-matrix" "Language package matrix" >}}
@@ -155,16 +437,11 @@ description: "Stop prompting. Start programming. Typed signatures become reliabl
 {{< backend-badges >}}
 </section>
 
-<div class="home-maintainer-cta">
-  <p>Built by <strong>@dosco</strong> — follow on X for new releases and to chat about Ax.</p>
-  <a href="https://x.com/intent/follow?screen_name=dosco">Follow @dosco on X</a>
-</div>
-
 <section class="home-section home-research-section" aria-labelledby="research">
 <div class="home-section-heading home-section-heading-wide">
   <p class="home-section-label">The ideas behind it</p>
   <h2 id="research">Built on DSPy, GEPA, ACE, RLM, and PEEK.</h2>
-  <p>Ax is more than another LLM framework — it is where a serious research lineage ships. The typed signatures, validation with retry feedback, reflective optimization, runtime-backed agents, and context maps you just saw all come from these papers.</p>
+  <p>Explore the papers behind the programming model, optimization, and agents you have seen on this page. Each link connects a research idea to the part of Ax that puts it to work.</p>
 </div>
 <div class="home-research-list home-research-compact">
   <article class="home-paper-item">
@@ -239,272 +516,32 @@ description: "Stop prompting. Start programming. Typed signatures become reliabl
 </div>
 </section>
 
-<section class="home-section home-agent-section home-chapter-start" aria-labelledby="agents-that-work">
-<div class="home-section-heading home-agent-heading">
-  <p class="home-section-label">Agents</p>
-  <h2 id="agents-that-work">One agent harness, every size of job.</h2>
-  <p>The design bet: <strong>the model computes on your data instead of reading it.</strong> Bulky inputs live in a runtime session; the agent writes small code steps against them; only compact evidence enters the prompt — so prompts stay bounded at any data size and small, cheap models stay exact. Typed signatures define the job, discovery loads only the schemas the next action needs, and built-in memory, skills, child agents, telemetry, and <code>agent.optimize(...)</code> make it practical to operate.</p>
-  <p>Proof you can run: in the <a href="https://github.com/ax-llm/ax/blob/main/src/examples/agent-grounded-audit.ts">grounded-audit example</a>, a small Flash model audits a 250-row ledger it never sees in its prompt and reproduces the exact answer — total to the cent, count, and the full flagged-transaction list — verified against ground truth computed in plain code. <a href="/typescript/agents/performance/">See the measurements</a>.</p>
-</div>
-<div class="home-card-grid three-up home-agent-tier-grid">
-  <article class="home-marketing-card home-agent-tier-card">{{< home-icon "zap" "icon-blue" >}}<h3>Micro</h3><p>One signature, a few tools, a typed reply. Zero config still runs the full harness — runtime session included.</p><p><a href="/typescript/agents/micro/">Micro agents</a></p></article>
-  <article class="home-marketing-card home-agent-tier-card">{{< home-icon "bot" "icon-teal" >}}<h3>Standard</h3><p>Namespaced tool catalogs, specialist child agents, structured outputs, and clarification instead of guessing.</p><p><a href="/typescript/agents/standard/">Standard agents</a></p></article>
-  <article class="home-marketing-card home-agent-tier-card">{{< home-icon "brain" "icon-green" >}}<h3>Long-horizon</h3><p>Large context by reference, context policies, memory, skills, and offline optimization for runs that keep going.</p><p><a href="/typescript/agents/long-horizon/">Long-horizon agents</a></p></article>
-</div>
-<div class="home-agent-code">
-{{< home-code topic="agent" group="agent" >}}
-</div>
-<div class="home-agent-layout">
-  <div class="home-chart-panel">
-{{< svg "rlm-loop" "RLM loop" >}}
+<section class="home-section home-academy-cta" aria-labelledby="home-academy-title">
+<article class="home-editorial-callout">
+{{< home-icon "list-checks" "icon-violet" >}}
+  <div class="home-editorial-callout-copy">
+    <p class="home-section-label">Ax Academy</p>
+    <h2 id="home-academy-title">Learn Ax step by step.</h2>
+    <p>A free course in your browser, with short lessons, practice exercises, and review tailored to what you need next. Take it one lesson at a time; the full course is about six hours.</p>
   </div>
-  <div class="home-agent-feature-grid">
-    <article><h3>Discovery</h3><p>Large tool catalogs stay out of the base prompt. The agent discovers groups and loads concrete schemas only when they matter.</p></article>
-    <article><h3>Context maps</h3><p>Runtime state, context maps, summaries, and checkpoints preserve orientation without replaying every token.</p></article>
-    <article><h3>Memory + skills</h3><p>Built-in memory, skills, MCP tools, and child agents become typed capabilities behind the same signature contract.</p></article>
-    <article><h3>Optimization</h3><p><code>agent.optimize(...)</code> tunes instructions, examples, and agent behavior against evals, judges, and saved artifacts.</p></article>
-  </div>
-</div>
-<div class="home-resource-row home-resource-row-tight">
-  <div>
-    <p class="home-section-label">Function discovery</p>
-    <h3>Agents navigate large tool catalogs without stuffing every schema into the prompt.</h3>
-    <p>Function groups, child agents, MCP tools, memory, and runtime state are discovered and loaded as needed, which keeps even small models focused on the next useful action.</p>
-  </div>
-  <div>
-{{< svg "agent-tree" "Agent function discovery tree" >}}
-  </div>
-</div>
-<div class="home-resource-row home-resource-row-tight">
-  <div>
-    <p class="home-section-label">Context policy</p>
-    <h3>State grows in the runtime instead of the prompt.</h3>
-    <p>Context maps, summaries, checkpoint state, and runtime references keep long-running work usable without turning every turn into a full transcript replay.</p>
-  </div>
-  <div>
-{{< svg "context-growth" "Context growth chart" >}}
-  </div>
-</div>
-<div class="home-actions home-section-actions">
-  <a href="/typescript/agents/">Explore the Agents section</a>
-  <a class="home-button-secondary" href="/typescript/agents/performance/">Performance &amp; measurements</a>
-  <a class="home-button-secondary" href="/typescript/concepts/optimization/">Optimization guide</a>
-</div>
-</section>
-
-<section id="graphjin" class="home-section home-graphjin" aria-labelledby="graphjin-title">
-<div class="home-graphjin-header">
-  <div class="home-graphjin-heading">
-    <p class="home-section-label">Case study</p>
-    <h2 id="graphjin-title">GraphJin runs on Ax.</h2>
-    <p>An agent built with Ax effortlessly connects all your databases to AI</p>
-  </div>
-  <div class="home-actions home-graphjin-actions">
-    <a href="https://graphjin.com">Explore GraphJin</a>
-    <a class="home-button-secondary" href="https://github.com/dosco/graphjin">GraphJin on GitHub</a>
-  </div>
-</div>
-<div class="home-graphjin-demo">
-  <div class="home-graphjin-command-row" aria-label="GraphJin setup commands">
-    <div class="home-graphjin-command" aria-label="Install GraphJin"><span>$</span><code><span class="home-install-command">npm install -g graphjin</span></code></div>
-    <div class="home-graphjin-command" aria-label="Add GraphJin as an MCP server"><span>$</span><code><span class="home-install-command">claude mcp add graphjin -- graphjin mcp --demo</span></code></div>
-  </div>
-  <div class="home-graphjin-terminal" aria-label="GraphJin demo conversation">
-    <div class="home-panel-title">Then just ask</div>
-<pre><code>Q: which customers churned last month,
-   and what did they have in common?&#10;
-A: 9 of 12 churned accounts were on the Starter plan.
-   7 opened a support ticket in their final 30 days.
-   Median tenure: 4 months.</code></pre>
-  </div>
-</div>
-<div class="home-graphjin-status">
-  <span aria-hidden="true"></span>
-  <p>Schema-validated · role-checked · audited · 12+ database engines</p>
-  <a href="https://graphjin.com/agentic/server-agent/">Read how the Ax agent is built</a>
-</div>
-<div class="home-graphjin-proof">
-  <div class="home-graphjin-proof-heading">
-    <p class="home-section-label">Proof, in public</p>
-    <h3>DeepORG benchmark</h3>
-    <a href="https://graphjin.com/benchmark/">See the leaderboard</a>
-  </div>
-  <div class="home-stats" aria-label="DeepORG current board result">
-    <div><strong>100/113</strong><span>tasks passed in full</span></div>
-    <div><strong>0</strong><span>unsafe effects</span></div>
-    <div><strong>~4¢</strong><span>per task</span></div>
-    <div><strong>339</strong><span>graded attempts</span></div>
-  </div>
-</div>
-</section>
-
-<section class="home-section home-audio-section" aria-labelledby="audio">
-<div class="home-section-heading">
-  <p class="home-section-label">Audio</p>
-  <h2 id="audio">Build text, voice, and realtime AI apps.</h2>
-  <p>Ax treats audio as part of the same typed programming model: direct speech-to-text, direct text-to-speech, signature audio artifacts, conversational audio turns, realtime/native audio, and agent audio inputs.</p>
-</div>
-<div class="home-resource-row home-resource-row-tight">
-  <div>
-    <h3>Use the smallest audio surface that matches the job.</h3>
-    <ul class="home-method-list">
-      <li><code>ai.transcribe(...)</code> for batch speech-to-text.</li>
-      <li><code>ai.speak(...)</code> for batch text-to-speech.</li>
-      <li><code>speech:audio</code> for typed programs that return synthesized audio artifacts.</li>
-      <li><code>.chat()</code> audio config for conversational or realtime audio turns.</li>
-      <li>Agents transcribe audio inputs before planner, executor, and responder stages.</li>
-    </ul>
-    <p><a href="/typescript/concepts/llms/">Read the LLM guide</a> or <a href="/typescript/examples/#llm-media">open media examples</a>.</p>
-  </div>
-  <div>
-{{< home-code topic="audio" group="audio" >}}
-  </div>
-</div>
-<div class="home-card-grid three-up">
-  <article class="home-marketing-card">{{< home-icon "activity" "icon-blue" >}}<h3>Transcribe and speak</h3><p>Use direct batch APIs when the app needs speech-to-text, text-to-speech, transcripts, or reusable audio artifacts.</p></article>
-  <article class="home-marketing-card">{{< home-icon "message-circle" "icon-teal" >}}<h3>Conversational audio</h3><p>Use provider audio chat and realtime configurations when voice belongs inside the model conversation.</p></article>
-  <article class="home-marketing-card">{{< home-icon "brain" "icon-green" >}}<h3>Agent audio</h3><p>Let agents accept recordings and return spoken outputs while their internal tool loops operate on stable text.</p></article>
-</div>
-</section>
-
-<section class="home-section" aria-labelledby="optimize-frontiers">
-<div class="home-section-heading">
-  <p class="home-section-label">Optimization</p>
-  <h2 id="optimize-frontiers">Improve quality after it works.</h2>
-  <p>GEPA, the Genetic-Pareto optimizer, tunes prompts, demos, flows, and agents against evals. Pareto frontiers make quality, latency, cost, and brevity tradeoffs explicit instead of hiding them behind one metric.</p>
-</div>
-<div class="home-resource-row home-resource-row-tight">
-  <div>
-    <h3>Pick the artifact that matches production reality.</h3>
-    <p>Use optimized programs when quality matters, cheaper frontier points when cost dominates, and saved artifacts when the same tuned behavior needs to be deployed repeatedly.</p>
-    <p><a href="/typescript/concepts/optimization/">Read optimization docs</a> or <a href="/typescript/api/optimize/">open the optimize API</a>.</p>
-  </div>
-  <div>
-{{< svg "pareto-frontier" "GEPA Pareto frontier" >}}
-  </div>
-</div>
-</section>
-
-<section class="home-section home-chapter-start" aria-labelledby="included">
-<div class="home-section-heading home-section-heading-wide">
-  <p class="home-section-label">The full surface</p>
-  <h2 id="included">Everything you need to build useful LLM systems.</h2>
-  <p>Every capability above hangs off the same signature contract. Start with a single typed generation call, then grow into tools, agents, voice, workflows, telemetry, optimization, and native packages without switching mental models. New to Ax? <a href="/typescript/how-ax-fits-together/" data-home-lang-href="how-ax-fits-together/">See how the pieces fit together</a>.</p>
-</div>
-<div class="home-capability-grid">
-  <article class="home-marketing-card">{{< home-icon "zap" "icon-blue" >}}<h3>Structured generation <span>ax()</span></h3><p>Declare typed inputs and outputs, then get parsed host values with streaming, validation, retries, and traces.</p></article>
-  <article class="home-marketing-card">{{< home-icon "tags" "icon-violet" >}}<h3>Signatures <span>s() + f()</span></h3><p>Use concise string signatures, fluent fields, media types, enums, arrays, constraints, and Standard Schema output.</p></article>
-  <article class="home-marketing-card">{{< home-icon "bot" "icon-green" >}}<h3>Tools and MCP <span>fn()</span></h3><p>Expose typed host functions, MCP servers, runtimes, flows, and child agents as callable capabilities.</p></article>
-  <article class="home-marketing-card">{{< home-icon "brain" "icon-teal" >}}<h3>Agents <span>agent()</span></h3><p>Build agents with tool discovery, memory, skills, child agents, context policy, and persistent runtime state.</p></article>
-  <article class="home-marketing-card home-audio-card">{{< home-icon "activity" "icon-amber" >}}<h3>Audio <span>speech:audio</span></h3><p>Transcribe speech, synthesize speech, return typed audio artifacts, and use conversational or realtime audio turns.</p></article>
-  <article class="home-marketing-card">{{< home-icon "list-checks" "icon-teal" >}}<h3>Workflows <span>flow()</span></h3><p>Compose typed steps, branches, and parallel work into explicit LLM application flows.</p></article>
-  <article class="home-marketing-card">{{< home-icon "bar-chart" "icon-rust" >}}<h3>Optimization <span>optimize()</span></h3><p>Improve prompts, demos, programs, flows, and agents against evals, judges, and production tradeoffs.</p></article>
-  <article class="home-marketing-card">{{< home-icon "globe" "icon-blue" >}}<h3>Providers <span>ai()</span></h3><p>Use OpenAI, Responses, Claude, Gemini, OpenAI-compatible gateways, local routers, embeddings, and model catalogs.</p></article>
-  <article class="home-marketing-card">{{< home-icon "activity" "icon-violet" >}}<h3>Telemetry <span>traces</span></h3><p>Inspect model calls, tool calls, usage, cost, latency, errors, optimizer metrics, and agent turns.</p></article>
-  <article class="home-marketing-card">{{< home-icon "languages" "icon-green" >}}<h3>Native packages <span>AxIR</span></h3><p>Use the same Ax concepts from TypeScript, Python, Java, C++, Go, and Rust package surfaces.</p></article>
-</div>
-</section>
-
-<section class="home-section" aria-labelledby="production-ready">
-<div class="home-section-heading">
-  <p class="home-section-label">Production-ready from day one</p>
-  <h2 id="production-ready">The operational pieces are built in, not bolted on.</h2>
-  <p>Extensive test coverage, OpenTelemetry integration, cost tracking, provider routing, and enterprise-grade error handling all belong to one program story.</p>
-</div>
-<div class="home-stats" aria-label="Ax production highlights">
-  <div><strong>1000+</strong><span>tests</span></div>
-  <div><strong>40+</strong><span>OTel metrics</span></div>
-  <div><strong>15+</strong><span>LLM providers</span></div>
-  <div><strong>6</strong><span>languages</span></div>
-</div>
-<div class="home-card-grid production-grid">
-  <article class="home-marketing-card">{{< home-icon "activity" "icon-blue" >}}<h3>OpenTelemetry</h3><p>Distributed traces span LLM calls, function invocations, MCP calls, and agent turns.</p></article>
-  <article class="home-marketing-card">{{< home-icon "bar-chart" "icon-teal" >}}<h3>Detailed metrics</h3><p>Track latency, tokens, errors, context windows, thinking budgets, and custom labels.</p></article>
-  <article class="home-marketing-card">{{< home-icon "zap" "icon-violet" >}}<h3>Streaming and validation</h3><p>Structured outputs stream through parsers, assertions, retries, and correction feedback.</p></article>
-  <article class="home-marketing-card">{{< home-icon "dollar" "icon-green" >}}<h3>Cost tracking</h3><p>Estimate provider costs per request and make optimization tradeoffs concrete.</p></article>
-  <article class="home-marketing-card">{{< home-icon "globe" "icon-amber" >}}<h3>Multi-language</h3><p>One semantic core spans TypeScript, Python, Java, C++, Go, and Rust package shapes.</p></article>
-  <article class="home-marketing-card">{{< home-icon "shield" "icon-rust" >}}<h3>Enterprise controls</h3><p>Rate limits, sampling, redaction, provider routing, and error handling fit production workflows.</p></article>
-</div>
-<div class="home-resource-row home-resource-row-tight">
-  <div>
-    <p class="home-section-label">Operate Ax systems</p>
-    <h3>Observe the run from model call to optimized artifact.</h3>
-    <p>Use the telemetry guide for the concrete spans, counters, histograms, and labels emitted by Ax programs.</p>
-    <p><a href="/typescript/concepts/telemetry/">Read telemetry docs</a>.</p>
-  </div>
-  <div>
-{{< svg "production-loop" "Production telemetry loop" >}}
-  </div>
-</div>
-</section>
-
-<section class="home-section" aria-labelledby="declare-capabilities">
-<div class="home-section-heading">
-  <p class="home-section-label">Patterns</p>
-  <h2 id="declare-capabilities">Declare capabilities, not prompts.</h2>
-  <p>Signatures make common LLM tasks readable, testable, and portable. The contract is the unit Ax can validate, trace, optimize, and document.</p>
-</div>
-<div class="home-pattern-grid">
-  <article>{{< home-icon "tags" "icon-violet" >}}<h3>Classification</h3><p>Categorize text into predefined classes.</p>{{< home-code topic="patterns.classification" group="pattern-classification" compact="true" label="Classification" >}}</article>
-  <article>{{< home-icon "file-text" "icon-teal" >}}<h3>Extraction</h3><p>Pull structured data from unstructured text.</p>{{< home-code topic="patterns.extraction" group="pattern-extraction" compact="true" label="Extraction" >}}</article>
-  <article>{{< home-icon "message-circle" "icon-green" >}}<h3>Question answering</h3><p>Answer questions with provided context.</p>{{< home-code topic="patterns.qa" group="pattern-qa" compact="true" label="Question answering" >}}</article>
-  <article>{{< home-icon "image" "icon-amber" >}}<h3>Multimodal</h3><p>Process images and audio alongside text.</p>{{< home-code topic="patterns.multimodal" group="pattern-multimodal" compact="true" label="Multimodal" >}}</article>
-  <article>{{< home-icon "shield" "icon-rust" >}}<h3>Validation</h3><p>Auto-validate outputs with constraints.</p>{{< home-code topic="patterns.validation" group="pattern-validation" compact="true" label="Validation" >}}</article>
-  <article>{{< home-icon "zap" "icon-blue" >}}<h3>Streaming</h3><p>Receive structured results as they generate.</p>{{< home-code topic="patterns.streaming" group="pattern-streaming" compact="true" label="Streaming" >}}</article>
-  <article>{{< home-icon "languages" "icon-violet" >}}<h3>Translation</h3><p>Translate between languages with typed IO.</p>{{< home-code topic="patterns.translation" group="pattern-translation" compact="true" label="Translation" >}}</article>
-  <article>{{< home-icon "list-checks" "icon-teal" >}}<h3>Workflows</h3><p>Return multiple typed outputs from one call.</p>{{< home-code topic="patterns.workflows" group="pattern-workflows" compact="true" label="Workflows" >}}</article>
-</div>
-<div class="home-resource-row home-resource-row-tight">
-  <div>
-    <p class="home-section-label">MCP and tools</p>
-    <h3>External servers become typed Ax functions.</h3>
-    <p>Use MCP servers through <code>AxMCPClient.toFunction()</code> in <code>ax()</code> generation or pass MCP clients into agents for discovery-aware tool use.</p>
-    <p><a href="/typescript/concepts/mcp/">Read the MCP guide</a> or <a href="/typescript/concepts/tools/">open the tools guide</a>.</p>
-  </div>
-  <div>
-{{< svg "mcp-bridge" "MCP bridge" >}}
-  </div>
-</div>
-</section>
-
-<section class="home-section home-model-section" aria-labelledby="use-any-model">
-<div class="home-section-heading">
-  <p class="home-section-label">LLM providers</p>
-  <h2 id="use-any-model">Use any model.</h2>
-  <p>Pick OpenAI, Claude, Gemini, a gateway, or a local OpenAI-compatible endpoint in <code>ai()</code>. Your signatures, tools, traces, and outputs stay the same.</p>
-</div>
-<div class="home-provider-layout home-provider-layout-simple">
-  <div>
-    <div class="home-provider-strip" aria-label="Supported provider examples">
-      <span>OpenAI</span>
-      <span>Claude</span>
-      <span>Gemini</span>
-      <span>OpenAI-compatible</span>
-      <span>Local</span>
-    </div>
-{{< home-code topic="provider" group="provider" compact="true" label="Provider setup" >}}
-    <p class="home-inline-note">Need routing, embeddings, audio, or context caching? <a href="/typescript/concepts/llms/">Read the LLM guide</a>.</p>
-  </div>
-  <div class="home-provider-visual">
-{{< svg "provider-router" "Provider router map" >}}
-  </div>
-</div>
+  <div class="home-actions home-editorial-callout-actions"><a href="/typescript/academy/" data-home-lang-href="academy/">Start Ax Academy</a></div>
+</article>
 </section>
 
 <section class="home-section home-final-cta" aria-labelledby="get-started">
 <div class="home-section-heading">
   <p class="home-section-label">Start now</p>
-  <h2 id="get-started">Write your first signature today.</h2>
-  <p>One line in, typed data out — on npm, PyPI, Maven Central, crates.io, Go modules, and CMake FetchContent.</p>
+  <h2 id="get-started">Build your first AI feature today.</h2>
+  <p>Choose your language, install Ax, and run a small task. Add tools, agents, and optimization when you need them.</p>
 </div>
 <div class="home-actions">
-  <a href="/typescript/quick-start/">Get started</a>
-  <a class="home-button-secondary" href="/typescript/how-ax-fits-together/">How Ax fits together</a>
-  <a class="home-button-secondary" href="/typescript/examples/">Examples</a>
+  <a href="/typescript/quick-start/" data-home-lang-href="quick-start/">Build your first AI feature</a>
+  <a class="home-button-secondary" href="/typescript/how-ax-fits-together/" data-home-lang-href="how-ax-fits-together/">How Ax fits together</a>
+  <a class="home-button-secondary" href="/typescript/examples/" data-home-lang-href="examples/">Examples</a>
   <a class="home-button-secondary" href="https://github.com/ax-llm/ax">GitHub</a>
-  <a class="home-button-secondary" href="https://x.com/intent/follow?screen_name=dosco">Follow @dosco on X</a>
 </div>
 <p class="home-inline-note">Built by <a href="https://x.com/intent/follow?screen_name=dosco">@dosco</a> — follow on X for new releases and to chat about Ax.</p>
-<p class="home-inline-note">Building with an AI coding agent? <a href="/typescript/skills/">Install the Ax skills</a> and let it write Ax for you.</p>
+<p class="home-inline-note">Building with an AI coding agent? <a href="/typescript/skills/" data-home-lang-href="skills/">Install the Ax skills</a> to give your assistant the API guide.</p>
 </section>
+
 </div>

--- a/website/data/homepage_languages.yaml
+++ b/website/data/homepage_languages.yaml
@@ -65,7 +65,7 @@ languages:
     agent:
       filename: audit.ts
       runtimeLabel: JS runtime session
-      status: Gemini Flash matches plain-code ground truth — to the cent
+      status: Illustrative audit result — see the runnable example and measurements
       output: |
         {
           "total": 9161.10,
@@ -105,10 +105,10 @@ languages:
       extraction: ax("document:string -> names:string[], dates:date[]")
       qa: ax("context:string, question:string -> answer:string")
       multimodal: ax("photo:image, question:string -> answer:string")
-      validation: ax("email:string, score:number -> valid:boolean")
-      streaming: ax("topic:string -> chunk:string")
+      decision: ax("email:string, score:number -> valid:boolean")
+      generation: ax("topic:string -> chunk:string")
       translation: ax("text:string, targetLanguage:string -> translation:string")
-      workflows: ax("doc:string -> summary:string, keyPoints:string[]")
+      summarization: ax("doc:string -> summary:string, keyPoints:string[]")
   - id: python
     label: Python
     shortLabel: Python
@@ -172,7 +172,7 @@ languages:
     agent:
       filename: audit.py
       runtimeLabel: Python host session
-      status: The ledger stays in the host session — the answer comes back exact
+      status: Illustrative audit result — see the runnable example and measurements
       output: |
         {
           "total": 9161.10,
@@ -211,10 +211,10 @@ languages:
       extraction: ax("document:string -> names:string[], dates:date[]")
       qa: ax("context:string, question:string -> answer:string")
       multimodal: ax("photo:image, question:string -> answer:string")
-      validation: ax("email:string, score:number -> valid:boolean")
-      streaming: ax("topic:string -> chunk:string")
+      decision: ax("email:string, score:number -> valid:boolean")
+      generation: ax("topic:string -> chunk:string")
       translation: ax("text:string, targetLanguage:string -> translation:string")
-      workflows: ax("doc:string -> summary:string, keyPoints:string[]")
+      summarization: ax("doc:string -> summary:string, keyPoints:string[]")
   - id: java
     label: Java
     shortLabel: Java
@@ -282,7 +282,7 @@ languages:
     agent:
       filename: Audit.java
       runtimeLabel: JVM host session
-      status: Bulky data stays runtime-side; typed, exact results out
+      status: Illustrative audit result — see the runnable example and measurements
       output: |
         {
           "total": 9161.10,
@@ -322,10 +322,10 @@ languages:
       extraction: Ax.ax("document:string -> names:string[], dates:date[]")
       qa: Ax.ax("context:string, question:string -> answer:string")
       multimodal: Ax.ax("photo:image, question:string -> answer:string")
-      validation: Ax.ax("email:string, score:number -> valid:boolean")
-      streaming: Ax.ax("topic:string -> chunk:string")
+      decision: Ax.ax("email:string, score:number -> valid:boolean")
+      generation: Ax.ax("topic:string -> chunk:string")
       translation: Ax.ax("text:string, targetLanguage:string -> translation:string")
-      workflows: Ax.ax("doc:string -> summary:string, keyPoints:string[]")
+      summarization: Ax.ax("doc:string -> summary:string, keyPoints:string[]")
   - id: cpp
     label: C++
     shortLabel: C++
@@ -389,7 +389,7 @@ languages:
     agent:
       filename: audit.cpp
       runtimeLabel: C++ host session
-      status: Same audit, same exact answer — native C++ surface
+      status: Illustrative audit result — see the runnable example and measurements
       output: |
         {
           "total": 9161.10,
@@ -428,10 +428,10 @@ languages:
       extraction: axllm::ax("document:string -> names:string[], dates:date[]")
       qa: axllm::ax("context:string, question:string -> answer:string")
       multimodal: axllm::ax("photo:image, question:string -> answer:string")
-      validation: axllm::ax("email:string, score:number -> valid:boolean")
-      streaming: axllm::ax("topic:string -> chunk:string")
+      decision: axllm::ax("email:string, score:number -> valid:boolean")
+      generation: axllm::ax("topic:string -> chunk:string")
       translation: axllm::ax("text:string, targetLanguage:string -> translation:string")
-      workflows: axllm::ax("doc:string -> summary:string, keyPoints:string[]")
+      summarization: axllm::ax("doc:string -> summary:string, keyPoints:string[]")
   - id: go
     label: Go
     shortLabel: Go
@@ -501,7 +501,7 @@ languages:
     agent:
       filename: audit.go
       runtimeLabel: Go host session
-      status: Prompt stays bounded at any ledger size — output is exact
+      status: Illustrative audit result — see the runnable example and measurements
       output: |
         {
           "total": 9161.10,
@@ -540,10 +540,10 @@ languages:
       extraction: ax.NewAx("document:string -> names:string[], dates:date[]", nil)
       qa: ax.NewAx("context:string, question:string -> answer:string", nil)
       multimodal: ax.NewAx("photo:image, question:string -> answer:string", nil)
-      validation: ax.NewAx("email:string, score:number -> valid:boolean", nil)
-      streaming: ax.NewAx("topic:string -> chunk:string", nil)
+      decision: ax.NewAx("email:string, score:number -> valid:boolean", nil)
+      generation: ax.NewAx("topic:string -> chunk:string", nil)
       translation: ax.NewAx("text:string, targetLanguage:string -> translation:string", nil)
-      workflows: ax.NewAx("doc:string -> summary:string, keyPoints:string[]", nil)
+      summarization: ax.NewAx("doc:string -> summary:string, keyPoints:string[]", nil)
   - id: rust
     label: Rust
     shortLabel: Rust
@@ -611,7 +611,7 @@ languages:
     agent:
       filename: audit.rs
       runtimeLabel: Rust host session
-      status: Exact totals from a runtime-grounded agent
+      status: Illustrative audit result — see the runnable example and measurements
       output: |
         {
           "total": 9161.10,
@@ -648,7 +648,7 @@ languages:
       extraction: ax("document:string -> names:string[], dates:date[]")?
       qa: ax("context:string, question:string -> answer:string")?
       multimodal: ax("photo:image, question:string -> answer:string")?
-      validation: ax("email:string, score:number -> valid:boolean")?
-      streaming: ax("topic:string -> chunk:string")?
+      decision: ax("email:string, score:number -> valid:boolean")?
+      generation: ax("topic:string -> chunk:string")?
       translation: ax("text:string, targetLanguage:string -> translation:string")?
-      workflows: ax("doc:string -> summary:string, keyPoints:string[]")?
+      summarization: ax("doc:string -> summary:string, keyPoints:string[]")?

--- a/website/static/css/site.css
+++ b/website/static/css/site.css
@@ -1773,7 +1773,7 @@ pre.mermaid {
   letter-spacing: -0.04em;
 }
 
-/* One sentence per line — a natural wrap orphans "Start" / "programming." */
+/* Keep the hero's short phrases together as the viewport changes. */
 .home-h1-line {
   display: block;
 }
@@ -2320,6 +2320,14 @@ pre.mermaid {
   letter-spacing: 0.14em;
   margin: 0 0 0.72rem;
   text-transform: uppercase;
+}
+
+.home-hero .home-kicker {
+  font-family: var(--font-sans);
+  font-size: 0.85rem;
+  line-height: 1.5;
+  letter-spacing: 0;
+  text-transform: none;
 }
 
 .home-lede {
@@ -2969,7 +2977,7 @@ pre.mermaid {
 }
 
 .home-capability-grid {
-  grid-template-columns: repeat(5, minmax(0, 1fr));
+  grid-template-columns: repeat(3, minmax(0, 1fr));
 }
 
 .home-provider-grid {
@@ -3014,6 +3022,19 @@ pre.mermaid {
   font-weight: 620;
   letter-spacing: 0;
   margin-top: 0.16rem;
+}
+
+.home-marketing-card .home-card-eyebrow {
+  margin-bottom: 0.5rem;
+  color: var(--accent-2);
+  font-size: 0.8rem;
+  font-weight: 700;
+}
+
+.home-card-link {
+  display: inline-block;
+  margin-top: 0.85rem;
+  font-size: 0.92rem;
 }
 
 .home-method-list {


### PR DESCRIPTION
New visitors had to understand Ax internals before discovering what they could build, and “GraphJin runs on Ax” did not explain the database use case. The homepage now starts with practical benefits and gives DSPy-style programming, RLM agents, and one compiled framework equal prominence.

Move database connectivity near the top, explain technical terms as they appear, and guide visitors from a first AI feature to agents and optimization. Keep the existing visual style, with responsive foundation and use-case cards. Make content links follow all six language choices, label abridged examples, and link to benchmark methodology instead of undated headline results.

- **Kind:** website copy, information architecture, and layout.
- **Validation:** website build and quality/link checks (1,923 pages); generated package freshness; generated no-key examples and MCP compile checks across Python, Java, C++, Go, and Rust; skill validation; Biome; desktop/mobile browser review; both hero examples in all six languages; keyboard activation and focus.
- **AxIR portable behavior:** no runtime or public API behavior changes.

The homepage checker now enforces the three core strengths, practical use cases, section order, and documentation destinations across all six languages.
